### PR TITLE
Android client: hierarchical preferences navigation

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/PreferencesActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/PreferencesActivity.java
@@ -23,7 +23,6 @@
 
 package dk.bearware.gui;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -31,13 +30,11 @@ import android.content.res.Configuration;
 import android.media.Ringtone;
 import android.media.RingtoneManager;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
 import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceActivity;
-import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
 import android.preference.RingtonePreference;
@@ -67,7 +64,7 @@ import java.util.ArrayList;
 
 /**
  * A {@link PreferenceActivity} that presents a set of application settings. On handset devices, settings are presented
- * as a single list. On tablets, settings are split by category, with category headers shown to the left of the list of
+ * as a single hierarchy. On tablets, settings are split by category, with category headers shown to the left of the list of
  * settings.
  * <p>
  * See <a href="http://developer.android.com/design/patterns/settings.html"> Android Design: Settings</a> for design
@@ -81,7 +78,7 @@ public class PreferencesActivity extends PreferenceActivity implements TeamTalkC
     TeamTalkConnection mConnection;
     TeamTalkService ttservice;
 
-    int ACTIVITY_REQUEST_BEARWAREID = 2;
+    static final int ACTIVITY_REQUEST_BEARWAREID = 2;
 
     private AppCompatDelegate appCompatDelegate = null;
 
@@ -203,31 +200,11 @@ public class PreferencesActivity extends PreferenceActivity implements TeamTalkC
         }
     }
 
-    /**
-     * Determines whether to always show the simplified settings UI, where settings are presented in a single list. When
-     * false, settings are shown as a master/detail two-pane view on tablets. When true, a single pane is shown on
-     * tablets.
-     */
-    private static final boolean ALWAYS_SIMPLE_PREFS = false;
-
     @Override
     protected void onPostCreate(Bundle savedInstanceState) {
         super.onPostCreate(savedInstanceState);
         getDelegate().onPostCreate(savedInstanceState);
         getDelegate().getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-
-        setupSimplePreferencesScreen();
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getBaseContext());
-        String username = prefs.getString(Preferences.PREF_GENERAL_BEARWARE_USERNAME, "");
-
-        CheckBoxPreference preference = (CheckBoxPreference) findPreference(Preferences.PREF_GENERAL_BEARWARE_CHECKED);
-        preference.setChecked(username.length() > 0);
     }
 
     @Override
@@ -257,105 +234,10 @@ public class PreferencesActivity extends PreferenceActivity implements TeamTalkC
         }
     }
 
-    /**
-     * Shows the simplified settings UI if the device configuration dictates that a
-     * simplified, single-pane UI should be shown.
-     */
-    @SuppressWarnings("deprecation")
-    @Deprecated
-    private void setupSimplePreferencesScreen() {
-        if(!isSimplePreferences(this)) {
-            return;
-        }
-
-        // In the simplified UI, fragments are not used at all and we instead
-        // use the older PreferenceActivity APIs.
-
-        // Add 'general' preferences.
-        PreferenceCategory fakeHeader = new PreferenceCategory(this);
-        fakeHeader.setTitle(R.string.pref_header_general);
-        //getPreferenceScreen().addPreference(fakeHeader); //not allowed
-        addPreferencesFromResource(R.xml.pref_general);
-
-        // Add 'soundevents' preferences, and a corresponding header.
-        fakeHeader = new PreferenceCategory(this);
-        fakeHeader.setTitle(R.string.pref_title_audio_icons);
-        getPreferenceScreen().addPreference(fakeHeader);
-        addPreferencesFromResource(R.xml.pref_soundevents);
-
-        // Add 'connection' preferences, and a corresponding header.
-        fakeHeader = new PreferenceCategory(this);
-        fakeHeader.setTitle(R.string.pref_header_connection);
-        getPreferenceScreen().addPreference(fakeHeader);
-        addPreferencesFromResource(R.xml.pref_connection);
-
-        // Add 'tts' preferences, and a corresponding header.
-        fakeHeader = new PreferenceCategory(this);
-        fakeHeader.setTitle(R.string.pref_header_tts);
-        getPreferenceScreen().addPreference(fakeHeader);
-        addPreferencesFromResource(R.xml.pref_tts);
-
-        // Add 'sound system' preferences, and a corresponding header.
-        fakeHeader = new PreferenceCategory(this);
-        fakeHeader.setTitle(R.string.pref_header_soundsystem);
-        getPreferenceScreen().addPreference(fakeHeader);
-        addPreferencesFromResource(R.xml.pref_soundsystem);
-
-        // Bind the summaries of EditText/List/Dialog/Ringtone preferences to
-        // their values. When their values change, their summaries are updated
-        // to reflect the new value, per the Android Design guidelines.
-        bindPreferenceSummaryToValue(findPreference(Preferences.PREF_GENERAL_NICKNAME));
-
-        Preference bearwareLogin = findPreference(Preferences.PREF_GENERAL_BEARWARE_CHECKED);
-        bearwareLogin.setOnPreferenceChangeListener((preference, o) -> {
-            Intent edit = new Intent(PreferencesActivity.this, WebLoginActivity.class);
-            startActivityForResult(edit, ACTIVITY_REQUEST_BEARWAREID);
-            return true;
-        });
-        ListPreference enginePrefs = (ListPreference) findPreference("pref_speech_engine");
-        List<EngineInfo> engines = TTSWrapper.getEngines();
-        ArrayList<String> entries = new ArrayList();
-        ArrayList<String> values = new ArrayList();
-        for (EngineInfo info : engines) {
-            entries.add(info.label);
-            values.add(info.name);
-        }
-        enginePrefs.setEntries((CharSequence[]) entries.toArray(new CharSequence[engines.size()]));
-        enginePrefs.setEntryValues((CharSequence[]) values.toArray(new CharSequence[engines.size()]));
-    }
-
     /** {@inheritDoc} */
     @Override
