### PR TITLE
Set reactor's thread ID prior to notify

### DIFF
--- a/Library/TeamTalkLib/teamtalk/client/ClientNodeBase.cpp
+++ b/Library/TeamTalkLib/teamtalk/client/ClientNodeBase.cpp
@@ -54,11 +54,12 @@ int ClientNodeBase::svc(void)
         // ensure .wait() is called prior to .notify_all()
         std::unique_lock<std::mutex> lck(m_reactor_wait_mtx);
     }
-    m_reactor_wait_cv.notify_all();
 
     m_reactor_thread = ACE_OS::thr_self();
     int ret = m_reactor.owner (ACE_OS::thr_self());
     assert(ret >= 0);
+
+    m_reactor_wait_cv.notify_all();
 
     m_reactor.run_reactor_event_loop ();
 

--- a/Library/TeamTalkLib/teamtalk/ttassert.h
+++ b/Library/TeamTalkLib/teamtalk/ttassert.h
@@ -45,14 +45,16 @@ void tt_assert(const char* assertion, const char* file, int line);
 #define ASSERT_REACTOR_THREAD(reactor)                                  \
     do {                                                                \
         ACE_thread_t tid;                                               \
-        (reactor).owner(&tid);                                          \
+        int ret = (reactor).owner(&tid);                                \
+        TTASSERT(ret >= 0);                                             \
         TTASSERT(ACE_Thread::self() == tid);                            \
     } while(0)
 
 #define ASSERT_NOT_REACTOR_THREAD(reactor)                              \
     do {                                                                \
         ACE_thread_t tid;                                               \
-        (reactor).owner(&tid);                                          \
+        int ret = (reactor).owner(&tid);                                \
+        TTASSERT(ret >= 0);                                             \
         TTASSERT(ACE_Thread::self() != tid);                            \
     } while(0)
 


### PR DESCRIPTION
This fixes race condition when checking ACE_Reactor's owner in
ClientNode::Connect(). ASSERT_NOT_REACTOR_THREAD would fail with
invalid reactor owner.