### PR TITLE
Templates for creating issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,49 @@
+name: Bug Report
+description: Submit a bug report
+labels: [needs triage]
+body:
+  - type: textarea
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is, and why you consider it to be a bug.
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: Application
+      options:
+        - label: qtTeamTalk
+        - label: TeamTalkAndroid
+        - label: iTeamTalk
+        - label: TeamTalkClassic
+        - label: TeamTalkServer
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: Platform
+      options:
+        - label: Windows
+        - label: macOS
+        - label: Android
+        - label: iOS
+        - label: Linux
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: A description of what you expected to happen.
+  - type: textarea
+    attributes:
+      label: Actual behavior
+      description: A description of what is actually happening.
+  - type: textarea
+    attributes:
+      label: Repro steps
+      placeholder: |
+        A description with steps to reproduce the issue.
+        1. Step 1
+        2. Step 2
+    validations:
+        required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Submit a bug report
-labels: [needs triage]
+labels: [bug]
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Submit a feature request
-labels: [needs triage]
+labels: [enhancement]
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,20 @@
+name: Feature Request
+description: Submit a feature request
+labels: [needs triage]
+body:
+  - type: textarea
+    attributes:
+      label: Description
+      description: A description of the feature you would like to see
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: Application
+      options:
+        - label: qtTeamTalk
+        - label: TeamTalkAndroid
+        - label: iTeamTalk
+        - label: TeamTalkServer
+    validations:
+      required: true


### PR DESCRIPTION
I've set up two templates that people will have to fill out when creating an issue. One for bug reports and one for feature requests.

Many issues lack information, so hopefully this will make people more through before submitting issues. Also people should use Discussions more before creating an issue. Often the feature they request can be obtained in some other way using existing functionality.