### PR TITLE
Fix nickname change for servers with BearWare accounts

### DIFF
--- a/Client/qtTeamTalk/common.cpp
+++ b/Client/qtTeamTalk/common.cpp
@@ -362,7 +362,7 @@ bool HostEntry::sameHost(const HostEntry& host, bool nickcheck) const
            udpport == host.udpport &&
            encrypted == host.encrypted &&
            /* srvpasswd == host.srvpasswd && */ //don't include passwords
-           username == host.username &&
+           (username == host.username) || (username.compare(WEBLOGIN_BEARWARE_USERNAME, Qt::CaseInsensitive) == 0 || username.endsWith(WEBLOGIN_BEARWARE_USERNAMEPOSTFIX, Qt::CaseInsensitive)) &&
            /* password == host.password && */
            (!nickcheck || nickname == host.nickname) &&
            channel == host.channel

--- a/Client/qtTeamTalk/common.cpp
+++ b/Client/qtTeamTalk/common.cpp
@@ -362,7 +362,7 @@ bool HostEntry::sameHost(const HostEntry& host, bool nickcheck) const
            udpport == host.udpport &&
            encrypted == host.encrypted &&
            /* srvpasswd == host.srvpasswd && */ //don't include passwords
-           (username == host.username) || (username.compare(WEBLOGIN_BEARWARE_USERNAME, Qt::CaseInsensitive) == 0 || username.endsWith(WEBLOGIN_BEARWARE_USERNAMEPOSTFIX, Qt::CaseInsensitive)) &&
+           (username == host.username || (isWebLogin(host.username, true) && isWebLogin(username, false))) &&
            /* password == host.password && */
            (!nickcheck || nickname == host.nickname) &&
            channel == host.channel
@@ -820,11 +820,19 @@ QString getBearWareRegistrationUrl(const QDomDocument& doc)
     return parseXML(doc, "teamtalk/bearware/register-url");
 }
 
+bool isWebLogin(const QString& username, bool includeParentLoginName)
+{
+    if (username.endsWith(WEBLOGIN_BEARWARE_USERNAMEPOSTFIX, Qt::CaseInsensitive))
+        return true;
+
+    return includeParentLoginName && username.compare(WEBLOGIN_BEARWARE_USERNAME, Qt::CaseInsensitive) == 0;
+}
+
 QString userCacheID(const User& user)
 {
     bool restore = ttSettings->value(SETTINGS_GENERAL_RESTOREUSERSETTINGS, SETTINGS_GENERAL_RESTOREUSERSETTINGS_DEFAULT).toBool();
 
-    if (restore && _Q(user.szUsername).endsWith(WEBLOGIN_BEARWARE_USERNAMEPOSTFIX))
+    if (restore && isWebLogin(_Q(user.szUsername), false))
         return QString("%1|%2").arg(_Q(user.szUsername)).arg(_Q(user.szClientName));
 
     return QString();

--- a/Client/qtTeamTalk/common.h
+++ b/Client/qtTeamTalk/common.h
@@ -375,6 +375,7 @@ QString downloadUpdateURL(const QDomDocument& updateDoc);
 QString newBetaVersionAvailable(const QDomDocument& updateDoc);
 QString downloadBetaUpdateURL(const QDomDocument& updateDoc);
 QString getBearWareRegistrationUrl(const QDomDocument& doc);
+bool isWebLogin(const QString& username, bool includeParentLoginName);
 QString userCacheID(const User& user);
 
 QByteArray generateTTFile(const HostEntry& entry);

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -925,8 +925,7 @@ void MainWindow::processTTMessage(const TTMessage& msg)
         // retrieve initial welcome message and access token
         TT_GetServerProperties(ttInst, &m_srvprop);
 
-        if (m_host.username.compare(WEBLOGIN_BEARWARE_USERNAME, Qt::CaseInsensitive) == 0 ||
-            m_host.username.endsWith(WEBLOGIN_BEARWARE_USERNAMEPOSTFIX, Qt::CaseInsensitive))
+        if (isWebLogin(m_host.username, true))
         {
             QString username = ttSettings->value(SETTINGS_GENERAL_BEARWARE_USERNAME).toString();
             QString token = ttSettings->value(SETTINGS_GENERAL_BEARWARE_TOKEN).toString();

--- a/Client/qtTeamTalk/serverlistdlg.cpp
+++ b/Client/qtTeamTalk/serverlistdlg.cpp
@@ -155,12 +155,11 @@ void ServerListDlg::showHost(const HostEntry& entry)
     ui.udpportEdit->setText(QString::number(entry.udpport));
     ui.cryptChkBox->setChecked(entry.encrypted);
     ui.usernameBox->lineEdit()->setText(entry.username);
-    if (entry.username == WEBLOGIN_BEARWARE_USERNAME)
+    if (isWebLogin(entry.username, true))
         ui.passwordEdit->setText("");
     else
         ui.passwordEdit->setText(entry.password);
-    ui.passwordEdit->setDisabled(entry.username == WEBLOGIN_BEARWARE_USERNAME ||
-                                 entry.username.endsWith(WEBLOGIN_BEARWARE_USERNAMEPOSTFIX));
+    ui.passwordEdit->setDisabled(isWebLogin(entry.username, true));
     ui.nicknameEdit->setText(entry.nickname);
     ui.channelEdit->setText(entry.channel);
     ui.chanpasswdEdit->setText(entry.chanpasswd);
@@ -260,8 +259,7 @@ void ServerListDlg::slotConnect()
     HostEntry entry;
     if(getHostEntry(entry))
     {
-        if (entry.username == WEBLOGIN_BEARWARE_USERNAME ||
-            entry.username.endsWith(WEBLOGIN_BEARWARE_USERNAMEPOSTFIX))
+        if (isWebLogin(entry.username, true))
         {
             QString username = ttSettings->value(SETTINGS_GENERAL_BEARWARE_USERNAME).toString();
             if (username.isEmpty())
@@ -429,6 +427,6 @@ void ServerListDlg::slotGenerateEntryName(const QString&)
         ui.nameEdit->setText(QString());
 
     ui.passwordEdit->setDisabled(username == WEBLOGIN_BEARWARE_USERNAME);
-    if (username == WEBLOGIN_BEARWARE_USERNAME)
+    if (isWebLogin(username, true))
         ui.passwordEdit->setText("");
 }


### PR DESCRIPTION
Previously, sameHost checked if name = host.name, but in case of BearWare accounts usage, username defined in host entry is not really the same as used to login. This caused nickname changes to don't take effect if a server was saved using a BearWare account. This PR add a check to sameHost to see if username is BearWare or ends with @bearware.dk, and we can now change nicknames correctly for servers with BearWare accounts.