### PR TITLE
Push To Talk lock. Issue #278

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -23,6 +23,7 @@ iOS Client
 -
 Server
 - Support for SIGHUP to reload server configuration
+- Error reported if unable to save configuration file (tt5srv.xml)
 
 Version 5.8, 2021/06/24
 Accessible Windows Client

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -2027,20 +2027,23 @@ void MainWindow::hotkeyToggle(HotKeyID id, bool active)
     switch(id)
     {
     case HOTKEY_PUSHTOTALK :
-#if defined(Q_OS_LINUX) && QT_VERSION >= 0x050000
-        if(active)
+        if (ttSettings->value(SETTINGS_GENERAL_PUSHTOTALKLOCK,
+                              SETTINGS_GENERAL_PUSHTOTALKLOCK_DEFAULT).toBool())
         {
-            qDebug() << "Hotkeys are using PTT lock in Qt5 for now";
-            bool tx = (TT_GetFlags(ttInst) & CLIENT_TX_VOICE) != CLIENT_CLOSED;
-            TT_EnableVoiceTransmission(ttInst, !tx);
+            if (active)
+            {
+                bool tx = (TT_GetFlags(ttInst) & CLIENT_TX_VOICE) != CLIENT_CLOSED;
+                TT_EnableVoiceTransmission(ttInst, !tx);
+                emit(updateMyself());
+                playSoundEvent(SOUNDEVENT_HOTKEY);
+            }
+        }
+        else
+        {
+            TT_EnableVoiceTransmission(ttInst, active);
             emit(updateMyself());
             playSoundEvent(SOUNDEVENT_HOTKEY);
         }
-#else
-        TT_EnableVoiceTransmission(ttInst, active);
-        emit(updateMyself());
-        playSoundEvent(SOUNDEVENT_HOTKEY);
-#endif
         break;
     case HOTKEY_VOICEACTIVATION :
         if(active)

--- a/Client/qtTeamTalk/preferences.ui
+++ b/Client/qtTeamTalk/preferences.ui
@@ -292,13 +292,6 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QCheckBox" name="voiceactChkBox">
-            <property name="text">
-             <string>Voice activated</string>
-            </property>
-           </widget>
-          </item>
           <item row="2" column="0">
            <widget class="QCheckBox" name="pttlockChkBox">
             <property name="toolTip">
@@ -306,6 +299,13 @@
             </property>
             <property name="text">
              <string>Push To Talk Lock</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="voiceactChkBox">
+            <property name="text">
+             <string>Voice activated</string>
             </property>
            </widget>
           </item>

--- a/Client/qtTeamTalk/preferences.ui
+++ b/Client/qtTeamTalk/preferences.ui
@@ -292,10 +292,20 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="3" column="0">
            <widget class="QCheckBox" name="voiceactChkBox">
             <property name="text">
              <string>Voice activated</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="pttlockChkBox">
+            <property name="toolTip">
+             <string>Press to transmit.  Press to stop transmit</string>
+            </property>
+            <property name="text">
+             <string>Push To Talk Lock</string>
             </property>
            </widget>
           </item>
@@ -1749,7 +1759,7 @@
               <item row="8" column="0">
                <widget class="QLabel" name="label_66">
                 <property name="text">
-               <string>Transmit ready in &quot;No interruption&quot; channel</string>
+                 <string>Transmit ready in &quot;No interruption&quot; channel</string>
                 </property>
                 <property name="buddy">
                  <cstring>transmitqueueheadEdit</cstring>
@@ -1772,7 +1782,7 @@
               <item row="9" column="0">
                <widget class="QLabel" name="label_67">
                 <property name="text">
-               <string>Transmit stopped in &quot;No interruption&quot; channel</string>
+                 <string>Transmit stopped in &quot;No interruption&quot; channel</string>
                 </property>
                 <property name="buddy">
                  <cstring>transmitqueuestopEdit</cstring>
@@ -1841,7 +1851,7 @@
               <item row="12" column="0">
                <widget class="QLabel" name="label_70">
                 <property name="text">
-               <string>Voice activation enabled via &quot;Me&quot; menu</string>
+                 <string>Voice activation enabled via &quot;Me&quot; menu</string>
                 </property>
                 <property name="buddy">
                  <cstring>voiceactmeonEdit</cstring>
@@ -1864,7 +1874,7 @@
               <item row="13" column="0">
                <widget class="QLabel" name="label_71">
                 <property name="text">
-               <string>Voice activation disabled via &quot;Me&quot; menu</string>
+                 <string>Voice activation disabled via &quot;Me&quot; menu</string>
                 </property>
                 <property name="buddy">
                  <cstring>voiceactmeoffEdit</cstring>

--- a/Client/qtTeamTalk/preferencesdlg.cpp
+++ b/Client/qtTeamTalk/preferencesdlg.cpp
@@ -481,6 +481,8 @@ void PreferencesDlg::slotTabChange(int index)
         ui.awaySpinBox->setValue(ttSettings->value(SETTINGS_GENERAL_AUTOAWAY, SETTINGS_GENERAL_AUTOAWAY_DEFAULT).toInt());
         slotUpdateASBAccessibleName();
         ui.pttChkBox->setChecked(ttSettings->value(SETTINGS_GENERAL_PUSHTOTALK).toBool());
+        ui.pttlockChkBox->setChecked(ttSettings->value(SETTINGS_GENERAL_PUSHTOTALKLOCK,
+                                                       SETTINGS_GENERAL_PUSHTOTALKLOCK_DEFAULT).toBool());
         slotEnablePushToTalk(ttSettings->value(SETTINGS_GENERAL_PUSHTOTALK).toBool());
         ui.voiceactChkBox->setChecked(ttSettings->value(SETTINGS_GENERAL_VOICEACTIVATED,
                                                         SETTINGS_GENERAL_VOICEACTIVATED_DEFAULT).toBool());
@@ -762,6 +764,7 @@ void PreferencesDlg::slotSaveChanges()
         ttSettings->setValue(SETTINGS_GENERAL_AUTOAWAY, ui.awaySpinBox->value());
         saveHotKeySettings(HOTKEY_PUSHTOTALK, m_hotkey);
         ttSettings->setValue(SETTINGS_GENERAL_PUSHTOTALK, ui.pttChkBox->isChecked());
+        ttSettings->setValue(SETTINGS_GENERAL_PUSHTOTALKLOCK, ui.pttlockChkBox->isChecked());
         ttSettings->setValue(SETTINGS_GENERAL_VOICEACTIVATED, ui.voiceactChkBox->isChecked());
         ttSettings->setValue(SETTINGS_GENERAL_RESTOREUSERSETTINGS, ui.syncWebUserCheckBox->isChecked());
     }
