### PR TITLE
TT_EnableAudioBlockEvent outside channel for TT_MUXED_USERID

### DIFF
--- a/Library/TeamTalkLib/codec/MediaUtil.cpp
+++ b/Library/TeamTalkLib/codec/MediaUtil.cpp
@@ -31,6 +31,23 @@
 
 namespace media {
 
+    int AudioInputFormat::GetDurationMSec() const
+    {
+        assert(samples > 0);
+        assert(fmt.samplerate > 0);
+        return PCM16_SAMPLES_DURATION(samples, fmt.samplerate);
+    }
+
+    int AudioInputFormat::GetTotalSamples() const
+    {
+        return samples * fmt.channels;
+    }
+
+    int AudioInputFormat::GetBytes() const
+    {
+        return PCM16_BYTES(samples, fmt.channels);
+    }
+
     void AudioFrame::ApplyGain()
     {
         assert(input_buffer || input_samples == 0);
@@ -38,8 +55,7 @@ namespace media {
         SOFTGAIN(input_buffer, input_samples, inputfmt.channels,
                  gain.numerator, gain.denominator);
         gain = Rational(1, 1);
-    }
-
+    }    
 }
 
 void SplitStereo(const short* input_buffer, int input_samples,

--- a/Library/TeamTalkLib/codec/MediaUtil.h
+++ b/Library/TeamTalkLib/codec/MediaUtil.h
@@ -102,6 +102,26 @@ namespace media
         }
     };
 
+    struct AudioInputFormat
+    {
+        AudioFormat fmt;
+        int samples = 0;
+        AudioInputFormat(const AudioFormat& f, int s) : fmt(f), samples(s) {}
+        AudioInputFormat() {}
+        bool IsValid() const { return fmt.IsValid() && samples > 0; }
+        int GetDurationMSec() const;
+        int GetTotalSamples() const;
+        int GetBytes() const;
+        bool operator==(const AudioInputFormat& f) const
+        {
+            return fmt == f.fmt && samples == f.samples;
+        }
+        bool operator!=(const AudioInputFormat& f) const
+        {
+            return fmt != f.fmt || samples != f.samples;
+        }
+    };
+
 // Returns number of bytes from number of 'samples' with 'channels'
 #define PCM16_BYTES(samples, channels) ((samples) * (channels) * sizeof(short))
 // Returns number of msec from number of 'bytes' with 'channels' at given 'samplerate'

--- a/Library/TeamTalkLib/teamtalk/CodecCommon.cpp
+++ b/Library/TeamTalkLib/teamtalk/CodecCommon.cpp
@@ -334,6 +334,12 @@ namespace teamtalk
         return media::AudioFormat(GetAudioCodecSampleRate(codec), channels);
     }
 
