### PR TITLE
QT - Fixed issues caused by 2356b05

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -23,6 +23,7 @@ Default QT Client
 - Uniformize defaults sound files with classic client
 - More TTS events
 - URLs in chat history can be activated using Enter key
+- Paste a text at the start of the first line of the filename in the CTRL + S dialog now replaces the text of that line
 Android Client
 -
 iOS Client

--- a/Client/qtTeamTalk/streammediafiledlg.cpp
+++ b/Client/qtTeamTalk/streammediafiledlg.cpp
@@ -427,7 +427,7 @@ void StreamMediaFileDlg::slotMediaPlaybackProgress(int sessionid, const MediaFil
 
 bool StreamMediaFileDlg::eventFilter(QObject *object, QEvent *event)
 {
-    if (object == ui.mediafileComboBox/*->lineEdit()*/ && event->type() == QEvent::KeyPress)
+    if (object == ui.mediafileComboBox && event->type() == QEvent::KeyPress)
     {
         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
         if (keyEvent->matches(QKeySequence::Paste) && ui.mediafileComboBox->currentIndex() == 0 && ui.mediafileComboBox->lineEdit()->cursorPosition() == 0)

--- a/Client/qtTeamTalk/streammediafiledlg.cpp
+++ b/Client/qtTeamTalk/streammediafiledlg.cpp
@@ -30,6 +30,7 @@
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QComboBox>
+#include <QKeyEvent>
 
 extern QSettings* ttSettings;
 extern TTInstance* ttInst;
@@ -94,6 +95,8 @@ StreamMediaFileDlg::StreamMediaFileDlg(QWidget* parent/* = 0*/)
     ui.mediafileComboBox->setCurrentIndex(0); // generates showMediaFormatInfo()
 
     updateControls();
+    ui.mediafileComboBox->installEventFilter(this);
+    ui.mediafileComboBox->lineEdit()->setCursorPosition(0);
 }
 
 StreamMediaFileDlg::~StreamMediaFileDlg()
@@ -145,7 +148,6 @@ void StreamMediaFileDlg::slotSelectFile()
 void StreamMediaFileDlg::slotSelectionFile(const QString&)
 {
     showMediaFormatInfo();
-    ui.mediafileComboBox->lineEdit()->setSelection(0, ui.mediafileComboBox->lineEdit()->text().size());
 }
 
 void StreamMediaFileDlg::showMediaFormatInfo()
@@ -421,4 +423,21 @@ void StreamMediaFileDlg::slotMediaPlaybackProgress(int sessionid, const MediaFil
     }
 
     m_progressupdate = false;
+}
+
+bool StreamMediaFileDlg::eventFilter(QObject *object, QEvent *event)
+{
+    if (object == ui.mediafileComboBox/*->lineEdit()*/ && event->type() == QEvent::KeyPress)
+    {
+        QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+        if (keyEvent->matches(QKeySequence::Paste) && ui.mediafileComboBox->currentIndex() == 0 && ui.mediafileComboBox->lineEdit()->cursorPosition() == 0)
+        {
+            ui.mediafileComboBox->lineEdit()->clear();
+            ui.mediafileComboBox->lineEdit()->paste();
+            return true;
+        }
+        else
+            return false;
+    }
+    return false;
 }

--- a/Client/qtTeamTalk/streammediafiledlg.h
+++ b/Client/qtTeamTalk/streammediafiledlg.h
@@ -54,6 +54,9 @@ private:
     void slotChangePreprocessor(int);
     void slotSetupPreprocessor(bool);
 
+protected:
+    bool eventFilter(QObject *object, QEvent *event);
+
 private:
     Ui::StreamMediaFileDlg ui;
     MediaFileInfo m_mediaFile = {};


### PR DESCRIPTION
This fix issues caused by commit 2356b05:
- It's not anymore require to press enter twice to stream a file
- This also fix a regression with Orca screen reader which has some dificulties to read combobox after commit above

With this PR, if combobox's index is 0, cursor position is also 0 and user paste a text from clipboard, current text of combobox is replaced by newest.
If one of this conditions isn't respect, text is simply paste without any replacement.