### PR TITLE
Small fixes for iTeamTalk

### DIFF
--- a/Client/iTeamTalk/iTeamTalk/Base.lproj/Localizable.strings
+++ b/Client/iTeamTalk/iTeamTalk/Base.lproj/Localizable.strings
@@ -701,3 +701,18 @@
 
 /* Dialog */
 "You have been kicked from server" = "You have been kicked from server";
+
+/* channel list */
+"Active" = "Active";
+
+/* channel list */
+"Inactive" = "Inactive";
+
+/* Dialog */
+"You have been kicked from channel by" = "You have been kicked from channel by";
+
+/* Dialog */
+"You have been kicked from channel by %@" = "You have been kicked from channel by %@";
+
+/* Dialog */
+"You have been kicked from server by %@" = "You have been kicked from server by %@";

--- a/Client/iTeamTalk/iTeamTalk/ChannelListViewController.swift
+++ b/Client/iTeamTalk/iTeamTalk/ChannelListViewController.swift
@@ -674,7 +674,7 @@ class ChannelListViewController :
 
         let src_vc = segue.source as! UserDetailViewController
         
-        let vc = self.storyboard?.instantiateViewController(withIdentifier: format("Message - %@", getDisplayName(src_vc.userid)) as! TextMessageViewController
+        let vc = self.storyboard?.instantiateViewController(withIdentifier: "Text Message") as! TextMessageViewController
         openTextMessages(vc, userid: src_vc.userid)
         self.navigationController?.pushViewController(vc, animated: true)
 
@@ -1024,7 +1024,7 @@ class ChannelListViewController :
                 }
                 
                 if settings.object(forKey: PREF_DISPLAY_POPUPTXTMSG) == nil || settings.bool(forKey: PREF_DISPLAY_POPUPTXTMSG) {
-                    let vc = self.storyboard?.instantiateViewController(withIdentifier: format("Message - %@", getDisplayName(txtmsg.nFromUserID))) as! TextMessageViewController
+                    let vc = self.storyboard?.instantiateViewController(withIdentifier: "Text Message") as! TextMessageViewController
                     openTextMessages(vc, userid: txtmsg.nFromUserID)
                     self.navigationController?.pushViewController(vc, animated: true)
                     if vc.messages.count > 0 {

--- a/Client/iTeamTalk/iTeamTalk/ChannelListViewController.swift
+++ b/Client/iTeamTalk/iTeamTalk/ChannelListViewController.swift
@@ -746,9 +746,11 @@ class ChannelListViewController :
         case CLIENT_TX_VOICE.rawValue :
             txButton.backgroundColor = UIColor.red
             txButton.accessibilityHint = NSLocalizedString("Transmitting", comment: "channel list")
+            txButton.accessibilityValue = NSLocalizedString("Active", comment: "channel list")
         default :
             txButton.backgroundColor = UIColor.green
             txButton.accessibilityHint = NSLocalizedString("Transmit inactive", comment: "channel list")
+            txButton.accessibilityValue = NSLocalizedString("Inactive", comment: "channel list")
         }
         
         if hasPTTLock() {

--- a/Client/iTeamTalk/iTeamTalk/ChannelListViewController.swift
+++ b/Client/iTeamTalk/iTeamTalk/ChannelListViewController.swift
@@ -674,7 +674,7 @@ class ChannelListViewController :
 
         let src_vc = segue.source as! UserDetailViewController
         
-        let vc = self.storyboard?.instantiateViewController(withIdentifier: "Text Message") as! TextMessageViewController
+        let vc = self.storyboard?.instantiateViewController(withIdentifier: format("Message - %@", getDisplayName(src_vc.userid)) as! TextMessageViewController
         openTextMessages(vc, userid: src_vc.userid)
         self.navigationController?.pushViewController(vc, animated: true)
 
@@ -1024,7 +1024,7 @@ class ChannelListViewController :
                 }
                 
                 if settings.object(forKey: PREF_DISPLAY_POPUPTXTMSG) == nil || settings.bool(forKey: PREF_DISPLAY_POPUPTXTMSG) {
-                    let vc = self.storyboard?.instantiateViewController(withIdentifier: "Text Message") as! TextMessageViewController
+                    let vc = self.storyboard?.instantiateViewController(withIdentifier: format("Message - %@", getDisplayName(txtmsg.nFromUserID))) as! TextMessageViewController
                     openTextMessages(vc, userid: txtmsg.nFromUserID)
                     self.navigationController?.pushViewController(vc, animated: true)
                     if vc.messages.count > 0 {

--- a/Client/iTeamTalk/iTeamTalk/MainTabBarController.swift
+++ b/Client/iTeamTalk/iTeamTalk/MainTabBarController.swift
@@ -352,9 +352,9 @@ class MainTabBarController : UITabBarController, UIAlertViewDelegate, TeamTalkEv
                 if (m.ttType == __USER)
                 {
                     if #available(iOS 8.0, *) {
+                        let msg = String(format: NSLocalizedString("You have been kicked from server by %@", comment: "Dialog"), getDisplayName(m.user))
                         let alert = UIAlertController(title: NSLocalizedString("Error", comment: "Dialog"),
-                                                      message: format(NSLocalizedString("You have been kicked from server by %@", comment: "Dialog"), getDisplayName(msg.user)),
-                                                      preferredStyle: UIAlertController.Style.alert)
+                                                      message: msg, preferredStyle: UIAlertController.Style.alert)
                         alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Dialog"), style: UIAlertAction.Style.default, handler: nil))
                         self.present(alert, animated: true, completion: nil)
                     } else {
@@ -365,7 +365,7 @@ class MainTabBarController : UITabBarController, UIAlertViewDelegate, TeamTalkEv
                 {
                     if #available(iOS 8.0, *) {
                         let alert = UIAlertController(title: NSLocalizedString("Error", comment: "Dialog"),
-                                                      message: NSLocalizedString("You have been kicked from server", comment: "Dialog")),
+                                                      message: NSLocalizedString("You have been kicked from server", comment: "Dialog"),
                                                       preferredStyle: UIAlertController.Style.alert)
                         alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Dialog"), style: UIAlertAction.Style.default, handler: nil))
                         self.present(alert, animated: true, completion: nil)
@@ -379,9 +379,9 @@ class MainTabBarController : UITabBarController, UIAlertViewDelegate, TeamTalkEv
                 if (m.ttType == __USER)
                 {
                     if #available(iOS 8.0, *) {
+                        let msg = String(format: NSLocalizedString("You have been kicked from channel by %@", comment: "Dialog"), getDisplayName(m.user))
                         let alert = UIAlertController(title: NSLocalizedString("Error", comment: "Dialog"),
-                                                      message: format(NSLocalizedString("You have been kicked from channel by %@", comment: "Dialog"), getDisplayName(msg.user)),
-                                                      preferredStyle: UIAlertController.Style.alert)
+                                                      message: msg, preferredStyle: UIAlertController.Style.alert)
                         alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Dialog"), style: UIAlertAction.Style.default, handler: nil))
                         self.present(alert, animated: true, completion: nil)
                     } else {

--- a/Client/iTeamTalk/iTeamTalk/MainTabBarController.swift
+++ b/Client/iTeamTalk/iTeamTalk/MainTabBarController.swift
@@ -349,26 +349,56 @@ class MainTabBarController : UITabBarController, UIAlertViewDelegate, TeamTalkEv
             if (m.nSource == 0)
             {
                 playSound(.srv_LOST)
-                if #available(iOS 8.0, *) {
-                    let alert = UIAlertController(title: NSLocalizedString("Error", comment: "Dialog"),
-                                                  message: NSLocalizedString("You have been kicked from server", comment: "Dialog"),
-                                                  preferredStyle: UIAlertController.Style.alert)
-                    alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Dialog"), style: UIAlertAction.Style.default, handler: nil))
-                    self.present(alert, animated: true, completion: nil)
-                } else {
-                    // Fallback on earlier versions
+                if (m.ttType == __USER)
+                {
+                    if #available(iOS 8.0, *) {
+                        let alert = UIAlertController(title: NSLocalizedString("Error", comment: "Dialog"),
+                                                      message: format(NSLocalizedString("You have been kicked from server by %@", comment: "Dialog"), getDisplayName(msg.user)),
+                                                      preferredStyle: UIAlertController.Style.alert)
+                        alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Dialog"), style: UIAlertAction.Style.default, handler: nil))
+                        self.present(alert, animated: true, completion: nil)
+                    } else {
+                        // Fallback on earlier versions
+                    }
+                }
+                else
+                {
+                    if #available(iOS 8.0, *) {
+                        let alert = UIAlertController(title: NSLocalizedString("Error", comment: "Dialog"),
+                                                      message: NSLocalizedString("You have been kicked from server", comment: "Dialog")),
+                                                      preferredStyle: UIAlertController.Style.alert)
+                        alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Dialog"), style: UIAlertAction.Style.default, handler: nil))
+                        self.present(alert, animated: true, completion: nil)
+                    } else {
+                        // Fallback on earlier versions
+                    }
                 }
             }
             else
             {
-                if #available(iOS 8.0, *) {
-                    let alert = UIAlertController(title: NSLocalizedString("Error", comment: "Dialog"),
-                                                  message: NSLocalizedString("You have been kicked from channel", comment: "Dialog"),
-                                                  preferredStyle: UIAlertController.Style.alert)
-                    alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Dialog"), style: UIAlertAction.Style.default, handler: nil))
-                    self.present(alert, animated: true, completion: nil)
-                } else {
-                    // Fallback on earlier versions
+                if (m.ttType == __USER)
+                {
+                    if #available(iOS 8.0, *) {
+                        let alert = UIAlertController(title: NSLocalizedString("Error", comment: "Dialog"),
+                                                      message: format(NSLocalizedString("You have been kicked from channel by %@", comment: "Dialog"), getDisplayName(msg.user)),
+                                                      preferredStyle: UIAlertController.Style.alert)
+                        alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Dialog"), style: UIAlertAction.Style.default, handler: nil))
+                        self.present(alert, animated: true, completion: nil)
+                    } else {
+                        // Fallback on earlier versions
+                    }
+                }
+                else
+                {
+                    if #available(iOS 8.0, *) {
+                        let alert = UIAlertController(title: NSLocalizedString("Error", comment: "Dialog"),
+                                                      message: NSLocalizedString("You have been kicked from channel by", comment: "Dialog"),
+                                                      preferredStyle: UIAlertController.Style.alert)
+                        alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Dialog"), style: UIAlertAction.Style.default, handler: nil))
+                        self.present(alert, animated: true, completion: nil)
+                    } else {
+                        // Fallback on earlier versions
+                    }
                 }
             }
 

