### PR TITLE
See MOTD as tooltip and currently active users

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -11,6 +11,8 @@ Default Qt Client
 - Duration for voice transfer can now be set on "No Interruptions" channels
 - Modify server log events from "Server Properties" dialog
 - Added "Hear Myself" menu item to "Me" menu
+- See number of active users on public server list
+- See "Message of the Day" on public servers as tooltip in server list
 - Fixed issue where no all users and channels were listed after initial login
 - Fixed labels for server abuse options in server properties
 - Fixed crash issue when using Cmd+4 on macOS 12.2

--- a/Client/qtTeamTalk/common.cpp
+++ b/Client/qtTeamTalk/common.cpp
@@ -655,23 +655,6 @@ void processClientSetupXML(const QDomElement& hostElement, HostEntry& entry)
     }
 }
 
-void processStatsXML(const QDomElement& hostElement, HostEntry& entry)
-{
-    QDomElement stats = hostElement.firstChildElement("stats");
-    if (!stats.isNull())
-    {
-        QDomElement tmp = stats.firstChildElement("user-count");
-        if (!tmp.isNull())
-            entry.usercount = tmp.text().toInt();
-        tmp = stats.firstChildElement("country");
-        if (!tmp.isNull())
-            entry.country = tmp.text();
-        tmp = stats.firstChildElement("motd");
-        if (!tmp.isNull())
-            entry.motd = tmp.text();
-    }
-}
-
 bool getServerEntry(const QDomElement& hostElement, HostEntry& entry)
 {
     Q_ASSERT(hostElement.tagName() == "host");
@@ -703,7 +686,6 @@ bool getServerEntry(const QDomElement& hostElement, HostEntry& entry)
     processAuthXML(hostElement, entry);
     processJoinXML(hostElement, entry);
     processClientSetupXML(hostElement, entry);
-    processStatsXML(hostElement, entry);
 
     return ok;
 }

--- a/Client/qtTeamTalk/common.cpp
+++ b/Client/qtTeamTalk/common.cpp
@@ -663,6 +663,12 @@ void processStatsXML(const QDomElement& hostElement, HostEntry& entry)
         QDomElement tmp = stats.firstChildElement("user-count");
         if (!tmp.isNull())
             entry.usercount = tmp.text().toInt();
+        tmp = stats.firstChildElement("country");
+        if (!tmp.isNull())
+            entry.country = tmp.text();
+        tmp = stats.firstChildElement("motd");
+        if (!tmp.isNull())
+            entry.motd = tmp.text();
     }
 }
 

--- a/Client/qtTeamTalk/common.cpp
+++ b/Client/qtTeamTalk/common.cpp
@@ -361,7 +361,6 @@ bool HostEntry::sameHost(const HostEntry& host, bool nickcheck) const
            tcpport == host.tcpport &&
            udpport == host.udpport &&
            encrypted == host.encrypted &&
-           /* srvpasswd == host.srvpasswd && */ //don't include passwords
            (username == host.username || (isWebLogin(host.username, true) && isWebLogin(username, false))) &&
            /* password == host.password && */
            (!nickcheck || nickname == host.nickname) &&
@@ -533,65 +532,45 @@ void deleteServerEntry(const QString& name)
         setServerEntry(i, hosts[i]);
 }
 
