### PR TITLE
QT - Fix streaming of files path containing quote

### DIFF
--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -3132,7 +3132,9 @@ void MainWindow::processDesktopInput(int userid, const DesktopInput& input)
 void MainWindow::startStreamMediaFile()
 {
     QString fileName = ttSettings->value(QString(SETTINGS_STREAMMEDIA_FILENAME).arg(0)).toString();
+#if defined(Q_OS_WINDOWS)
     fileName=fileName.remove('"');
+#endif
 
     VideoCodec vidcodec;
     vidcodec.nCodec = (Codec)ttSettings->value(SETTINGS_STREAMMEDIA_CODEC).toInt();

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -3132,6 +3132,7 @@ void MainWindow::processDesktopInput(int userid, const DesktopInput& input)
 void MainWindow::startStreamMediaFile()
 {
     QString fileName = ttSettings->value(QString(SETTINGS_STREAMMEDIA_FILENAME).arg(0)).toString();
+    fileName=fileName.remove('"');
 
     VideoCodec vidcodec;
     vidcodec.nCodec = (Codec)ttSettings->value(SETTINGS_STREAMMEDIA_CODEC).toInt();


### PR DESCRIPTION
Very useful on Windows to use option "Copy as file path" of files explorer and past this to CTRL-S dialog.