--- a/Client/iTeamTalk/iTeamTalk/ar.lproj/Localizable.strings
+++ b/Client/iTeamTalk/iTeamTalk/ar.lproj/Localizable.strings
@@ -41,6 +41,9 @@
    user detail */
 "Actions" = "الإجراءات";
 
+/* channel list */
+"Active" = "Active";
+
 /* serverlist */
 "Add new server entry" = "إضافة بيانات خادم جديد";
 
@@ -239,6 +242,9 @@
 
 /* server entry */
 "Host address" = "عنوان المضيف";
+
+/* channel list */
+"Inactive" = "Inactive";
 
 /* Dialog message */
 "Join" = "إنضم";
@@ -690,7 +696,16 @@
 "You have been kicked from channel" = "You have been kicked from channel";
 
 /* Dialog */
+"You have been kicked from channel by" = "You have been kicked from channel by";
+
+/* Dialog */
+"You have been kicked from channel by %@" = "You have been kicked from channel by %@";
+
+/* Dialog */
 "You have been kicked from server" = "You have been kicked from server";
+
+/* Dialog */
+"You have been kicked from server by %@" = "You have been kicked from server by %@";
 
 /* speech */
 "You have selected %@" = " لقد اخترت %@";

--- a/Client/iTeamTalk/iTeamTalk/da.lproj/Localizable.strings
+++ b/Client/iTeamTalk/iTeamTalk/da.lproj/Localizable.strings
@@ -41,6 +41,9 @@
    user detail */
 "Actions" = "Handlinger";
 