+    media::AudioInputFormat GetAudioCodecAudioInputFormat(const AudioCodec& codec)
+    {
+        return media::AudioInputFormat(GetAudioCodecAudioFormat(codec),
+                                       GetAudioCodecCbSamples(codec));
+    }
+
     int GetSpeexBandMode(const AudioCodec& codec)
     {
         switch(codec.codec)

--- a/Library/TeamTalkLib/teamtalk/CodecCommon.h
+++ b/Library/TeamTalkLib/teamtalk/CodecCommon.h
@@ -44,6 +44,7 @@ namespace teamtalk
     int GetAudioCodecBitRate(const AudioCodec& codec);
     int GetAudioCodecMaxPacketBitrate(const AudioCodec& codec);
     media::AudioFormat GetAudioCodecAudioFormat(const AudioCodec& codec);
+    media::AudioInputFormat GetAudioCodecAudioInputFormat(const AudioCodec& codec);
 
     int GetSpeexBandMode(const AudioCodec& codec);
     int GetSpeexQuality(const AudioCodec& codec);

--- a/Library/TeamTalkLib/teamtalk/client/AudioMuxer.h
+++ b/Library/TeamTalkLib/teamtalk/client/AudioMuxer.h
@@ -61,7 +61,7 @@ public:
     AudioMuxer(teamtalk::StreamTypes sts);
     virtual ~AudioMuxer();
 
-    bool RegisterMuxCallback(const teamtalk::AudioCodec& codec,
+    bool RegisterMuxCallback(const media::AudioInputFormat& fmt,
                              audiomuxer_callback_t cb);
     void UnregisterMuxCallback();
 
@@ -78,8 +78,8 @@ public:
     void SetMuxInterval(int msec);
     
 private:
-    bool Init(const teamtalk::AudioCodec& codec);
-    bool StartThread(const teamtalk::AudioCodec& codec);
+    bool Init(const media::AudioInputFormat& fmt);
+    bool StartThread(const media::AudioInputFormat& fmt);
     void StopThread();
     void Run();
     int TimerEvent(ACE_UINT32 timer_event_id, long userdata);
@@ -119,7 +119,7 @@ private:
 
     uint32_t m_sample_no = 0;
     uint32_t m_last_flush_time = 0;
-    teamtalk::AudioCodec m_codec;
+    media::AudioInputFormat m_inputformat;
     teamtalk::StreamTypes m_streamtypes = teamtalk::STREAMTYPE_NONE;
 
     wavepcmfile_t m_wavefile;

--- a/Library/TeamTalkLib/teamtalk/client/ClientNode.cpp
+++ b/Library/TeamTalkLib/teamtalk/client/ClientNode.cpp
@@ -3010,15 +3010,30 @@ bool ClientNode::EnableAudioBlockCallback(int userid, StreamTypes sts,
     {
         if (enable)
         {
-            m_audiomuxer_stream.reset(new AudioMuxer(sts));
-            // start muxer if already in channel
-            if (m_mychannel)
+            audiomuxer_t newmuxer(new AudioMuxer(sts));
+            media::AudioInputFormat infmt;
+
+            if (outfmt.IsValid())
+                infmt = media::AudioInputFormat(outfmt, PCM16_DURATION_SAMPLES(20, outfmt.samplerate));
+            else if (m_mychannel)
             {
                 auto codec = m_mychannel->GetAudioCodec();
-                bool startmux = m_audiomuxer_stream->RegisterMuxCallback(GetAudioCodecAudioInputFormat(codec),
-                                                                         std::bind(&ClientNode::AudioMuxCallback, this, _1, _2));
-                MYTRACE_COND(!startmux, ACE_TEXT("Failed to start audio muxer\n"));
+                infmt = GetAudioCodecAudioInputFormat(codec);
             }
+
+            if (infmt.IsValid())
+            {
+                bool startmux = newmuxer->RegisterMuxCallback(infmt,std::bind(&ClientNode::AudioMuxCallback, this, _1, _2));
+                MYTRACE_COND(!startmux, ACE_TEXT("Failed to start audio muxer\n"));
+                if (!startmux)
+                    return false;
+            }
+            else
+            {
+                return false;
+            }
+
+            m_audiomuxer_stream = newmuxer;
         }
         else
         {
@@ -4197,14 +4212,6 @@ void ClientNode::JoinChannel(clientchannel_t& chan)
     // add "self" from muxed recording
     m_channelrecord.AddUser(LOCAL_TX_USERID, STREAMTYPE_VOICE, chan->GetChannelID());
 
-    // enable audio muxer callback
-    if (m_audiomuxer_stream)
-    {
-        bool startmux = m_audiomuxer_stream->RegisterMuxCallback(GetAudioCodecAudioInputFormat(codec),
-                                                                 std::bind(&ClientNode::AudioMuxCallback, this, _1, _2));
-        MYTRACE_COND(!startmux, ACE_TEXT("Failed to start audio muxer\n"));
-    }
-
     //start recorder for voice stream
     OpenAudioCapture(codec);
 }
@@ -4245,10 +4252,6 @@ void ClientNode::LeftChannel(ClientChannel& chan)
         CloseAudioCapture();
 
     m_voice_thread.StopEncoder();
-
-    // leaving channel so put AudioMuxer into clean state
-    if (m_audiomuxer_stream)
-        m_audiomuxer_stream->UnregisterMuxCallback();
 
     // remove "self" from muxed recording
     m_channelrecord.RemoveUser(LOCAL_TX_USERID, STREAMTYPE_VOICE);

--- a/Library/TeamTalkLib/teamtalk/client/ClientNode.cpp
+++ b/Library/TeamTalkLib/teamtalk/client/ClientNode.cpp
@@ -3015,7 +3015,8 @@ bool ClientNode::EnableAudioBlockCallback(int userid, StreamTypes sts,
             if (m_mychannel)
             {
                 auto codec = m_mychannel->GetAudioCodec();
-                bool startmux = m_audiomuxer_stream->RegisterMuxCallback(codec, std::bind(&ClientNode::AudioMuxCallback, this, _1, _2));
+                bool startmux = m_audiomuxer_stream->RegisterMuxCallback(GetAudioCodecAudioInputFormat(codec),
+                                                                         std::bind(&ClientNode::AudioMuxCallback, this, _1, _2));
                 MYTRACE_COND(!startmux, ACE_TEXT("Failed to start audio muxer\n"));
             }
         }
@@ -4199,7 +4200,8 @@ void ClientNode::JoinChannel(clientchannel_t& chan)
     // enable audio muxer callback
     if (m_audiomuxer_stream)
     {
-        bool startmux = m_audiomuxer_stream->RegisterMuxCallback(codec, std::bind(&ClientNode::AudioMuxCallback, this, _1, _2));
+        bool startmux = m_audiomuxer_stream->RegisterMuxCallback(GetAudioCodecAudioInputFormat(codec),
+                                                                 std::bind(&ClientNode::AudioMuxCallback, this, _1, _2));
         MYTRACE_COND(!startmux, ACE_TEXT("Failed to start audio muxer\n"));
     }
 

--- a/Library/TeamTalkLib/test/TTUnitTest.h
+++ b/Library/TeamTalkLib/test/TTUnitTest.h
@@ -75,4 +75,19 @@ public:
 
 ttinst InitTeamTalk();
 
+class abptr
+{
+private:
+    TTInstance* m_inst = nullptr;
+    AudioBlock* m_ab = nullptr;
+    abptr(const abptr&) = delete;
+    void operator=(const abptr&) = delete;
+public:
+    abptr(TTInstance* inst, AudioBlock* ab) : m_inst(inst), m_ab(ab) {}
+    ~abptr() { if (m_inst && m_ab) TT_ReleaseUserAudioBlock(m_inst, m_ab); }
+    operator AudioBlock*() { return m_ab; }
+    AudioBlock* operator->() const { return m_ab; }
+    operator bool() const { return m_ab != nullptr; }
+};
+
 #endif

--- a/Library/TeamTalk_DLL/TeamTalk.h
+++ b/Library/TeamTalk_DLL/TeamTalk.h
@@ -722,8 +722,7 @@ extern "C" {
  * into a single stream.
  *
  * This user ID is passed to TT_EnableAudioBlockEvent() in order to
- * receive #AudioBlock of audio that is played in the #TTInstance's
- * channel. */
+ * receive #AudioBlock of audio that is played by the #TTInstance. */
 #define TT_MUXED_USERID 0x1001 /* TT_USERID_MAX + 2 */
 
     /** @} */
@@ -4547,35 +4546,15 @@ extern "C" {
 
     /**
      * @brief Enable/disable access to raw audio from individual
-     * users, local microphone input or muxed stream of all users.
+     * users, local microphone input or mixed stream of all users.
      *
-     * With audio block event enabled all audio which has been played
-     * will be accessible by calling TT_AcquireUserAudioBlock(). Every
-     * time a new #AudioBlock is available the event
-     * #CLIENTEVENT_USER_AUDIOBLOCK is generated.
+     * @deprecated Use TT_EnableAudioBlockEventEx().
      *
      * @param lpTTInstance Pointer to client instance created by
      * #TT_InitTeamTalk.
-     * @param nUserID User ID has different meanings depending on
-     *  the #StreamType being passed.
-     *
-     * For #STREAMTYPE_VOICE:
-     * - Pass user ID to monitor for audio callback from voice stream.
-     * - Pass special user ID #TT_LOCAL_USERID to monitor
-     *   local recorded audio prior to encoding/processing.
-     * - Pass special user ID #TT_MUXED_USERID to get a single audio
-     *   stream of all audio that is being played from users.
-     * For #STREAMTYPE_MEDIAFILE_AUDIO:
-     * - Pass #TT_LOCAL_USERID to receive audio from media file being
-     *   streamed. @see TT_StartStreamingMediaFileToChannel().
-     * For #STREAMTYPE_LOCALMEDIAPLAYBACK_AUDIO:
-     * - Pass session ID returned by TT_InitLocalPlayback() to receive
-     *   audio stream from local playback.
-     * - Pass #TT_LOCAL_USERID to receive audio stream from all local
-     *   playbacks.
-     * @param uStreamTypes Either #STREAMTYPE_VOICE,
-     * #STREAMTYPE_MEDIAFILE_AUDIO or #STREAMTYPE_LOCALMEDIAPLAYBACK_AUDIO.
-     * @param bEnable Whether to enable the #CLIENTEVENT_USER_AUDIOBLOCK event.
+     * @param nUserID See description in TT_EnableAudioBlockEventEx()
+     * @param uStreamTypes See description in TT_EnableAudioBlockEventEx()
+     * @param bEnable See description in TT_EnableAudioBlockEventEx()
      * @see TT_AcquireUserAudioBlock()
      * @see TT_ReleaseUserAudioBlock()
      * @see CLIENTEVENT_USER_AUDIOBLOCK */
@@ -4585,17 +4564,78 @@ extern "C" {
                                                     IN TTBOOL bEnable);
 
     /**
-     * @brief Same as TT_EnableAudioBlockEvent() but option to specify
-     * audio output format.
+     * @brief Enable/disable access to raw audio from individual
+     * users, local microphone input or mixed stream of all users.
+     *
+     * With audio block event enabled all audio which has been played
+     * will be accessible by calling TT_AcquireUserAudioBlock(). Every
+     * time a new #AudioBlock is available the event
+     * #CLIENTEVENT_USER_AUDIOBLOCK is generated.
+     *
+     * Special user IDs can be used to retrieve certain types of audio
+     * from the client instance:
+     *
+     * - #TT_LOCAL_USERID
+     *   - Unprocessed audio from microphone when using #STREAMTYPE_VOICE.
+     *   - Decoded PCM16 when using #STREAMTYPE_MEDIAFILE_AUDIO.
+     *   - Decoded PCM16 when using #STREAMTYPE_LOCALMEDIAPLAYBACK_AUDIO
+     *     from all active local playbacks @see TT_InitLocalPlayback().
+     * - #TT_LOCAL_TX_USERID
+     *   - Processed audio from microphone that is transmitted to channel
+     *     when using #STREAMTYPE_VOICE.
+     *   - Not applicable for all other stream types except #STREAMTYPE_VOICE
+     * - #TT_MUXED_USERID
+     *   - Decoded PCM16 from all specified audio streams (#StreamTypes)
+     *     mixed into a single stream.
      *
      * @param lpTTInstance Pointer to client instance created by
      * #TT_InitTeamTalk.
-     * @param nUserID See description in TT_EnableAudioBlockEvent()
-     * @param uStreamTypes See description in TT_EnableAudioBlockEvent()
-     * @param lpAudioFormat Resample audio format from user to this #AudioFormat.
-     * Currently only AFF_WAVE_FORMAT is supported.
+     * @param nUserID User ID has different meanings depending on
+     *  the #StreamType being passed.
+     *
+     * For #STREAMTYPE_VOICE:
+     * - Pass user ID to receive audio from voice stream.
+     * - Pass special user ID #TT_LOCAL_USERID for audio callback from
+     *   local recorded audio prior to encoding/processing.
+     * - Pass special user ID #TT_MUXED_USERID to receive audio where
+     *   voice stream has been mixed into the single stream.
+     * For #STREAMTYPE_MEDIAFILE_AUDIO:
+     * - Pass user ID to receive audio from media stream.
+     * - Pass #TT_LOCAL_USERID to receive audio from media file being
+     *   streamed (transmitted). @see TT_StartStreamingMediaFileToChannel().
+     * - Pass special user ID #TT_MUXED_USERID to receive audio where
+     *   media stream has been mixed into the single stream.
+     * For #STREAMTYPE_LOCALMEDIAPLAYBACK_AUDIO:
+     * - Pass session ID returned by TT_InitLocalPlayback() to receive
+     *   audio stream from local playback.
+     * - Pass #TT_LOCAL_USERID to receive audio stream from all local
+     *   playbacks.
+     * - Pass special user ID #TT_MUXED_USERID to receive audio where
+     *   local playback stream has been mixed into the single stream.
+     *
+     * When using #TT_MUXED_USERID as user ID the #TTInstance must be
+     * in a channel with a configured #AudioCodec. Alternatively use
+     * @lpAudioFormat to specify the audio properties.
+     *
+     * @param uStreamTypes Either #STREAMTYPE_VOICE,
+     * #STREAMTYPE_MEDIAFILE_AUDIO or #STREAMTYPE_LOCALMEDIAPLAYBACK_AUDIO.
+     * For #TT_MUXED_USERID it's possible to mix #StreamTypes so e.g.
+     * #STREAMTYPE_LOCALMEDIAPLAYBACK_AUDIO **or'ed** with
+     * #STREAMTYPE_VOICE) will return an #AudioBlock where these two
+     * stream types have been mixed together.
+     *
+     * @param lpAudioFormat Resample audio format from user to this
+     * #AudioFormat. Currently only #AFF_WAVE_FORMAT is supported.
      * Specify NULL to get original audio format.
+     *
+     * When using #TT_MUXED_USERID as user ID in combination with @c
+     * lpAudioFormat will cause #AudioBlock to contain 20 msec of
+     * audio. If @c lpAudioFormat is NULL then the #TTInstance will
+     * use the audio format that is configured in the channel's
+     * #AudioCodec.
+     *
      * @param bEnable Whether to enable the #CLIENTEVENT_USER_AUDIOBLOCK event.
+     *
      * @see TT_AcquireUserAudioBlock()
      * @see TT_ReleaseUserAudioBlock()
      * @see CLIENTEVENT_USER_AUDIOBLOCK */


### PR DESCRIPTION
When not in a channel calling `TT_EnableAudioBlockEventEx(ttInst, TT_MUXED_USERID, STREAMTYPE_VOICE, fmt, TRUE)` will now cause TTInstance to output AudioBlock's containing silence. The AudioBlocks will use a frame size of 20 msec when 'fmt' is specified.