### PR TITLE
Coma bitween micro and gender emoji

### DIFF
--- a/Client/qtTeamTalk/channelstree.cpp
+++ b/Client/qtTeamTalk/channelstree.cpp
@@ -1063,9 +1063,9 @@ void ChannelsTree::slotUpdateTreeWidgetItem(QTreeWidgetItem* item)
         if (emoji)
         {
             if (user.nStatusMode & STATUSMODE_FEMALE)
-                itemtext += " 👩";
+                itemtext += (_Q(user.szStatusMsg).size() ? " 👩" : ", 👩");
             else if ((user.nStatusMode & STATUSMODE_GENDER_MASK) == STATUSMODE_MALE)
-                itemtext += " 👨";
+                itemtext += (_Q(user.szStatusMsg).size() ? " 👨" : ", 👨");
             if(user.uUserType & USERTYPE_ADMIN)
                 itemtext += tr(" (Administrator)");
 


### PR DESCRIPTION
For now when an user is speaking and don't have a status message define, emojis 🎤 and 👨 or 👩 are not separate, which can cause confuse and some users requested a little break with screen reader.
So, this PR introduce a coma bitween emojis when user hasn't status message, which force synthetisor to make a small break bitween emojis.