+/* channel list */
+"Active" = "Active";
+
 /* serverlist */
 "Add new server entry" = "Tilføj ny server";
 
@@ -239,6 +242,9 @@
 
 /* server entry */
 "Host address" = "Serveradresse";
+
+/* channel list */
+"Inactive" = "Inactive";
 
 /* Dialog message */
 "Join" = "Deltag";
@@ -690,7 +696,16 @@
 "You have been kicked from channel" = "You have been kicked from channel";
 
 /* Dialog */
+"You have been kicked from channel by" = "You have been kicked from channel by";
+
+/* Dialog */
+"You have been kicked from channel by %@" = "You have been kicked from channel by %@";
+
+/* Dialog */
 "You have been kicked from server" = "You have been kicked from server";
+
+/* Dialog */
+"You have been kicked from server by %@" = "You have been kicked from server by %@";
 
 /* speech */
 "You have selected %@" = "Du har valgt %@";

--- a/Client/iTeamTalk/iTeamTalk/de.lproj/Localizable.strings
+++ b/Client/iTeamTalk/iTeamTalk/de.lproj/Localizable.strings
@@ -41,6 +41,9 @@
    user detail */
 "Actions" = "Aktionen";
 
+/* channel list */
+"Active" = "Active";
+
 /* serverlist */
 "Add new server entry" = "Neuer Servereintrag";
 