-bool getServerEntry(const QDomElement& hostElement, HostEntry& entry)
+void processAuthXML(const QDomElement& hostElement, HostEntry& entry)
 {
-    Q_ASSERT(hostElement.tagName() == "host");
-    bool ok = true;
-    QDomElement tmp = hostElement.firstChildElement("name");
-    if(!tmp.isNull())
-        entry.name = tmp.text();
-    else ok = false;
-
-    tmp = hostElement.firstChildElement("address");
-    if(!tmp.isNull())
-        entry.ipaddr = tmp.text();
-    else ok = false;
-
-    tmp = hostElement.firstChildElement("tcpport");
-    if(!tmp.isNull())
-        entry.tcpport = tmp.text().toInt();
-    else ok = false;
-
-    tmp = hostElement.firstChildElement("udpport");
-    if(!tmp.isNull())
-        entry.udpport = tmp.text().toInt();
-    else ok = false;
-
-    tmp = hostElement.firstChildElement("encrypted");
-    if(!tmp.isNull())
-        entry.encrypted = (tmp.text().toLower() == "true" || tmp.text() == "1");
-
     QDomElement auth = hostElement.firstChildElement("auth");
-    if(!auth.isNull())
+    if (!auth.isNull())
     {
-        tmp = auth.firstChildElement("username");
-        if(!tmp.isNull())
+        QDomElement tmp = auth.firstChildElement("username");
+        if (!tmp.isNull())
             entry.username = tmp.text();
 
         tmp = auth.firstChildElement("password");
-        if(!tmp.isNull())
+        if (!tmp.isNull())
             entry.password = tmp.text();
 
         tmp = auth.firstChildElement("nickname");
-        if(!tmp.isNull())
+        if (!tmp.isNull())
             entry.nickname = tmp.text();
     }
+}
 
+void processJoinXML(const QDomElement& hostElement, HostEntry& entry)
+{
     QDomElement join = hostElement.firstChildElement("join");
     if(!join.isNull())
     {
-        tmp = join.firstChildElement("channel");
-        if(!tmp.isNull())
+        QDomElement tmp = join.firstChildElement("channel");
+        if (!tmp.isNull())
             entry.channel = tmp.text();
         tmp = join.firstChildElement("password");
-        if(!tmp.isNull())
+        if (!tmp.isNull())
             entry.chanpasswd = tmp.text();
     }
+}
 
+void processClientSetupXML(const QDomElement& hostElement, HostEntry& entry)
+{
     QDomElement client = hostElement.firstChildElement(CLIENTSETUP_TAG);
-    if(!client.isNull())
+    if (!client.isNull())
     {
-        tmp = client.firstChildElement("gender");
+        QDomElement tmp = client.firstChildElement("gender");
         if(!tmp.isNull())
         {
             switch (tmp.text().toInt())
@@ -638,7 +617,7 @@ bool getServerEntry(const QDomElement& hostElement, HostEntry& entry)
             cap = tmp.firstChildElement("height");
             if(!cap.isNull())
                 entry.capformat.nHeight = cap.text().toInt();
-            
+
             cap = tmp.firstChildElement("fps-numerator");
             if(!cap.isNull())
                 entry.capformat.nFPS_Numerator = cap.text().toInt();
@@ -674,6 +653,52 @@ bool getServerEntry(const QDomElement& hostElement, HostEntry& entry)
             }
         }
     }
+}
+
+void processStatsXML(const QDomElement& hostElement, HostEntry& entry)
+{
+    QDomElement stats = hostElement.firstChildElement("stats");
+    if (!stats.isNull())
+    {
+        QDomElement tmp = stats.firstChildElement("user-count");
+        if (!tmp.isNull())
+            entry.usercount = tmp.text().toInt();
+    }
+}
+
+bool getServerEntry(const QDomElement& hostElement, HostEntry& entry)
+{
+    Q_ASSERT(hostElement.tagName() == "host");
+    bool ok = true;
+    QDomElement tmp = hostElement.firstChildElement("name");
+    if(!tmp.isNull())
+        entry.name = tmp.text();
+    else ok = false;
+
+    tmp = hostElement.firstChildElement("address");
+    if(!tmp.isNull())
+        entry.ipaddr = tmp.text();
+    else ok = false;
+
+    tmp = hostElement.firstChildElement("tcpport");
+    if(!tmp.isNull())
+        entry.tcpport = tmp.text().toInt();
+    else ok = false;
+
+    tmp = hostElement.firstChildElement("udpport");
+    if(!tmp.isNull())
+        entry.udpport = tmp.text().toInt();
+    else ok = false;
+
+    tmp = hostElement.firstChildElement("encrypted");
+    if(!tmp.isNull())
+        entry.encrypted = (tmp.text().toLower() == "true" || tmp.text() == "1");
+
+    processAuthXML(hostElement, entry);
+    processJoinXML(hostElement, entry);
+    processClientSetupXML(hostElement, entry);
+    processStatsXML(hostElement, entry);
+
     return ok;
 }
 

