### PR TITLE
Dummy channels as pure info items

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -278,7 +278,7 @@ implements TeamTalkConnectionListener,
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         boolean isEditable = curchannel != null;
-        boolean isJoinable = (ttclient != null) && (curchannel != null) && (ttclient.getMyChannelID() != curchannel.nChannelID);
+        boolean isJoinable = (ttclient != null) && (curchannel != null) && (ttclient.getMyChannelID() != curchannel.nChannelID) && (curchannel.nMaxUsers > 0);
         boolean isMyChannel = (ttclient != null) && (curchannel != null) && (ttclient.getMyChannelID() == curchannel.nChannelID);
         menu.findItem(R.id.action_edit).setEnabled(isEditable).setVisible(isEditable);
         menu.findItem(R.id.action_join).setEnabled(isJoinable).setVisible(isJoinable);
@@ -866,8 +866,9 @@ implements TeamTalkConnectionListener,
         private static final int PARENT_CHANNEL_VIEW_TYPE = 0,
             CHANNEL_VIEW_TYPE = 1,
             USER_VIEW_TYPE = 2,
+            INFO_VIEW_TYPE = 3,
 
-            VIEW_TYPE_COUNT = 3;
+            VIEW_TYPE_COUNT = 4;
 
         private LayoutInflater inflater;
 
@@ -967,12 +968,12 @@ implements TeamTalkConnectionListener,
                     return PARENT_CHANNEL_VIEW_TYPE;
                 }
                 else if (position <= subchannels.size()) {
-                    return CHANNEL_VIEW_TYPE;
+                    return (subchannels.get(position - 1).nMaxUsers > 0) ? CHANNEL_VIEW_TYPE : INFO_VIEW_TYPE;
                 }
                 return USER_VIEW_TYPE;
             }
             else if (position < subchannels.size()) {
-                return CHANNEL_VIEW_TYPE;
+                return (subchannels.get(position).nMaxUsers > 0) ? CHANNEL_VIEW_TYPE : INFO_VIEW_TYPE;
             }
             return USER_VIEW_TYPE;
         }
@@ -996,6 +997,15 @@ implements TeamTalkConnectionListener,
                     if (convertView == null ||
                         convertView.findViewById(R.id.parentname) == null)
                         convertView = inflater.inflate(R.layout.item_channel_back, parent, false);
+                }
+                else if (channel.nMaxUsers == 0) {
+                    if (convertView == null ||
+                        convertView.findViewById(R.id.titletext) == null)
+                        convertView = inflater.inflate(R.layout.item_info, parent, false);
+                    TextView title = (TextView) convertView.findViewById(R.id.titletext);
+                    TextView details = (TextView) convertView.findViewById(R.id.infodetails);
+                    title.setText(channel.szName);
+                    details.setText(channel.szTopic);
                 }
                 else {
 
@@ -1045,8 +1055,10 @@ implements TeamTalkConnectionListener,
                     join.setAccessibilityDelegate(accessibilityAssistant);
                     join.setEnabled(channel.nChannelID != ttclient.getMyChannelID());
                 }
-                int population = Utils.getUsers(channel.nChannelID, ttservice.getUsers()).size();
-                ((TextView)convertView.findViewById(R.id.population)).setText((population > 0) ? String.format("(%d)", population) : "");
+                if (channel.nMaxUsers > 0) {
+                    int population = Utils.getUsers(channel.nChannelID, ttservice.getUsers()).size();
+                    ((TextView)convertView.findViewById(R.id.population)).setText((population > 0) ? String.format("(%d)", population) : "");
+                }
             }
             else if(item instanceof User) {
                 if (convertView == null ||

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -902,6 +902,10 @@ implements TeamTalkConnectionListener,
             Collections.sort(subchannels, new Comparator<Channel>() {
                     @Override
                     public int compare(Channel c1, Channel c2) {
+                        if ((c1.nMaxUsers <= 0) && (c2.nMaxUsers > 0))
+                            return -1;
+                        else if ((c1.nMaxUsers > 0) && (c2.nMaxUsers <= 0))
+                            return 1;
                         return c1.szName.compareToIgnoreCase(c2.szName);
                     }
                 });

--- a/Client/TeamTalkAndroid/src/main/res/layout/item_info.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/item_info.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical" >
+
+    <TextView
+        android:id="@+id/titletext"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text=""
+        android:textSize="16sp" />
+
+    <TextView
+        android:id="@+id/infodetails"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text=""
+        android:textSize="14sp" />
+</LinearLayout>


### PR DESCRIPTION
It appears to be more or less common practice to publish
announcements, schedules, and other info via channel items. Such
channels usually have maximum users limit set to 0. In this sense they
are dummy, i.e. not joinable. Thus there is no reson to keep
corresponding button. Since text fields of the item bear useful
information, it seems rational to make them multiline in order to
avoid cropping. And, at last, these info items should be displayed at
the top of list. All this is implemented here.

Maybe, there is another way, more natural and elegant?

Of course, I know that server can pass general info to clients via
messages. But it seems to be less convenient, since requires shift to
another tab where general info becomes lost in other messages.
