### PR TITLE
Modify behavior on file added

### DIFF
--- a/Client/TeamTalkClassic/TeamTalkDlg.cpp
+++ b/Client/TeamTalkClassic/TeamTalkDlg.cpp
@@ -1854,7 +1854,7 @@ void CTeamTalkDlg::OnFileAdd(const TTMessage& msg)
        m_commands[m_nCurrentCmdID] != CMD_COMPLETE_JOIN)
     {
         PlaySoundEvent(SOUNDEVENT_FILES_UPDATED);
-        TT_GetUserByUsername(ttInst, remotefile.szUsername, &user);
+//        TT_GetUserByUsername(ttInst, remotefile.szUsername, &user);
         CString szMsg;
         szMsg.Format(LoadText(IDS_FILEADDED), GetDisplayName(user), remotefile.szFileName);
         AddStatusText(szMsg);


### PR DESCRIPTION
Attempt to fix # 535, for which the real description should be: "name of user who added incorrect file on servers without user accounts"
Unfortunately I can't test in this time, so result it maybe catastrofic