### PR TITLE
Log message on transmit user changing

### DIFF
--- a/Library/TeamTalkLib/bin/ttsrv/ServerGuard.cpp
+++ b/Library/TeamTalkLib/bin/ttsrv/ServerGuard.cpp
@@ -391,20 +391,24 @@ void ServerGuard::OnChannelCreated(const ServerChannel& channel,
 void ServerGuard::OnChannelUpdated(const ServerChannel& channel, 
                                    const ServerUser* user/* = NULL*/)
 {
-    if(!user)
-        return;
-
     tostringstream oss;
     oss << ACE_TEXT("Channel #") << channel.GetChannelID() << ACE_TEXT(" ");
-    if(user)
+    if (user)
     {
         oss << ACE_TEXT("\"") << LogPrepare(channel.GetChannelPath()).c_str() << ACE_TEXT("\" updated by ");
         oss << ACE_TEXT("nickname: \"") << LogPrepare(user->GetNickname()).c_str() << ACE_TEXT("\" ");
-        if(user->GetUsername().length())
-            oss << ACE_TEXT("username: \"") << LogPrepare(user->GetUsername()).c_str() << ACE_TEXT("\".");
+        if (user->GetUsername().length())
+            oss << ACE_TEXT("username: \"") << LogPrepare(user->GetUsername()).c_str() << ACE_TEXT("\"");
     }
     else
-        oss << ACE_TEXT("\"") << LogPrepare(channel.GetChannelPath()).c_str() << ACE_TEXT("\" updated.");
+    {
+        oss << ACE_TEXT("\"") << LogPrepare(channel.GetChannelPath()).c_str() << ACE_TEXT("\" updated");
+    }
+
+    if ((channel.GetChannelType() & CHANNEL_SOLO_TRANSMIT) && channel.GetTransmitQueue().size())
+        oss << ACE_TEXT(", transmitter: #") << *channel.GetTransmitQueue().begin();
+
+    oss << ACE_TEXT(".");
 
     TT_LOG(oss.str().c_str());
 }

--- a/Library/TeamTalkLib/teamtalk/server/ServerChannel.h
+++ b/Library/TeamTalkLib/teamtalk/server/ServerChannel.h
@@ -37,10 +37,11 @@ namespace teamtalk {
         typedef Channel<ServerChannel, ServerUser> PARENT;
         ServerChannel(int channelid);
         ServerChannel(channel_t& parent, int channelid, const ACE_TString& name);
-        //Used for channels with CHANNEL_SOLO_TRANSMIT 
-        bool CanTransmit(int userid, StreamType txtype, int streamid);
+        // Used for channels with CHANNEL_SOLO_TRANSMIT. 'modified' is only set if 'true'
+        bool CanTransmit(int userid, StreamType txtype, int streamid, bool* modified);
         void RemoveUser(int userid);
-        void ClearFromTransmitQueue(int userid);
+        void RemoveUser(int userid, bool* modified);
+        bool ClearFromTransmitQueue(int userid);
     private:
         void Init();
         // userid -> last transmit time

--- a/Library/TeamTalkLib/teamtalk/server/ServerNode.h
+++ b/Library/TeamTalkLib/teamtalk/server/ServerNode.h
@@ -320,8 +320,8 @@ namespace teamtalk {
         void OnClosed(ACE_HANDLE h);
         bool OnReceive(ACE_HANDLE h, const char* buff, int len);
         //notify users of channel update
-        void UpdateChannel(const serverchannel_t& chan);
-        void UpdateChannel(const ServerChannel& chan, const ServerChannel::users_t& users);
+        void UpdateChannel(const serverchannel_t& chan, const ServerUser* user);
+        void UpdateChannel(const ServerChannel& chan, const ServerChannel::users_t& users, const ServerUser* user);
         void CleanChannels(serverchannel_t& channel);
         void UpdateSoloTransmitChannels();
         //update the number of times a user has tried to login unsuccessfully


### PR DESCRIPTION
Transmit users queue clean up as well to use same channel update methods.

Fixes #321 