-    public boolean onIsMultiPane() {
-        return isXLargeTablet(this) && !isSimplePreferences(this);
-    }
-
-    /**
-     * Helper method to determine if the device has an extra-large screen. For example, 10" tablets are extra-large.
-     */
-    private static boolean isXLargeTablet(Context context) {
-        return (context.getResources().getConfiguration().screenLayout & Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_XLARGE;
-    }
-
-    /**
-     * Determines whether the simplified settings UI should be shown. This is true if this is forced via
-     * {@link #ALWAYS_SIMPLE_PREFS}, or the device doesn't have newer APIs like {@link PreferenceFragment}, or the
-     * device doesn't have an extra-large screen. In these cases, a single-pane "simplified" settings UI should be
-     * shown.
-     */
-    private static boolean isSimplePreferences(Context context) {
-        return ALWAYS_SIMPLE_PREFS
-            || Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB
-            || !isXLargeTablet(context);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public void onBuildHeaders(List<Header> target) {
-        if(!isSimplePreferences(this)) {
-            loadHeadersFromResource(R.xml.pref_headers, target);
-        }
+        loadHeadersFromResource(R.xml.pref_headers, target);
     }
 
     /**
@@ -434,10 +316,10 @@ public class PreferencesActivity extends PreferenceActivity implements TeamTalkC
     }
 
     /**
-     * This fragment shows general preferences only. It is used when the activity is showing a two-pane settings UI.
+     * This fragment shows general preferences only.
      */
-    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public static class GeneralPreferenceFragment extends PreferenceFragment {
+
         @Override
         public void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
@@ -448,10 +330,28 @@ public class PreferencesActivity extends PreferenceActivity implements TeamTalkC
             // updated to reflect the new value, per the Android Design
             // guidelines.
             bindPreferenceSummaryToValue(findPreference(Preferences.PREF_GENERAL_NICKNAME));
+
+            Preference bearwareLogin = findPreference(Preferences.PREF_GENERAL_BEARWARE_CHECKED);
+            bearwareLogin.setOnPreferenceChangeListener((preference, o) -> {
+                Intent edit = new Intent(getActivity(), WebLoginActivity.class);
+                getActivity().startActivityForResult(edit, ACTIVITY_REQUEST_BEARWAREID);
+                return true;
+            });
         }
+
+        @Override
+        public void onResume() {
+            super.onResume();
+
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity().getBaseContext());
+            String username = prefs.getString(Preferences.PREF_GENERAL_BEARWARE_USERNAME, "");
+
+            CheckBoxPreference preference = (CheckBoxPreference) findPreference(Preferences.PREF_GENERAL_BEARWARE_CHECKED);
+            preference.setChecked(username.length() > 0);
+        }
+
     }
-    
-    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+
     public static class SoundEventsPreferenceFragment extends PreferenceFragment {
         @Override
         public void onCreate(Bundle savedInstanceState) {
@@ -459,8 +359,7 @@ public class PreferencesActivity extends PreferenceActivity implements TeamTalkC
             addPreferencesFromResource(R.xml.pref_soundevents);
         }
     }
-    
-    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+
     public static class ConnectionPreferenceFragment extends PreferenceFragment {
         @Override
         public void onCreate(Bundle savedInstanceState) {
@@ -469,16 +368,25 @@ public class PreferencesActivity extends PreferenceActivity implements TeamTalkC
         }
     }
 
-    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public static class TtsPreferenceFragment extends PreferenceFragment {
         @Override
         public void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
             addPreferencesFromResource(R.xml.pref_tts);
+
+            ListPreference enginePrefs = (ListPreference) findPreference("pref_speech_engine");
+            List<EngineInfo> engines = TTSWrapper.getEngines();
+            ArrayList<String> entries = new ArrayList();
+            ArrayList<String> values = new ArrayList();
+            for (EngineInfo info : engines) {
+                entries.add(info.label);
+                values.add(info.name);
+            }
+            enginePrefs.setEntries((CharSequence[]) entries.toArray(new CharSequence[engines.size()]));
+            enginePrefs.setEntryValues((CharSequence[]) values.toArray(new CharSequence[engines.size()]));
         }
     }
 
-    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public static class SoundSystemPreferenceFragment extends PreferenceFragment {
         @Override
         public void onCreate(Bundle savedInstanceState) {

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/PreferencesActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/PreferencesActivity.java
@@ -220,7 +220,7 @@ public class PreferencesActivity extends PreferenceActivity implements TeamTalkC
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-            finish();
+            onBackPressed();
             return true;
         }
         return super.onOptionsItemSelected(item);


### PR DESCRIPTION
Native mechanism is used to distinguish screen sizes and deploy
two-panel layout when it is appropriate. Otherwise settings are
organized hierarchically.