@@ -1118,6 +1121,12 @@ void PreferencesDlg::slotEnablePushToTalk(bool checked)
 {
     ui.setupkeysButton->setEnabled(checked);
     ui.keycompEdit->setEnabled(checked);
+    ui.pttlockChkBox->setEnabled(checked);
+#if defined(Q_OS_LINUX) && QT_VERSION >= 0x050000
+    // push/release only supported on X11
+    ui.pttlockChkBox->setEnabled(false);
+    ui.pttlockChkBox->setChecked(checked);
+#endif
 }
 
 void PreferencesDlg::slotSetupHotkey()

--- a/Client/qtTeamTalk/settings.h
+++ b/Client/qtTeamTalk/settings.h
@@ -51,6 +51,8 @@
 #define SETTINGS_GENERAL_AUTOAWAY_DEFAULT                   180
 #define SETTINGS_GENERAL_PUSHTOTALK                 "general_/push-to-talk"
 #define SETTINGS_GENERAL_PUSHTOTALK_KEY             "general_/ptt-key"
+#define SETTINGS_GENERAL_PUSHTOTALKLOCK             "general_/ptt-key-lock"
+#define SETTINGS_GENERAL_PUSHTOTALKLOCK_DEFAULT     false
 #define SETTINGS_GENERAL_VOICEACTIVATED             "general_/voice-activated"
 #define SETTINGS_GENERAL_VOICEACTIVATED_DEFAULT     false
 #define SETTINGS_GENERAL_STATUSMESSAGE              "general_/statusmsg"


### PR DESCRIPTION
Can you check that "push-to-talk lock" is always disabled on Linux and follows the "normal" push-to-talk?