### PR TITLE
Fixed crash issue when starting second instance on macOS

### DIFF
--- a/Client/qtTeamTalk/Entitlements.plist
+++ b/Client/qtTeamTalk/Entitlements.plist
@@ -13,6 +13,8 @@
     <true/>
     <key>com.apple.security.device.camera</key>
     <true/>
+    <key>com.apple.security.device.microphone</key>
+    <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
     <key>com.apple.security.network.server</key>

--- a/Library/TeamTalkLib/teamtalk/client/ClientNodeBase.h
+++ b/Library/TeamTalkLib/teamtalk/client/ClientNodeBase.h
@@ -33,6 +33,9 @@
 
 #include <ace/Reactor.h>
 
+#include <condition_variable>
+#include <mutex>
+
 #define TIMERID_MASK            0x0000FFFF
 #define USER_TIMER_START        0x00008000
 #define USER_TIMER_USERID_MASK  0xFFFF0000 // ((userid << 16) | USER_TIMER_START) + TIMERID
@@ -127,6 +130,10 @@ namespace teamtalk {
         ACE_Reactor m_reactor;
         ACE_thread_t m_reactor_thread;
 
+        // sync reactor thread start/stop
+        std::condition_variable m_reactor_wait_cv;
+        std::mutex m_reactor_wait_mtx;
+
         ACE_Recursive_Thread_Mutex m_timers_lock; //mutexes must be the last to be destroyed
 
         //set of timers currently in use. Protected by lock_timers().
@@ -154,7 +161,6 @@ namespace teamtalk {
         void ResumeEventHandling() override;
 
         ACE_Lock& reactor_lock();
-        ACE_Semaphore m_reactor_wait;
 
         // Get reactor running timers
         ACE_Reactor* GetEventLoop() { return reactor(); }


### PR DESCRIPTION
Replace ACE_Semaphore by std::conditional_variable.

Fixes crash issue in AppStore version when starting second instance.

Reported in issue #1145 