--- a/Client/qtTeamTalk/common.h
+++ b/Client/qtTeamTalk/common.h
@@ -268,11 +268,6 @@ struct HostEntry
     VideoFormat capformat = {};
     VideoCodec vidcodec = {};
 
-    // public server settings
-    int usercount = 0;
-    QString country;
-    QString motd;
-
     // doesn't include 'name'
     bool sameHost(const HostEntry& host, bool nickcheck = true) const;
     // same as sameHost() but also host.name == name

--- a/Client/qtTeamTalk/common.h
+++ b/Client/qtTeamTalk/common.h
@@ -267,7 +267,11 @@ struct HostEntry
     int voiceact = -1;
     VideoFormat capformat = {};
     VideoCodec vidcodec = {};
+
+    // public server settings
     int usercount = 0;
+    QString country;
+    QString motd;
 
     // doesn't include 'name'
     bool sameHost(const HostEntry& host, bool nickcheck = true) const;

--- a/Client/qtTeamTalk/common.h
+++ b/Client/qtTeamTalk/common.h
@@ -253,24 +253,21 @@ struct HostEntry
 {
     QString name;
     QString ipaddr;
-    int tcpport;
-    int udpport;
-    bool encrypted;
+    int tcpport = DEFAULT_TCPPORT;
+    int udpport = DEFAULT_UDPPORT;
+    bool encrypted = false;
     QString username;
     QString password;
     QString nickname;
     QString channel;
     QString chanpasswd;
     //tt-file specific
-    Gender gender;
+    Gender gender = GENDER_NONE;
     hotkey_t hotkey;
-    int voiceact;
-    VideoFormat capformat;
-    VideoCodec vidcodec;
-
-    HostEntry()
-    : tcpport(0), udpport(0), encrypted(false), gender(GENDER_NONE)
-    , voiceact(-1), capformat(), vidcodec() {}
+    int voiceact = -1;
+    VideoFormat capformat = {};
+    VideoCodec vidcodec = {};
+    int usercount = 0;
 
     // doesn't include 'name'
     bool sameHost(const HostEntry& host, bool nickcheck = true) const;

--- a/Client/qtTeamTalk/serverlist.ui
+++ b/Client/qtTeamTalk/serverlist.ui
@@ -27,7 +27,20 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
-       <widget class="QListWidget" name="listWidget"/>
+       <widget class="QTreeView" name="serverTreeView">
+        <property name="rootIsDecorated">
+         <bool>false</bool>
+        </property>
+        <property name="itemsExpandable">
+         <bool>false</bool>
+        </property>
+        <property name="sortingEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="expandsOnDoubleClick">
+         <bool>false</bool>
+        </property>
+       </widget>
       </item>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_3">

--- a/Client/qtTeamTalk/serverlistdlg.cpp
+++ b/Client/qtTeamTalk/serverlistdlg.cpp
@@ -121,9 +121,9 @@ QVariant ServerListModel::data(const QModelIndex & index, int role /*= Qt::Displ
         switch (getServerType(getServers()[index.row()]))
         {
         case SERVERTYPE_LOCAL :
-            return "A" + data(index, Qt::DisplayRole).toString();
+            return QString("%1-%2").arg('A').arg(data(index, Qt::DisplayRole).toString());
         case SERVERTYPE_PUBLIC :
-            return "B" + data(index, Qt::DisplayRole).toString();
+            return QString("%1-%2-%3").arg('B').arg(getServers()[index.row()].id, 9, 10, QLatin1Char('0')).arg(data(index, Qt::DisplayRole).toString());
         }
     }
     return QVariant();
@@ -389,6 +389,7 @@ void ServerListDlg::slotRefreshServers()
     HostEntryEx entry;
     while (getServerEntry(index++, entry))
     {
+        entry.id = ++m_nextid;
         m_model->addServer(entry, SERVERTYPE_LOCAL);
         entry = HostEntryEx();
     }
@@ -490,6 +491,7 @@ void ServerListDlg::slotFreeServerRequest(QNetworkReply* reply)
         if (getServerEntry(element, entry))
         {
             processStatsXML(element, entry);
+            entry.id = ++m_nextid;
             m_model->addServer(entry, SERVERTYPE_PUBLIC);
         }
 		element = element.nextSiblingElement();

--- a/Client/qtTeamTalk/serverlistdlg.cpp
+++ b/Client/qtTeamTalk/serverlistdlg.cpp
@@ -105,6 +105,13 @@ QVariant ServerListModel::data(const QModelIndex & index, int role /*= Qt::Displ
         }
         break;
     case Qt::AccessibleTextRole :
+        switch (getServerType(getServers()[index.row()]))
+        {
+        case SERVERTYPE_LOCAL :
+            return QString(tr("Name: %1, Users: %2").arg(getServers()[index.row()].name).arg(getServers()[index.row()].usercount));
+        case SERVERTYPE_PUBLIC :
+            return QString(tr("Name: %1, Users: %2, Country: %3, MOTD: %4").arg(getServers()[index.row()].name).arg(getServers()[index.row()].usercount).arg(getServers()[index.row()].country).arg(getServers()[index.row()].motd));
+        }
         break;
     case Qt::ToolTipRole :
         return getServers()[index.row()].motd;

--- a/Client/qtTeamTalk/serverlistdlg.cpp
+++ b/Client/qtTeamTalk/serverlistdlg.cpp
@@ -128,9 +128,13 @@ QVariant ServerListModel::data(const QModelIndex & index, int role /*= Qt::Displ
         switch (getServerType(getServers()[index.row()]))
         {
         case SERVERTYPE_LOCAL :
-            return QString("%1-%2").arg('A').arg(data(index, Qt::DisplayRole).toString());
+            if (index.column() == COLUMN_INDEX_SERVERNAME)
+                return QString("%1-%2-%3").arg('A').arg(0, 9, 10, QLatin1Char('0')).arg(data(index, Qt::DisplayRole).toString());
+            return data(index, Qt::DisplayRole);
         case SERVERTYPE_PUBLIC :
-            return QString("%1-%2-%3").arg('B').arg(getServers()[index.row()].id, 9, 10, QLatin1Char('0')).arg(data(index, Qt::DisplayRole).toString());
+            if (index.column() == COLUMN_INDEX_SERVERNAME)
+                return QString("%1-%2-%3").arg('B').arg(getServers()[index.row()].id, 9, 10, QLatin1Char('0')).arg(data(index, Qt::DisplayRole).toString());
+            return data(index, Qt::DisplayRole);
         }
     }
     return QVariant();

--- a/Client/qtTeamTalk/serverlistdlg.cpp
+++ b/Client/qtTeamTalk/serverlistdlg.cpp
@@ -108,7 +108,7 @@ QVariant ServerListModel::data(const QModelIndex & index, int role /*= Qt::Displ
         switch (getServerType(getServers()[index.row()]))
         {
         case SERVERTYPE_LOCAL :
-            return QString(tr("Name: %1, Users: %2").arg(getServers()[index.row()].name).arg(getServers()[index.row()].usercount));
+            return getServers()[index.row()].name;
         case SERVERTYPE_PUBLIC :
             return QString(tr("Name: %1, Users: %2, Country: %3, MOTD: %4").arg(getServers()[index.row()].name).arg(getServers()[index.row()].usercount).arg(getServers()[index.row()].country).arg(getServers()[index.row()].motd));
         }

--- a/Client/qtTeamTalk/serverlistdlg.cpp
+++ b/Client/qtTeamTalk/serverlistdlg.cpp
@@ -42,6 +42,7 @@ enum
 {
     COLUMN_INDEX_SERVERNAME,
     COLUMN_INDEX_USERCOUNT,
+    COLUMN_INDEX_COUNTRY,
     COLUMN_COUNT,
 };
 
@@ -59,6 +60,7 @@ QVariant ServerListModel::headerData(int section, Qt::Orientation orientation, i
         {
             case COLUMN_INDEX_SERVERNAME: return tr("Name");
             case COLUMN_INDEX_USERCOUNT: return tr("Users");
+            case COLUMN_INDEX_COUNTRY: return tr("Country");
         }
     }
     }
@@ -81,10 +83,14 @@ QVariant ServerListModel::data(const QModelIndex & index, int role /*= Qt::Displ
             return getServers()[index.row()].name;
         case COLUMN_INDEX_USERCOUNT :
             return getServers()[index.row()].usercount;
+        case COLUMN_INDEX_COUNTRY :
+            return getServers()[index.row()].country;
         }
         break;
     case Qt::AccessibleTextRole :
         break;
+    case Qt::ToolTipRole :
+        return getServers()[index.row()].motd;
     case Qt::BackgroundRole :
         switch (getServerType(getServers()[index.row()]))
         {
@@ -180,9 +186,9 @@ ServerListDlg::ServerListDlg(QWidget * parent/* = 0*/)
 
     m_model = new ServerListModel(this);
     m_proxyModel = new QSortFilterProxyModel(this);
-    m_proxyModel->setSourceModel(m_model);
     m_proxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);
     m_proxyModel->setSortRole(Qt::UserRole);
