### PR TITLE
String handling for Python

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,6 +58,12 @@ jobs:
       working-directory: ${{runner.workspace}}/TeamTalk5/Library/TeamTalkLib/test
       run: catchtt.app/Contents/MacOS/catchtt --durations yes
 
+    - name: Run Python client
+      working-directory: ${{runner.workspace}}/TeamTalk5
+      run: |
+        source env.sh
+        make -C Client/ttserverlogpy
+
     - name: Stop TeamTalk Pro Server
       run: killall tt5prosrv
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,12 +58,6 @@ jobs:
       working-directory: ${{runner.workspace}}/TeamTalk5/Library/TeamTalkLib/test
       run: catchtt.app/Contents/MacOS/catchtt --durations yes
 
-    - name: Run Python client
-      working-directory: ${{runner.workspace}}/TeamTalk5
-      run: |
-        source env.sh
-        make -C Client/ttserverlogpy
-
     - name: Stop TeamTalk Pro Server
       run: killall tt5prosrv
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,6 +33,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: '11'
+        architecture: ${{ matrix.dotnetarch }}
 
     - uses: actions/setup-python@v2
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,12 +34,13 @@ jobs:
         distribution: 'temurin'
         java-version: '11'
 
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+        architecture: ${{ matrix.dotnetarch }}
+
     - name: Setup VSTest Path
       uses: darenm/Setup-VSTest@v1
-
-    - name: Print environment
-      shell: cmd
-      run: set
 
     - name: Init TeamTalk Client submodules
       working-directory: ${{runner.workspace}}/TeamTalk5
@@ -66,6 +67,11 @@ jobs:
         cmake --build output --parallel 8 --config Release
         echo ${{runner.workspace}}\TeamTalk5\Library\TeamTalk_DLL>> %GITHUB_PATH%
         echo ${{runner.workspace}}\TeamTalk5\Library\TeamTalkJNI\libs>> %GITHUB_PATH%
+        echo PYTHONPATH=${{runner.workspace}}\TeamTalk5\Library\TeamTalkPy>> %GITHUB_ENV%
+
+    - name: Print environment
+      shell: cmd
+      run: set
 
     - name: Copy Server Configuration
       working-directory: ${{runner.workspace}}/TeamTalk5
@@ -102,6 +108,11 @@ jobs:
         cd output\Library\TeamTalk.NET\TeamTalkTest.NET\Release
         xcopy /S /Y /E ${{runner.workspace}}\TeamTalk5\Library\TeamTalkLib\test\testdata testdata\
         VSTest.Console.exe /Platform:${{ matrix.dotnetarch }} TeamTalk5Test.NET.dll
+
+    - name: Run Python client
+      working-directory: ${{runner.workspace}}/TeamTalk5/Client/ttserverlogpy
+      run: |
+        python main.py
 
     - name: Stop TeamTalk Standard Service
       working-directory: ${{runner.workspace}}/TeamTalk5/Server

--- a/Client/ttserverlogpy/main.py
+++ b/Client/ttserverlogpy/main.py
@@ -27,11 +27,11 @@ def waitForCmdSuccess(ttclient, cmdid, timeout):
 
     return False, TTMessage()
 
-print(getVersion())
+print(ttstr(getVersion()))
 
 ttclient = TeamTalk()
 
-if ttclient.connect(b"127.0.0.1", 10443, 10443, 0, 0, True):
+if ttclient.connect(ttstr("127.0.0.1"), 10333, 10333, 0, 0, False):
     print("Connecting")
 else:
     sys.exit('Failed to issue connect')
@@ -42,7 +42,7 @@ if result:
 else:
     sys.exit("Failed to connect")
 
-cmdid = ttclient.doLogin(b"Hello Python", b"guest", b"guest", b"python")
+cmdid = ttclient.doLogin(ttstr("Hello Python"), ttstr("guest"), ttstr("guest"), ttstr("python"))
 
 result, msg = waitForEvent(ttclient, ClientEvent.CLIENTEVENT_CMD_MYSELF_LOGGEDIN)
 if result:
@@ -52,21 +52,23 @@ else:
 
 result, msg = waitForEvent(ttclient, ClientEvent.CLIENTEVENT_CMD_SERVER_UPDATE)
 if result:
-    print("Server name is: " + msg.serverproperties.szServerName.decode("utf-8"))
+    print("Server name is: " + ttstr(msg.serverproperties.szServerName))
 else:
     sys.exit("Failed to log in")
 
 result, msg = waitForEvent(ttclient, ClientEvent.CLIENTEVENT_CMD_CHANNEL_NEW)
 if result:
-    print("New channel: " + msg.channel.szName.decode("utf-8"))
+    print("New channel: " + ttstr(msg.channel.szName))
     print("Audio codec: " + str(msg.channel.audiocodec.nCodec))
 
 result, msg = waitForCmdSuccess(ttclient, cmdid, DEF_WAIT)
 
+print(ttstr(msg.channel.szName))
+
 if result:
     print("Login completed")
 
-cmdid = ttclient.doJoinChannelByID(ttclient.getRootChannelID(), b"")
+cmdid = ttclient.doJoinChannelByID(ttclient.getRootChannelID(), ttstr(""))
 
 result, msg = waitForCmdSuccess(ttclient, cmdid, DEF_WAIT)
 if result:

--- a/Library/TeamTalkPy/TeamTalk5.py
+++ b/Library/TeamTalkPy/TeamTalk5.py
@@ -60,6 +60,19 @@ TT_SAMPLERATES_MAX = 16
 _TTInstance = c_void_p
 _TTSoundLoop = c_void_p
 
+# Encode string to UTF-8. Encoding on Windows is not necessary since
+# string to and from TeamTalk5.dll are UTF-16.
+def ttstr(ttchar_p_str: TTCHAR_P) -> str:
+
+    if sys.platform == "win32":
+        return ttchar_p_str
+
+    if isinstance(ttchar_p_str, bytes):
+        return str(ttchar_p_str, encoding = 'utf-8')
+    if isinstance(ttchar_p_str, str):
+        return ttchar_p_str.encode('utf-8')
+    return ttchar_p_str
+
 # bindings
 class StreamType(UINT32):
     STREAMTYPE_NONE = 0x00000000


### PR DESCRIPTION
Introduced ttstr() in TeamTalk5.py as a helper function to convert to/from utf-8 on macOS and Linux.

On Windows no string conversion is needed for TT_* functions because TTCHAR is convertible to Python's str-class.

@beqabeqa473 Do you only use Python on Windows? Or do you also have to make workarounds for Python strings?