@@ -239,6 +242,9 @@
 
 /* server entry */
 "Host address" = "Hostadresse";
+
+/* channel list */
+"Inactive" = "Inactive";
 
 /* Dialog message */
 "Join" = "Betreten";
@@ -690,7 +696,16 @@
 "You have been kicked from channel" = "You have been kicked from channel";
 
 /* Dialog */
+"You have been kicked from channel by" = "You have been kicked from channel by";
+
+/* Dialog */
+"You have been kicked from channel by %@" = "You have been kicked from channel by %@";
+
+/* Dialog */
 "You have been kicked from server" = "You have been kicked from server";
+
+/* Dialog */
+"You have been kicked from server by %@" = "You have been kicked from server by %@";
 
 /* speech */
 "You have selected %@" = "Du hast %@ gewählt";

--- a/Client/iTeamTalk/iTeamTalk/en.lproj/Localizable.strings
+++ b/Client/iTeamTalk/iTeamTalk/en.lproj/Localizable.strings
@@ -41,6 +41,9 @@
    user detail */
 "Actions" = "Actions";
 
+/* channel list */
+"Active" = "Active";
+
 /* serverlist */
 "Add new server entry" = "Add new server entry";
 
@@ -243,6 +246,9 @@
 
 /* server entry */
 "Host address" = "Host address";
+
+/* channel list */
+"Inactive" = "Inactive";
 
 /* Dialog message */
 "Join" = "Join";
@@ -697,7 +703,16 @@
 "You have been kicked from channel" = "You have been kicked from channel";
 
 /* Dialog */
+"You have been kicked from channel by" = "You have been kicked from channel by";
+
+/* Dialog */
+"You have been kicked from channel by %@" = "You have been kicked from channel by %@";
+
+/* Dialog */
 "You have been kicked from server" = "You have been kicked from server";
+
+/* Dialog */
+"You have been kicked from server by %@" = "You have been kicked from server by %@";
 
 /* speech */
 "You have selected %@" = "You have selected %@";

--- a/Client/iTeamTalk/iTeamTalk/es.lproj/Localizable.strings
+++ b/Client/iTeamTalk/iTeamTalk/es.lproj/Localizable.strings
@@ -41,6 +41,9 @@
    user detail */
 "Actions" = "Acciones";
 
+/* channel list */
+"Active" = "Active";
+
 /* serverlist */
 "Add new server entry" = "Añadir nuevo servidor";
 
@@ -239,6 +242,9 @@
 
 /* server entry */
 "Host address" = "Dirección";