+    m_proxyModel->setSourceModel(m_model);
     ui.serverTreeView->setModel(m_proxyModel);
 
     ui.usernameBox->addItem(WEBLOGIN_BEARWARE_USERNAME);

--- a/Client/qtTeamTalk/serverlistdlg.h
+++ b/Client/qtTeamTalk/serverlistdlg.h
@@ -29,13 +29,12 @@
 #include <QVector>
 #include <QNetworkAccessManager>
 #include <QAbstractItemModel>
+#include <QSortFilterProxyModel>
 
 enum ServerType
 {
     SERVERTYPE_LOCAL    = 1 << 0,
     SERVERTYPE_PUBLIC   = 1 << 1,
-
-    SERVERTYPE_ALL      = SERVERTYPE_LOCAL | SERVERTYPE_PUBLIC,
 
     SERVERTYPE_MIN      = SERVERTYPE_LOCAL,
     SERVERTYPE_MAX      = SERVERTYPE_PUBLIC,
@@ -62,7 +61,7 @@ public:
 private:
     QMap<ServerType, QVector<HostEntry>> m_servers;
     QVector<HostEntry> m_servercache;
-    ServerTypes m_srvtypes = SERVERTYPE_ALL;
+    ServerTypes m_srvtypes = SERVERTYPE_LOCAL | SERVERTYPE_PUBLIC;
     ServerType getServerType(const HostEntry& host) const;
 };
 
