### PR TITLE
Copy user infos using CTRL+C from online users dialog

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -16,6 +16,7 @@ Default QT Client
 - Option to automatically expand all channels in channels tree
 - Last modification date shown on user accounts
 - Upload time shown on files
+- Press CTRL+C in online users dialog now copy user informations to clipboard
 - Fixed default values for "Transmit ready in "No interruption" channel" and "Transmit stopped in "No interruption" channel" sound events
 - Fixed Shift+Tab navigation issues in main window
 - Fixed missing accessible labels in main window

--- a/Client/qtTeamTalk/onlineusersdlg.cpp
+++ b/Client/qtTeamTalk/onlineusersdlg.cpp
@@ -52,7 +52,6 @@ OnlineUsersDlg::OnlineUsersDlg(QWidget* parent/* = 0 */)
 
     m_model->resetUsers();
     updateTitle();
-    ui.treeView->installEventFilter(this);
 }
 
 void OnlineUsersDlg::updateTitle()
@@ -148,12 +147,11 @@ void OnlineUsersDlg::slotTreeContextMenu(const QPoint& /*point*/)
     }
 }
 
-bool OnlineUsersDlg::eventFilter(QObject *object, QEvent *event)
+void OnlineUsersDlg::keyPressEvent(QKeyEvent* e)
 {
-    if (object == ui.treeView && event->type() == QEvent::KeyPress)
+    if (ui.treeView->hasFocus())
     {
-        QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
-        if (keyEvent->matches(QKeySequence::Copy))
+        if (e->matches(QKeySequence::Copy))
         {
             QItemSelectionModel* selModel = ui.treeView->selectionModel();
             QModelIndexList indexes = selModel->selectedRows();
@@ -162,7 +160,7 @@ bool OnlineUsersDlg::eventFilter(QObject *object, QEvent *event)
             {
                 QModelIndex index = m_proxyModel->mapToSource(indexes[i]);
                 if(!index.isValid())
-                    return false;
+                    return;
                 int userid = index.internalId();
                 User user;
                 if(!TT_GetUser(ttInst, userid, &user))
@@ -181,10 +179,7 @@ bool OnlineUsersDlg::eventFilter(QObject *object, QEvent *event)
                     clipboard->setText(QString(tr("ID: %1, Nickname: %2, Status message: %3, Username: %4, Channel: %5, IP address: %6, Version: %7").arg(user.nUserID).arg(_Q(user.szNickname)).arg(_Q(user.szStatusMsg)).arg(_Q(user.szUsername)).arg(_Q(channel)).arg(_Q(user.szIPAddress)).arg(getVersion(user))));
                 }
             }
-            return true;
         }
-        else
-            return false;
     }
-    return false;
+    QDialog::keyPressEvent(e);
 }

--- a/Client/qtTeamTalk/onlineusersdlg.h
+++ b/Client/qtTeamTalk/onlineusersdlg.h
@@ -55,7 +55,7 @@ signals:
     void streamfileToUser(int userid);
 
 protected:
-    bool eventFilter(QObject *object, QEvent *event);
+    void keyPressEvent(QKeyEvent* e) override;
 
 private:
     void slotTreeContextMenu(const QPoint&);

--- a/Client/qtTeamTalk/onlineusersdlg.h
+++ b/Client/qtTeamTalk/onlineusersdlg.h
@@ -54,6 +54,9 @@ signals:
     void kickbanUser(int userid, int chanid);
     void streamfileToUser(int userid);
 
+protected:
+    bool eventFilter(QObject *object, QEvent *event);
+
 private:
     void slotTreeContextMenu(const QPoint&);
 


### PR DESCRIPTION
If necessary, we can retrieve the existing translations from ts files because the text copy to clipboard is the same as the text using for accessible text role.
I precise this point in case this feature has to be include in 5.8.1 and to avoid waiting for new translations.