### PR TITLE
QT - Fix sameHost and sameHostEntry when checking for nickname changes

### DIFF
--- a/Client/qtTeamTalk/common.cpp
+++ b/Client/qtTeamTalk/common.cpp
@@ -1105,36 +1105,21 @@ void addTextToSpeechMessage(TextToSpeechEvent event, const QString& msg)
 
 bool HostEntry::sameHost(const HostEntry& host, bool nickcheck) const
 {
-    if(nickcheck == true)
-    {
-        return ipaddr == host.ipaddr &&
-               tcpport == host.tcpport &&
-               udpport == host.udpport &&
-               encrypted == host.encrypted &&
-               /* srvpasswd == host.srvpasswd && */ //don't include passwords
-               username == host.username &&
-               /* password == host.password && */
-               nickname == host.nickname &&
-               channel == host.channel/* &&
-            hosts[i].chanpasswd == host.chanpasswd*/;
-    }
-    else
-    {
-        return ipaddr == host.ipaddr &&
-               tcpport == host.tcpport &&
-               udpport == host.udpport &&
-               encrypted == host.encrypted &&
-               /* srvpasswd == host.srvpasswd && */ //don't include passwords
-               username == host.username &&
-               /* password == host.password && */
-               channel == host.channel/* &&
-            hosts[i].chanpasswd == host.chanpasswd*/;
-    }
+    return ipaddr == host.ipaddr &&
+           tcpport == host.tcpport &&
+           udpport == host.udpport &&
+           encrypted == host.encrypted &&
+           /* srvpasswd == host.srvpasswd && */ //don't include passwords
+           username == host.username &&
+           /* password == host.password && */
+           (!nickcheck || nickname == host.nickname) &&
+           channel == host.channel
+           /* && hosts[i].chanpasswd == host.chanpasswd*/;
 }
 
-bool HostEntry::sameHostEntry(const HostEntry& host, bool nickcheck) const
+bool HostEntry::sameHostEntry(const HostEntry& host) const
 {
-    return sameHost(host) && host.name == name;
+    return sameHost(host, false) && host.name == name;
 }
 
 void addLatestHost(const HostEntry& host)

--- a/Client/qtTeamTalk/common.cpp
+++ b/Client/qtTeamTalk/common.cpp
@@ -1103,20 +1103,36 @@ void addTextToSpeechMessage(TextToSpeechEvent event, const QString& msg)
     }
 }
 
-bool HostEntry::sameHost(const HostEntry& host) const
+bool HostEntry::sameHost(const HostEntry& host, bool nickcheck) const
 {
-    return ipaddr == host.ipaddr &&
-           tcpport == host.tcpport &&
-           udpport == host.udpport &&
-           /* srvpasswd == host.srvpasswd && */ //don't include passwords
-           username == host.username &&
-           /* password == host.password && */
-           nickname == host.nickname &&
-           channel == host.channel/* &&
-        hosts[i].chanpasswd == host.chanpasswd*/;
+    if(nickcheck == true)
+    {
+        return ipaddr == host.ipaddr &&
+               tcpport == host.tcpport &&
+               udpport == host.udpport &&
+               encrypted == host.encrypted &&
+               /* srvpasswd == host.srvpasswd && */ //don't include passwords
+               username == host.username &&
+               /* password == host.password && */
+               nickname == host.nickname &&
+               channel == host.channel/* &&
+            hosts[i].chanpasswd == host.chanpasswd*/;
+    }
+    else
+    {
+        return ipaddr == host.ipaddr &&
+               tcpport == host.tcpport &&
+               udpport == host.udpport &&
+               encrypted == host.encrypted &&
+               /* srvpasswd == host.srvpasswd && */ //don't include passwords
+               username == host.username &&
+               /* password == host.password && */
+               channel == host.channel/* &&
+            hosts[i].chanpasswd == host.chanpasswd*/;
+    }
 }
 
-bool HostEntry::sameHostEntry(const HostEntry& host) const
+bool HostEntry::sameHostEntry(const HostEntry& host, bool nickcheck) const
 {
     return sameHost(host) && host.name == name;
 }

--- a/Client/qtTeamTalk/common.h
+++ b/Client/qtTeamTalk/common.h
@@ -446,7 +446,7 @@ struct HostEntry
     // doesn't include 'name'
     bool sameHost(const HostEntry& host, bool nickcheck = true) const;
     // same as sameHost() but also host.name == name
-    bool sameHostEntry(const HostEntry& host, bool nickcheck = true) const;
+    bool sameHostEntry(const HostEntry& host) const;
 };
 
 struct DesktopAccessEntry

--- a/Client/qtTeamTalk/common.h
+++ b/Client/qtTeamTalk/common.h
@@ -444,9 +444,9 @@ struct HostEntry
     , voiceact(-1), capformat(), vidcodec() {}
 
     // doesn't include 'name'
-    bool sameHost(const HostEntry& host) const;
+    bool sameHost(const HostEntry& host, bool nickcheck = true) const;
     // same as sameHost() but also host.name == name
-    bool sameHostEntry(const HostEntry& host) const;
+    bool sameHostEntry(const HostEntry& host, bool nickcheck = true) const;
 };
 
 struct DesktopAccessEntry

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -3837,7 +3837,7 @@ void MainWindow::slotMeChangeNickname(bool /*checked =false */)
             index = 0;
             while(getLatestHost(index, tmp))
             {
-                if (m_host.sameHostEntry(tmp, false))
+                if (m_host.sameHostEntry(tmp))
                     lasthost = index;
                 index++;
             }

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -3828,7 +3828,7 @@ void MainWindow::slotMeChangeNickname(bool /*checked =false */)
             int serv, lasthost, index = 0;
             while(getServerEntry(index, tmp))
             {
-                if (m_host.sameHost(tmp))
+                if (m_host.sameHost(tmp, false))
                     serv = index;
                 index++;
                 tmp = HostEntry();
@@ -3837,7 +3837,7 @@ void MainWindow::slotMeChangeNickname(bool /*checked =false */)
             index = 0;
             while(getLatestHost(index, tmp))
             {
-                if (m_host.sameHostEntry(tmp))
+                if (m_host.sameHostEntry(tmp, false))
                     lasthost = index;
                 index++;
             }

--- a/Client/qtTeamTalk/serverlistdlg.cpp
+++ b/Client/qtTeamTalk/serverlistdlg.cpp
@@ -95,7 +95,7 @@ ServerListDlg::ServerListDlg(QWidget * parent/* = 0*/)
         int index = 0;
         while(getServerEntry(index++, entry))
         {
-            if (entry.sameHost(lasthost))
+            if (entry.sameHost(lasthost, false))
             {
                 ui.listWidget->setCurrentRow(index-1);
                 ui.listWidget->setFocus();


### PR DESCRIPTION
After commit 27f2a75 of PR #940, change nickname when connecting only update latesthost, change wasn't save to serverentry.
This issue is due to sameHost and sameHostEntry which always check nickname corresponding. This PR add a parameter to this functions to make nickname check optional.
When call dialog to change nickname, sameHost and sameHostEntry are now call without checking nickname, and issue described above is fix.