@@ -76,6 +75,7 @@ public:
 private:
     Ui::ServerListDlg ui;
     ServerListModel* m_model;
+    QSortFilterProxyModel* m_proxyModel;
 
     QNetworkAccessManager* m_http_manager;
 

--- a/Client/qtTeamTalk/serverlistdlg.h
+++ b/Client/qtTeamTalk/serverlistdlg.h
@@ -28,35 +28,73 @@
 #include "common.h"
 #include <QVector>
 #include <QNetworkAccessManager>
+#include <QAbstractItemModel>
+
+enum ServerType
+{
+    SERVERTYPE_LOCAL    = 1 << 0,
+    SERVERTYPE_PUBLIC   = 1 << 1,
+
+    SERVERTYPE_ALL      = SERVERTYPE_LOCAL | SERVERTYPE_PUBLIC,
+
+    SERVERTYPE_MIN      = SERVERTYPE_LOCAL,
+    SERVERTYPE_MAX      = SERVERTYPE_PUBLIC,
+};
+
+typedef quint32 ServerTypes;
+
+class ServerListModel : public QAbstractItemModel
+{
+    Q_OBJECT
+public:
+    ServerListModel(QObject* parent);
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
+    int columnCount(const QModelIndex & parent = QModelIndex()) const;
+    QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const;
+    QModelIndex index(int row, int column, const QModelIndex & parent = QModelIndex()) const;
+    QModelIndex parent(const QModelIndex & index) const;
+    int rowCount(const QModelIndex & parent = QModelIndex()) const;
+
+    void addServer(const HostEntry& host, ServerType srvtype);
+    void clearServers();
+    void setServerTypes(ServerTypes srvtypes);
+    const QVector<HostEntry>& getServers() const;
+private:
+    QMap<ServerType, QVector<HostEntry>> m_servers;
+    QVector<HostEntry> m_servercache;
+    ServerTypes m_srvtypes = SERVERTYPE_ALL;
+    ServerType getServerType(const HostEntry& host) const;
+};
 
 class ServerListDlg : public QDialog
 {
     Q_OBJECT
 public:
     ServerListDlg(QWidget * parent = 0);
+    ~ServerListDlg();
 
 private:
     Ui::ServerListDlg ui;
-    void showServers();
-    void showLatestHosts();
-    QVector<HostEntry> m_servers, m_freeservers;
+    ServerListModel* m_model;
+
     QNetworkAccessManager* m_http_manager;
 
+    void showHostEntry(const HostEntry& entry);
     bool getHostEntry(HostEntry& entry);
-    void showHost(const HostEntry& entry);
-    void clearServer();
-
-private:
-    void slotShowHost(int index);
-    void slotShowServer(int index);
-    void slotAddUpdServer();
-    void slotDeleteServer();
+    void clearHostEntry();
+    void showLatestHosts();
+    void showLatestHostEntry(int index);
     void slotClearServerClicked();
     void slotConnect();
-    void slotServerSelected(QListWidgetItem * item);
-    void slotDoubleClicked(QListWidgetItem*);
+
+    void slotRefreshServers();
+    void slotShowSelectedServer(const QModelIndex &index);
+    void slotAddUpdServer();
+    void slotDeleteServer();
+    void slotDoubleClicked(const QModelIndex& index);
     void slotFreeServers(bool checked);
     void slotFreeServerRequest(QNetworkReply* reply);
+
     void slotGenerateFile();
     void slotLoadTTFile();
     void slotDeleteLatestHost();

--- a/Client/qtTeamTalk/serverlistdlg.h
+++ b/Client/qtTeamTalk/serverlistdlg.h
@@ -48,6 +48,7 @@ struct HostEntryEx : HostEntry
     int usercount = 0;
     QString country;
     QString motd;
+    int id = 0;
 };
 
 class ServerListModel : public QAbstractItemModel
