### PR TITLE
QT - Only select server if lastest host is an existing entry

### DIFF
--- a/Client/qtTeamTalk/serverlistdlg.cpp
+++ b/Client/qtTeamTalk/serverlistdlg.cpp
@@ -87,6 +87,21 @@ ServerListDlg::ServerListDlg(QWidget * parent/* = 0*/)
 
     ui.delButton->setEnabled(false);
     showServers();
+    HostEntry lasthost;
+    if(getLatestHost(0, lasthost))
+    {
+        ui.hostaddrBox->setFocus();
+        HostEntry entry;
+        int index = 0;
+        while(getServerEntry(index++, entry))
+        {
+            if(entry.ipaddr == lasthost.ipaddr && entry.tcpport == lasthost.tcpport && entry.udpport == lasthost.udpport && entry.encrypted == lasthost.encrypted && entry.username == lasthost.username && entry.password == lasthost.password && entry.channel == lasthost.channel && entry.chanpasswd == lasthost.chanpasswd)
+            {
+                ui.listWidget->setCurrentRow(index-1);
+                ui.listWidget->setFocus();
+            }
+        }
+    }
 }
 
 void ServerListDlg::showLatestHosts()


### PR DESCRIPTION
With this PR, if latest host is save in known hosts, it's selected when opening serverlist class and listWidget get the focus, otherwise hostaddrBox get focus and no server is selected in listWidget.
I tested behavior expected in issue #915 and it's working correctly now.