### PR TITLE
QT client: Generate languages files when using make

### DIFF
--- a/Client/qtTeamTalk/teamtalk5.pro
+++ b/Client/qtTeamTalk/teamtalk5.pro
@@ -32,3 +32,8 @@ CONFIG(release, debug|release) {
         LIBS += -sectcreate __TEXT __info_plist $${TARGET}.app/Contents/Info.plist
     }
 }
+
+@
+QMAKE_POST_LINK = lrelease teamtalk5.pro
+@
+

--- a/Client/qtTeamTalk/teamtalk5pro.pro
+++ b/Client/qtTeamTalk/teamtalk5pro.pro
@@ -29,3 +29,6 @@ CONFIG(release, debug|release) {
     OBJECTS_DIR = build/rel_teamtalk5pro/obj
 
 }
+@
+QMAKE_POST_LINK = lrelease teamtalk5pro.pro
+@


### PR DESCRIPTION
Call lrelease <filename>.pro for teamtalk5.pro and teamtalk5pro.pro to have updated languages when compiling the QT client.
Using this method we can have last translations from the repository.