@@ -83,6 +84,7 @@ public:
 private:
     Ui::ServerListDlg ui;
     ServerListModel* m_model;
+    int m_nextid = 0;
     QSortFilterProxyModel* m_proxyModel;
 
     QNetworkAccessManager* m_http_manager;

--- a/Client/qtTeamTalk/serverlistdlg.h
+++ b/Client/qtTeamTalk/serverlistdlg.h
@@ -42,6 +42,14 @@ enum ServerType
 
 typedef quint32 ServerTypes;
 
+struct HostEntryEx : HostEntry
+{
+    // public server settings
+    int usercount = 0;
+    QString country;
+    QString motd;
+};
+
 class ServerListModel : public QAbstractItemModel
 {
     Q_OBJECT
@@ -54,15 +62,15 @@ public:
     QModelIndex parent(const QModelIndex & index) const;
     int rowCount(const QModelIndex & parent = QModelIndex()) const;
 
-    void addServer(const HostEntry& host, ServerType srvtype);
+    void addServer(const HostEntryEx& host, ServerType srvtype);
     void clearServers();
     void setServerTypes(ServerTypes srvtypes);
-    const QVector<HostEntry>& getServers() const;
+    const QVector<HostEntryEx>& getServers() const;
 private:
-    QMap<ServerType, QVector<HostEntry>> m_servers;
-    QVector<HostEntry> m_servercache;
+    QMap<ServerType, QVector<HostEntryEx>> m_servers;
+    QVector<HostEntryEx> m_servercache;
     ServerTypes m_srvtypes = SERVERTYPE_LOCAL | SERVERTYPE_PUBLIC;
-    ServerType getServerType(const HostEntry& host) const;
+    ServerType getServerType(const HostEntryEx& host) const;
 };
 
 class ServerListDlg : public QDialog

