### PR TITLE
Receive combined text messages on Android

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
@@ -766,9 +766,7 @@ public class TeamTalkService extends Service
     public Vector<MyTextMessage> getChatLogTextMsgs() {
         if (chatlogtxtmsgs.size() > HISTORY_CHATLOG_MSG_MAX)
             chatlogtxtmsgs.remove(0);
-        int c = chatlogtxtmsgs.size();
         MyTextMessage.merge(chatlogtxtmsgs);
-        Log.d(TAG, "Messages changed from " + c + " to " + chatlogtxtmsgs.size());
         return chatlogtxtmsgs;
     }
 
@@ -1169,19 +1167,19 @@ public class TeamTalkService extends Service
         MyTextMessage newmsg = new MyTextMessage(textmessage, 
                                                  user == null? "" : Utils.getDisplayName(getBaseContext(), user));
 
+        Vector<MyTextMessage> msgs = null;
         switch(textmessage.nMsgType) {
-            case TextMsgType.MSGTYPE_USER : {
-                getUserTextMsgs(textmessage.nFromUserID).add(newmsg);
+            case TextMsgType.MSGTYPE_USER :
+                msgs = getUserTextMsgs(textmessage.nFromUserID);
                 break;
-            }
-            case TextMsgType.MSGTYPE_BROADCAST : {
-                getChatLogTextMsgs().add(newmsg);
+            case TextMsgType.MSGTYPE_BROADCAST :
+            case TextMsgType.MSGTYPE_CHANNEL :
+                msgs = getChatLogTextMsgs();
                 break;
-            }
-            case TextMsgType.MSGTYPE_CHANNEL : {
-                getChatLogTextMsgs().add(newmsg);
-                break;
-            }
+        }
+        if (msgs != null) {
+            msgs.add(newmsg);
+            MyTextMessage.merge(msgs);
         }
     }
 

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
@@ -750,21 +750,25 @@ public class TeamTalkService extends Service
     public int HISTORY_USER_MSG_MAX = 100;
 
     public Vector<MyTextMessage> getUserTextMsgs(int userid) {
-        Vector<MyTextMessage> msgs;
-        if(usertxtmsgs.get(userid) == null) {
-            msgs = new Vector<>();
+        Vector<MyTextMessage> msgs = usertxtmsgs.get(userid);
+        if (msgs == null) {
+            msgs = new Vector<MyTextMessage>();
             usertxtmsgs.put(userid, msgs);
         }
-        msgs = usertxtmsgs.get(userid);
-        if(msgs.size() > HISTORY_USER_MSG_MAX)
+        if (msgs.size() > HISTORY_USER_MSG_MAX)
             msgs.remove(0);
+
+        MyTextMessage.merge(msgs);
+
         return msgs;
     }
 
     public Vector<MyTextMessage> getChatLogTextMsgs() {
-        if(chatlogtxtmsgs.size()>HISTORY_CHATLOG_MSG_MAX)
+        if (chatlogtxtmsgs.size() > HISTORY_CHATLOG_MSG_MAX)
             chatlogtxtmsgs.remove(0);
-
+        int c = chatlogtxtmsgs.size();
+        MyTextMessage.merge(chatlogtxtmsgs);
+        Log.d(TAG, "Messages changed from " + c + " to " + chatlogtxtmsgs.size());
         return chatlogtxtmsgs;
     }
 

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/MyTextMessage.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/MyTextMessage.java
@@ -96,6 +96,30 @@ public class MyTextMessage extends TextMessage {
         return result;
     }
 
+    public static MyTextMessage mergeMessage(Map<Integer, Vector<MyTextMessage>> pending, MyTextMessage msg) {
+        int key = (msg.nMsgType << 16) | msg.nFromUserID;
+        Vector<MyTextMessage> parts = pending.get(key);
+        if (msg.bMore) {
+            if (parts == null) {
+                parts = new Vector<>();
+                pending.put(key, parts);
+            }
+            parts.add(msg);
+            if (parts.size() > 1000)
+                pending.remove(key);
+            return null;
+        }
+        if (parts != null) {
+            StringBuilder content = new StringBuilder();
+            for (MyTextMessage part : parts)
+                content.append(part.szMessage);
+            content.append(msg.szMessage);
+            msg.szMessage = content.toString();
+            pending.remove(key);
+        }
+        return msg;
+    }
+
     public static void merge(Vector<MyTextMessage> msgs) {
         Map<Integer, Vector<MyTextMessage> > mergemsgs = new HashMap<>();
         Vector<MyTextMessage> removemsgs = new Vector<>();

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -199,6 +199,7 @@ extends AppCompatActivity
     ChannelListAdapter channelsAdapter;
     FileListAdapter filesAdapter;
     TextMessageAdapter textmsgAdapter;
+    final Map<Integer, Vector<MyTextMessage>> txtmsgMergeBuffer = new HashMap<>();
     MediaAdapter mediaAdapter;
     TTSWrapper ttsWrapper = null;
     AccessibilityAssistant accessibilityAssistant;
@@ -2258,6 +2259,7 @@ private EditText newmsg;
     public void onCmdUserTextMessage(TextMessage textmessage) {
         User sender;
         String name;
+        MyTextMessage completemsg = MyTextMessage.mergeMessage(txtmsgMergeBuffer, new MyTextMessage(textmessage, ""));
         switch (textmessage.nMsgType) {
         case TextMsgType.MSGTYPE_CHANNEL :
 
@@ -2265,20 +2267,23 @@ private EditText newmsg;
             textmsgAdapter.notifyDataSetChanged();
             accessibilityAssistant.unlockEvents();
 
+            if (completemsg == null)
+                break;
+
             if (textmessage.nFromUserID != getService().getTTInstance().getMyUserID()) {
                 if (sounds.get(SOUND_CHANMSG) != 0)
                     audioIcons.play(sounds.get(SOUND_CHANMSG), 1.0f, 1.0f, 0, 0, 1.0f);
                 if (ttsWrapper != null && prefs.get("channel_message_checkbox", false)) {
                     sender = getService().getUsers().get(textmessage.nFromUserID);
                     name = Utils.getDisplayName(getBaseContext(), sender);
-                    ttsWrapper.speak(getString(R.string.text_tts_channel_message, (sender != null) ? name : "", textmessage.szMessage));
+                    ttsWrapper.speak(getString(R.string.text_tts_channel_message, (sender != null) ? name : "", completemsg.szMessage));
                 }
             }
             else if (textmessage.nFromUserID == getService().getTTInstance().getMyUserID()) {
                 if (sounds.get(SOUND_CHANMSGSENT) != 0)
                     audioIcons.play(sounds.get(SOUND_CHANMSGSENT), 1.0f, 1.0f, 0, 0, 1.0f);
                 if (ttsWrapper != null && prefs.get("channel_message_sent_checkbox", false)) {
-                    ttsWrapper.speak(getString(R.string.text_tts_channel_message_sent, textmessage.szMessage));
+                    ttsWrapper.speak(getString(R.string.text_tts_channel_message_sent, completemsg.szMessage));
                 }
             }
             Log.d(TAG, "Channel message in " + this.hashCode());
@@ -2287,17 +2292,23 @@ private EditText newmsg;
             accessibilityAssistant.lockEvents();
             textmsgAdapter.notifyDataSetChanged();
             accessibilityAssistant.unlockEvents();
-            
+
+            if (completemsg == null)
+                break;
+
             if (sounds.get(SOUND_BCASTMSG) != 0)
                 audioIcons.play(sounds.get(SOUND_BCASTMSG), 1.0f, 1.0f, 0, 0, 1.0f);
             if (ttsWrapper != null && prefs.get("broadcast_message_checkbox", false)) {
                 sender = getService().getUsers().get(textmessage.nFromUserID);
                 name = Utils.getDisplayName(getBaseContext(), sender);
-                ttsWrapper.speak(getString(R.string.text_tts_broadcast_message, (sender != null) ? name : "", textmessage.szMessage));
+                ttsWrapper.speak(getString(R.string.text_tts_broadcast_message, (sender != null) ? name : "", completemsg.szMessage));
             }
             Log.d(TAG, "Broadcast message in " + this.hashCode());
             break;
         case TextMsgType.MSGTYPE_USER :
+            if (completemsg == null)
+                break;
+
             if (sounds.get(SOUND_USERMSG) != 0)
                 audioIcons.play(sounds.get(SOUND_USERMSG), 1.0f, 1.0f, 0, 0, 1.0f);
             
@@ -2305,7 +2316,7 @@ private EditText newmsg;
             name = Utils.getDisplayName(getBaseContext(), sender);
             String senderName = (sender != null) ? name : "";
             if (ttsWrapper != null && prefs.get("private_message_checkbox", false))
-                ttsWrapper.speak(getString(R.string.text_tts_private_message, senderName, textmessage.szMessage));
+                ttsWrapper.speak(getString(R.string.text_tts_private_message, senderName, completemsg.szMessage));
             Intent action = new Intent(this, TextMessageActivity.class);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 NotificationChannel mChannel = new NotificationChannel(MSG_NOTIFICATION_CHANNEL_ID, "Teamtalk incoming message", NotificationManager.IMPORTANCE_HIGH);

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/TextMessageActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/TextMessageActivity.java
@@ -168,6 +168,7 @@ extends AppCompatActivity implements TeamTalkConnectionListener, ClientEventList
                 sent = sent && ttclient.doTextMessage(m) > 0;
                 service.getUserTextMsgs(userid).add(m);
             }
+            MyTextMessage.merge(service.getUserTextMsgs(userid));
             if (sent) {
                 send_msg.setText("");
                 adapter.notifyDataSetChanged();


### PR DESCRIPTION
@poretsky In TeamTalk v5.9 I've added 'bMore' member variable to TextMessage-class. When 'bMore' is set then the current message type (nMsgType) is part of a combined message. The combined TextMessage ends when 'bMore' is cleared (false).

Can you find a way for TextMessageAdapter to support this type of messages? Basically TextMessageAdapter should not update until all TextMessages with 'bMore' has been received.