+
+/* channel list */
+"Inactive" = "Inactive";
 
 /* Dialog message */
 "Join" = "Unirse";
@@ -690,7 +696,16 @@
 "You have been kicked from channel" = "You have been kicked from channel";
 
 /* Dialog */
+"You have been kicked from channel by" = "You have been kicked from channel by";
+
+/* Dialog */
+"You have been kicked from channel by %@" = "You have been kicked from channel by %@";
+
+/* Dialog */
 "You have been kicked from server" = "You have been kicked from server";
+
+/* Dialog */
+"You have been kicked from server by %@" = "You have been kicked from server by %@";
 
 /* speech */
 "You have selected %@" = "Has seleccionado %@";

--- a/Client/iTeamTalk/iTeamTalk/fr.lproj/Localizable.strings
+++ b/Client/iTeamTalk/iTeamTalk/fr.lproj/Localizable.strings
@@ -41,6 +41,9 @@
    user detail */
 "Actions" = "Actions";
 
+/* channel list */
+"Active" = "Active";
+
 /* serverlist */
 "Add new server entry" = "Ajouter un nouveau serveur";
 
@@ -243,6 +246,9 @@
 
 /* server entry */
 "Host address" = "Adresse de l'hôte";
+
+/* channel list */
+"Inactive" = "Inactive";
 
 /* Dialog message */
 "Join" = "Rejoindre";
@@ -697,7 +703,16 @@
 "You have been kicked from channel" = "Vous avez été exclu du canal";
 
 /* Dialog */
+"You have been kicked from channel by" = "You have been kicked from channel by";
+
+/* Dialog */
+"You have been kicked from channel by %@" = "You have been kicked from channel by %@";
+
+/* Dialog */
 "You have been kicked from server" = "Vous avez été exclu du serveur";
+
+/* Dialog */
+"You have been kicked from server by %@" = "You have been kicked from server by %@";
 
 /* speech */
 "You have selected %@" = "Vous avez sélectionné %@";

--- a/Client/iTeamTalk/iTeamTalk/hu.lproj/Localizable.strings
+++ b/Client/iTeamTalk/iTeamTalk/hu.lproj/Localizable.strings
@@ -41,6 +41,9 @@
    user detail */
 "Actions" = "Műveletek";
 
+/* channel list */
+"Active" = "Active";
+
 /* serverlist */
 "Add new server entry" = "új szerver hozzáadása";
 
@@ -239,6 +242,9 @@
 
 /* server entry */
 "Host address" = "Host címe";
+
+/* channel list */
+"Inactive" = "Inactive";
 
 /* Dialog message */
 "Join" = "Belépett";
@@ -690,7 +696,16 @@
 "You have been kicked from channel" = "You have been kicked from channel";
 
 /* Dialog */
+"You have been kicked from channel by" = "You have been kicked from channel by";
+
+/* Dialog */
+"You have been kicked from channel by %@" = "You have been kicked from channel by %@";
+
+/* Dialog */
 "You have been kicked from server" = "You have been kicked from server";
+
+/* Dialog */
+"You have been kicked from server by %@" = "You have been kicked from server by %@";
 
 /* speech */
 "You have selected %@" = "a %@ hangot választotta";

--- a/Client/iTeamTalk/iTeamTalk/it.lproj/Localizable.strings
+++ b/Client/iTeamTalk/iTeamTalk/it.lproj/Localizable.strings
@@ -41,6 +41,9 @@
    user detail */
 "Actions" = "Azioni";
 
+/* channel list */
+"Active" = "Active";
+
 /* serverlist */
 "Add new server entry" = "Aggiungi una nuova voce del server";
 
@@ -243,6 +246,9 @@
 
 /* server entry */
 "Host address" = "Indirizzo dell'host";
+
+/* channel list */
+"Inactive" = "Inactive";
 
 /* Dialog message */
 "Join" = "Aderire";
@@ -697,7 +703,16 @@
 "You have been kicked from channel" = "Sei stato espulso dal canale";
 
 /* Dialog */