--- a/Client/qtTeamTalk/settings.h
+++ b/Client/qtTeamTalk/settings.h
@@ -125,6 +125,8 @@
 #define SETTINGS_DISPLAY_CHANNELSORT                 "display/sort-channels"
 #define SETTINGS_DISPLAY_CHANNELSORT_DEFAULT         CHANNELSORT_ASCENDING
 #define SETTINGS_DISPLAY_WINDOW_MAXIMIZE                          "display/window-maximized"
+#define SETTINGS_DISPLAY_SERVERLIST_HEADERSIZES     "display/serverlist-header"
+#define SETTINGS_DISPLAY_SERVERLISTDLG_SIZE         "display/serverlist-dialog-size"
 
 #define SETTINGS_CONNECTION_AUTOCONNECT             "connection/autoconnect"
 #define SETTINGS_CONNECTION_AUTOCONNECT_DEFAULT     false

--- a/Client/qtTeamTalk/utilui.cpp
+++ b/Client/qtTeamTalk/utilui.cpp
@@ -98,3 +98,21 @@ QVariant getCurrentItemData(QComboBox* cbox, const QVariant& not_found/* = QVari
         return cbox->itemData(cbox->currentIndex());
     return not_found;
 }
+
+RestoreIndex::RestoreIndex(QAbstractItemView* view)
+    : m_view(view)
+{
+    m_parent = view->currentIndex().parent();
+    m_row = view->currentIndex().row();
+    m_column = view->currentIndex().column();
+}
+
+RestoreIndex::~RestoreIndex()
+{
+    if (m_view->model()->rowCount() == 0 || m_view->model()->columnCount() == 0)
+        return;
+
+    m_row = std::min(m_row, m_view->model()->rowCount() - 1);
+    m_column = std::min(m_column, m_view->model()->columnCount() - 1);
+    m_view->setCurrentIndex(m_view->model()->index(m_row, m_column, m_parent));
+}

--- a/Client/qtTeamTalk/utilui.h
+++ b/Client/qtTeamTalk/utilui.h
@@ -31,6 +31,7 @@
 #include <QLayout>
 #include <QComboBox>
 #include <QDialog>
+#include <QAbstractItemView>
 
 enum DoubleClickChannelAction
 {
@@ -120,5 +121,18 @@ void setMacResizeMargins(QDialog* dlg, QLayout* layout);
 
 void setCurrentItemData(QComboBox* cbox, const QVariant& itemdata);
 QVariant getCurrentItemData(QComboBox* cbox, const QVariant& not_found = QVariant());
+
+
+class RestoreIndex
+{
+    Q_DISABLE_COPY(RestoreIndex)
+    int m_row, m_column;
+    QModelIndex m_parent;
+    QAbstractItemView* m_view;
+public:
+    RestoreIndex(QAbstractItemView* view);
+    ~RestoreIndex();
+};
+
 
 #endif


### PR DESCRIPTION
I plan to run a service that updates the number of currently active users and MOTD every 5 minutes. At the moment the service is not running but you should be able to see the feature anyway.

Can you look into making the server list items accessible?
https://github.com/BearWare/TeamTalk5/blob/serverlist/Client/qtTeamTalk/serverlistdlg.cpp#L107