### PR TITLE
Manually specify quit keyboard sequence

### DIFF
--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -210,6 +210,13 @@ MainWindow::MainWindow(const QString& cfgfile)
     ui.statusbar->addPermanentWidget(m_pinglabel);
     ui.statusbar->addPermanentWidget(m_pttlabel);
 
+
+#if defined(Q_OS_WIN32)
+    ui.actionExit->setShortcut(QKeySequence(Qt::ALT + Qt::Key_F4));
+#else
+    ui.actionExit->setShortcut(QKeySequence::Quit);
+#endif
+
     connect(ui.msgEdit, &QLineEdit::textChanged, this, &MainWindow::slotTextChanged);
     connect(ui.sendButton, &QAbstractButton::clicked,
             this, &MainWindow::slotSendChannelMessage);


### PR DESCRIPTION
Oddly 'Quit' menu item in French translation is disable but still works.

Fixes #1109

I hope this doesn't screw up #994 again w.r.t. Alt+F4