+"You have been kicked from channel by" = "You have been kicked from channel by";
+
+/* Dialog */
+"You have been kicked from channel by %@" = "You have been kicked from channel by %@";
+
+/* Dialog */
 "You have been kicked from server" = "Sei stato espulso dal server";
+
+/* Dialog */
+"You have been kicked from server by %@" = "You have been kicked from server by %@";
 
 /* speech */
 "You have selected %@" = "Hai selezionato %@";

--- a/Client/iTeamTalk/iTeamTalk/nl.lproj/Localizable.strings
+++ b/Client/iTeamTalk/iTeamTalk/nl.lproj/Localizable.strings
@@ -41,6 +41,9 @@
    user detail */
 "Actions" = "Taken";
 
+/* channel list */
+"Active" = "Active";
+
 /* serverlist */
 "Add new server entry" = "Nieuwe server toevoegen";
 
@@ -239,6 +242,9 @@
 
 /* server entry */
 "Host address" = "Hostadres";
+
+/* channel list */
+"Inactive" = "Inactive";
 
 /* Dialog message */
 "Join" = "Binnengaan";
@@ -690,7 +696,16 @@
 "You have been kicked from channel" = "You have been kicked from channel";
 
 /* Dialog */
+"You have been kicked from channel by" = "You have been kicked from channel by";
+
+/* Dialog */
+"You have been kicked from channel by %@" = "You have been kicked from channel by %@";
+
+/* Dialog */
 "You have been kicked from server" = "You have been kicked from server";
+
+/* Dialog */
+"You have been kicked from server by %@" = "You have been kicked from server by %@";
 
 /* speech */
 "You have selected %@" = "U hebt %@ geselecteerd";

--- a/Client/iTeamTalk/iTeamTalk/pl.lproj/Localizable.strings
+++ b/Client/iTeamTalk/iTeamTalk/pl.lproj/Localizable.strings
@@ -41,6 +41,9 @@
    user detail */
 "Actions" = "Czynności";
 
+/* channel list */
+"Active" = "Active";
+
 /* serverlist */
 "Add new server entry" = "Dodaj serwer";
 
@@ -239,6 +242,9 @@
 
 /* server entry */
 "Host address" = "Adres serwera";
+
+/* channel list */
+"Inactive" = "Inactive";
 
 /* Dialog message */
 "Join" = "Dołącz";
@@ -690,7 +696,16 @@
 "You have been kicked from channel" = "You have been kicked from channel";
 
 /* Dialog */
+"You have been kicked from channel by" = "You have been kicked from channel by";
+
+/* Dialog */
+"You have been kicked from channel by %@" = "You have been kicked from channel by %@";
+
+/* Dialog */
 "You have been kicked from server" = "You have been kicked from server";
+
+/* Dialog */
+"You have been kicked from server by %@" = "You have been kicked from server by %@";
 
 /* speech */
 "You have selected %@" = "Wybrano %@";

--- a/Client/iTeamTalk/iTeamTalk/pt-BR.lproj/Localizable.strings
+++ b/Client/iTeamTalk/iTeamTalk/pt-BR.lproj/Localizable.strings
@@ -41,6 +41,9 @@
    user detail */
 "Actions" = "Ações";
 
+/* channel list */
+"Active" = "Active";
+
 /* serverlist */
 "Add new server entry" = "Adicionar novo servidor";
 
@@ -243,6 +246,9 @@
 
 /* server entry */
 "Host address" = "Endereço";
+
+/* channel list */
+"Inactive" = "Inactive";
 
 /* Dialog message */
 "Join" = "Entrar";
@@ -697,7 +703,16 @@
 "You have been kicked from channel" = "You have been kicked from channel";
 
 /* Dialog */
+"You have been kicked from channel by" = "You have been kicked from channel by";
+
+/* Dialog */
+"You have been kicked from channel by %@" = "You have been kicked from channel by %@";
+
+/* Dialog */
 "You have been kicked from server" = "You have been kicked from server";
+
+/* Dialog */
+"You have been kicked from server by %@" = "You have been kicked from server by %@";
 
 /* speech */
 "You have selected %@" = "Você selecionou %@";

