### PR TITLE
Channel list organization in Android client

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -31,6 +31,7 @@ Android client
 - Blank nicknames are set to NoName followed by user ID
 - More elements are now labeled, specifically some edit fields
 - Bluetooth headset microphone usage facility
+- Use back button to navigate to the parent channel
 iOS client
 - Channels are now sorted correctly in TeamTalk on iOS 13 and newer
 - French translation has been updated

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -340,7 +340,16 @@ implements TeamTalkConnectionListener,
                 break;
             }
             case android.R.id.home : {
-                if (filesAdapter.getActiveTransfersCount() > 0) {
+                Channel parentChannel = ((mViewPager.getCurrentItem() == SectionsPagerAdapter.CHANNELS_PAGE)
+                                         && (curchannel != null)
+                                         && (curchannel.nChannelID != ttclient.getRootChannelID())) ?
+                    ttservice.getChannels().get(curchannel.nParentID) :
+                    null;
+                if ((parentChannel != null) && (parentChannel.nChannelID > 0)) {
+                    setCurrentChannel(parentChannel);
+                    channelsAdapter.notifyDataSetChanged();
+                }
+                else if (filesAdapter.getActiveTransfersCount() > 0) {
                     AlertDialog.Builder alert = new AlertDialog.Builder(this);
                     alert.setMessage(R.string.disconnect_alert);
                     alert.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -892,6 +892,7 @@ implements TeamTalkConnectionListener,
         private LayoutInflater inflater;
 
         Vector<Channel> subchannels = new Vector<Channel>();
+        Vector<Channel> stickychannels = new Vector<Channel>();
         Vector<User> currentusers = new Vector<User>();
 
         ChannelListAdapter(Context context) {
@@ -903,12 +904,14 @@ implements TeamTalkConnectionListener,
             int chanid = 0;
 
             subchannels.clear();
+            stickychannels.clear();
             currentusers.clear();
 
             if(curchannel != null) {
                 chanid = curchannel.nChannelID;
 
                 subchannels = Utils.getSubChannels(chanid, ttservice.getChannels());
+                stickychannels = Utils.getStickyChannels(chanid, ttservice.getChannels());
                 currentusers = Utils.getUsers(chanid, ttservice.getUsers());
             }
             else {
@@ -918,15 +921,12 @@ implements TeamTalkConnectionListener,
                     subchannels.add(root);
             }
 
-            Collections.sort(subchannels, new Comparator<Channel>() {
-                    @Override
-                    public int compare(Channel c1, Channel c2) {
-                        if ((c1.nMaxUsers <= 0) && (c2.nMaxUsers > 0))
-                            return -1;
-                        else if ((c1.nMaxUsers > 0) && (c2.nMaxUsers <= 0))
-                            return 1;
-                        return c1.szName.compareToIgnoreCase(c2.szName);
-                    }
+            Collections.sort(subchannels, (c1, c2) -> {
+                    return c1.szName.compareToIgnoreCase(c2.szName);
+                });
+
+            Collections.sort(stickychannels, (c1, c2) -> {
+                    return c1.szName.compareToIgnoreCase(c2.szName);
                 });
 
             Collections.sort(currentusers, new Comparator<User>() {
@@ -950,7 +950,7 @@ implements TeamTalkConnectionListener,
 
         @Override
         public int getCount() {
-            int count = currentusers.size() + subchannels.size();
+            int count = currentusers.size() + subchannels.size() + stickychannels.size();
             if ((curchannel != null) && (curchannel.nParentID > 0)) {
                 count++; // include parent channel shortcut
             }
@@ -959,6 +959,13 @@ implements TeamTalkConnectionListener,
 
         @Override
         public Object getItem(int position) {
+
+            if (position < stickychannels.size()) {
+                return stickychannels.get(position);
+            }
+
+            // sticky channels are first so subtract these
+            position -= stickychannels.size();
 
             if (position < currentusers.size()) {
                 return currentusers.get(position);
@@ -989,6 +996,12 @@ implements TeamTalkConnectionListener,
         @Override
         public int getItemViewType(int position) {
 
+            if (position < stickychannels.size())
+                return INFO_VIEW_TYPE;
+
+            // sticky channels are first so subtract these
+            position -= stickychannels.size();
+
             if (position < currentusers.size())
                 return USER_VIEW_TYPE;
 
@@ -1003,7 +1016,7 @@ implements TeamTalkConnectionListener,
                 position--; // subtract parent channel shortcut
             }
 
-            return (subchannels.get(position).nMaxUsers > 0) ? CHANNEL_VIEW_TYPE : INFO_VIEW_TYPE;
+            return CHANNEL_VIEW_TYPE;
         }
 
         @Override

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/Utils.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/Utils.java
@@ -172,17 +172,30 @@ public class Utils {
 
     public static Vector<Channel> getSubChannels(int chanid, Map<Integer, Channel> channels) {
         Vector<Channel> result = new Vector<Channel>();
-        
+
         Iterator<Entry<Integer, Channel>> it = channels.entrySet().iterator();
 
         while (it.hasNext()) {
             Channel chan = it.next().getValue();
-            if (chan.nParentID == chanid)
+            if ((chan.nParentID == chanid) && (chan.nMaxUsers > 0))
                 result.add(chan);
         }
         return result;
     }
-    
+
+    public static Vector<Channel> getStickyChannels(int chanid, Map<Integer, Channel> channels) {
+        Vector<Channel> result = new Vector<Channel>();
+
+        Iterator<Entry<Integer, Channel>> it = channels.entrySet().iterator();
+
+        while (it.hasNext()) {
+            Channel chan = it.next().getValue();
+            if ((chan.nParentID == chanid) && (chan.nMaxUsers <= 0))
+                result.add(chan);
+        }
+        return result;
+    }
+
     public static Vector<User> getUsers(int chanid, Map<Integer, User> users) {
         Vector<User> result = new Vector<User>();
         Iterator<Entry<Integer, User>> it = users.entrySet().iterator();


### PR DESCRIPTION
Here is a solution for couple of issues discussed in #530. Sticky
channels are moved to the very top of list, just before users, and
back button can be used for navigation to the parent channel. Back
button behaviour is modified only for channels tab. In other tabs it
closes connection and returns to the server list as earlier.
