### PR TITLE
Set status description to away only when appropriate

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -1164,8 +1164,7 @@ implements TeamTalkConnectionListener,
                         icon_resource = away? R.drawable.man_orange : R.drawable.man_blue;
                     }
                 }
-                if(away) {
-                    status.setContentDescription(getString(R.string.user_state_away, name));
+                status.setContentDescription(away?getString(R.string.user_state_away, name):null);
                 }
                 usericon.setImageResource(icon_resource);
                 usericon.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);


### PR DESCRIPTION
A new try to apply better changes to status description in Android client.
With my latest PR, description is set to away when an user switch to this mode, but when switch again to another one, description isn't reset.