--- a/Client/iTeamTalk/iTeamTalk/ru.lproj/Localizable.strings
+++ b/Client/iTeamTalk/iTeamTalk/ru.lproj/Localizable.strings
@@ -41,6 +41,9 @@
    user detail */
 "Actions" = "Действия";
 
+/* channel list */
+"Active" = "Active";
+
 /* serverlist */
 "Add new server entry" = "Добавление нового сервера";
 
@@ -239,6 +242,9 @@
 
 /* server entry */
 "Host address" = "Адрес хоста";
+
+/* channel list */
+"Inactive" = "Inactive";
 
 /* Dialog message */
 "Join" = "Подключить";
@@ -690,7 +696,16 @@
 "You have been kicked from channel" = "You have been kicked from channel";
 
 /* Dialog */
+"You have been kicked from channel by" = "You have been kicked from channel by";
+
+/* Dialog */
+"You have been kicked from channel by %@" = "You have been kicked from channel by %@";
+
+/* Dialog */
 "You have been kicked from server" = "You have been kicked from server";
+
+/* Dialog */
+"You have been kicked from server by %@" = "You have been kicked from server by %@";
 
 /* speech */
 "You have selected %@" = "Вы выбрали %@";

--- a/Client/iTeamTalk/iTeamTalk/tr.lproj/Localizable.strings
+++ b/Client/iTeamTalk/iTeamTalk/tr.lproj/Localizable.strings
@@ -41,6 +41,9 @@
    user detail */
 "Actions" = "Eylemler";
 
+/* channel list */
+"Active" = "Active";
+
 /* serverlist */
 "Add new server entry" = "Yeni sunucu girişi ekle";
 
@@ -243,6 +246,9 @@
 
 /* server entry */
 "Host address" = "Ana bilgisayar adresi";
+
+/* channel list */
+"Inactive" = "Inactive";
 
 /* Dialog message */
 "Join" = "Katıl";
@@ -697,7 +703,16 @@
 "You have been kicked from channel" = "Kanaldan uzaklaştırıldınız";
 
 /* Dialog */
+"You have been kicked from channel by" = "You have been kicked from channel by";
+
+/* Dialog */
+"You have been kicked from channel by %@" = "You have been kicked from channel by %@";
+
+/* Dialog */
 "You have been kicked from server" = "Sunucudan uzaklaştırıldınız";
+
+/* Dialog */
+"You have been kicked from server by %@" = "You have been kicked from server by %@";
 
 /* speech */
 "You have selected %@" = "Seçtiğiniz: %@";

--- a/Client/iTeamTalk/iTeamTalk/zh.lproj/Localizable.strings
+++ b/Client/iTeamTalk/iTeamTalk/zh.lproj/Localizable.strings
@@ -41,6 +41,9 @@
    user detail */
 "Actions" = "操作";
 
+/* channel list */
+"Active" = "Active";
+
 /* serverlist */
 "Add new server entry" = "添加新服务器";
 
@@ -243,6 +246,9 @@
 
 /* server entry */
 "Host address" = "主机地址";
+
+/* channel list */
+"Inactive" = "Inactive";
 
 /* Dialog message */
 "Join" = "加入";
@@ -697,7 +703,16 @@
 "You have been kicked from channel" = "您已被踢出频道";
 
 /* Dialog */
+"You have been kicked from channel by" = "You have been kicked from channel by";
+
+/* Dialog */
+"You have been kicked from channel by %@" = "You have been kicked from channel by %@";
+
+/* Dialog */
 "You have been kicked from server" = "您已被踢出服务器";
+
+/* Dialog */
+"You have been kicked from server by %@" = "You have been kicked from server by %@";
 
 /* speech */
 "You have selected %@" = "您已选择 %@";


### PR DESCRIPTION
- Add an accessibility value to say if tx button is on or off
- Return who has kicked
- Change title for private messages to return nickname
Unfortunately I can't test changes for iOS at moment. @bear101 please let me know if something should be change. If it's OK for you, could you update translations, after that a new beta will be appreciated.