### PR TITLE
Choose language at first startup

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -6,6 +6,7 @@ Version 5.9.2, unreleased
 Accessible Windows Client
 Default Qt Client
 - Option to show server list on startup
+- Choose language at first startup
 Android Client
 iOS Client
 Server

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -724,11 +724,12 @@ void MainWindow::loadSettings()
 
     if(connect_ok)
         QTimer::singleShot(0, this, &MainWindow::slotConnectToLatest);
-// Ask to set language at first start
-    if (ttSettings->value(SETTINGS_GENERAL_FIRSTSTART, SETTINGS_GENERAL_FIRSTSTART_DEFAULT).toBool())
+
+    // Ask to set language at first start
+    if (!ttSettings->contains(SETTINGS_DISPLAY_LANGUAGE))
     {
-        QDir dir( TRANSLATE_FOLDER, "*.qm", QDir::Name, QDir::Files);
-        QStringList languages = dir.entryList();
+        QStringList languages = extractLanguages();
+        languages.insert(0, SETTINGS_DISPLAY_LANGUAGE_DEFAULT); //default language is none
         bool ok = false;
         QInputDialog inputDialog;
         inputDialog.setOkButtonText(tr("&Ok"));
@@ -741,8 +742,13 @@ void MainWindow::loadSettings()
         QString choice = inputDialog.textValue();
         if (ok)
         {
-            ttSettings->setValue(SETTINGS_DISPLAY_LANGUAGE, choice.remove(".qm"));
+            ttSettings->setValue(SETTINGS_DISPLAY_LANGUAGE, choice);
+            switchLanguage(choice);
         }
+    }
+
+    if (ttSettings->value(SETTINGS_GENERAL_FIRSTSTART, SETTINGS_GENERAL_FIRSTSTART_DEFAULT).toBool())
+    {
 #if defined(Q_OS_WINDOWS) && defined(ENABLE_TOLK)
     bool tolkLoaded = Tolk_IsLoaded();
     if (!tolkLoaded)

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -724,7 +724,25 @@ void MainWindow::loadSettings()
 
     if(connect_ok)
         QTimer::singleShot(0, this, &MainWindow::slotConnectToLatest);
-
+// Ask to set language at first start
+    if (ttSettings->value(SETTINGS_GENERAL_FIRSTSTART, SETTINGS_GENERAL_FIRSTSTART_DEFAULT).toBool())
+    {
+        QDir dir( TRANSLATE_FOLDER, "*.qm", QDir::Name, QDir::Files);
+        QStringList languages = dir.entryList();
+        bool ok = false;
+        QInputDialog inputDialog;
+        inputDialog.setOkButtonText(tr("&Ok"));
+        inputDialog.setCancelButtonText(tr("&Cancel"));
+        inputDialog.setComboBoxItems(languages);
+        inputDialog.setComboBoxEditable(false);
+        inputDialog.setWindowTitle(tr("Choose language"));
+        inputDialog.setLabelText(tr("Select the language will be use by %1").arg(APPNAME_SHORT));
+        ok = inputDialog.exec();
+        QString choice = inputDialog.textValue();
+        if (ok)
+        {
+            ttSettings->setValue(SETTINGS_DISPLAY_LANGUAGE, choice.remove(".qm"));
+        }
 #if defined(Q_OS_WINDOWS) && defined(ENABLE_TOLK)
     bool tolkLoaded = Tolk_IsLoaded();
     if (!tolkLoaded)
@@ -735,7 +753,7 @@ void MainWindow::loadSettings()
     if (!tolkLoaded)
         Tolk_Unload();
 
-    if (ttSettings->value(SETTINGS_GENERAL_FIRSTSTART, SETTINGS_GENERAL_FIRSTSTART_DEFAULT).toBool() && SRActive)
+    if (SRActive)
     {
         QMessageBox answer;
         answer.setText(tr("%1 has detected usage of a screenreader on your computer. Do you wish to enable accessibility options offered by %1 with recommended settings?").arg(APPNAME_SHORT));
@@ -750,12 +768,11 @@ void MainWindow::loadSettings()
         {
             ttSettings->setValue(SETTINGS_TTS_ENGINE, TTSENGINE_TOLK);
             ttSettings->setValue(SETTINGS_DISPLAY_VU_METER_UPDATES, false);
-            ttSettings->setValue(SETTINGS_GENERAL_FIRSTSTART, false);
         }
-        else
-            ttSettings->setValue(SETTINGS_GENERAL_FIRSTSTART, false);
     }
 #endif
+        ttSettings->setValue(SETTINGS_GENERAL_FIRSTSTART, false);
+    }
 // Sounds pack checks
     QString packset = ttSettings->value(SETTINGS_SOUNDS_PACK).toString();
     QString packname = QString("%1/%2").arg(SOUNDSPATH).arg(packset);

--- a/Client/qtTeamTalk/settings.h
+++ b/Client/qtTeamTalk/settings.h
@@ -115,6 +115,7 @@
 #define SETTINGS_DISPLAY_UNOFFICIALSERVERS          "display/show-unofficial-servers"
 #define SETTINGS_DISPLAY_UNOFFICIALSERVERS_DEFAULT  false
 #define SETTINGS_DISPLAY_LANGUAGE                   "display/language"
+#define SETTINGS_DISPLAY_LANGUAGE_DEFAULT           ""
 #define SETTINGS_DISPLAY_APPUPDATE                  "display/check-appupdate"
 #define SETTINGS_DISPLAY_APPUPDATE_DEFAULT                  true
 #define SETTINGS_DISPLAY_APPUPDATE_BETA                  "display/check-beta-versions"

--- a/Client/qtTeamTalk/utilui.cpp
+++ b/Client/qtTeamTalk/utilui.cpp
@@ -24,7 +24,10 @@
 #include "utilui.h"
 #include "settings.h"
 #include "bearwarelogindlg.h"
+#include "appinfo.h"
 
+#include <QTranslator>
+#include <QDir>
 #if QT_VERSION < QT_VERSION_CHECK(6,0,0)
 #include <QDesktopWidget>
 #include <QApplication>
@@ -35,6 +38,7 @@
 
 extern TTInstance* ttInst;
 extern QSettings* ttSettings;
+extern QTranslator* ttTranslator;
 
 void setVideoTextBox(const QRect& rect, const QColor& bgcolor,
                      const QColor& fgcolor, const QString& text,
@@ -236,4 +240,32 @@ bool restoreWindowPosition(const QString& setting, QWidget* widget)
 #endif
     }
     return success;
+}
+
+
+void switchLanguage(const QString& language)
+{
+    QApplication::removeTranslator(ttTranslator);
+    delete ttTranslator;
+    ttTranslator = nullptr;
+    if(!language.isEmpty())
+    {
+        ttTranslator = new QTranslator();
+        if(ttTranslator->load(language, TRANSLATE_FOLDER))
+            QApplication::installTranslator(ttTranslator);
+        else
+        {
+            delete ttTranslator;
+            ttTranslator = nullptr;
+        }
+    }
+}
+
+QStringList extractLanguages()
+{
+    QStringList languages;
+    QDir dir(TRANSLATE_FOLDER, "*.qm", QDir::Name, QDir::Files);
+    for (auto lang : dir.entryList())
+        languages.append(lang.left(lang.size()-3));
+    return languages;
 }

--- a/Client/qtTeamTalk/utilui.cpp
+++ b/Client/qtTeamTalk/utilui.cpp
@@ -243,7 +243,7 @@ bool restoreWindowPosition(const QString& setting, QWidget* widget)
 }
 
 
-void switchLanguage(const QString& language)
+bool switchLanguage(const QString& language)
 {
     QApplication::removeTranslator(ttTranslator);
     delete ttTranslator;
@@ -257,8 +257,10 @@ void switchLanguage(const QString& language)
         {
             delete ttTranslator;
             ttTranslator = nullptr;
+            return false;
         }
     }
+    return true;
 }
 
 QStringList extractLanguages()

--- a/Client/qtTeamTalk/utilui.h
+++ b/Client/qtTeamTalk/utilui.h
@@ -139,5 +139,6 @@ public:
 
 void saveWindowPosition(const QString& setting, QWidget* widget);
 bool restoreWindowPosition(const QString& setting, QWidget* widget);
-
+QStringList extractLanguages();
+void switchLanguage(const QString& language);
 #endif

--- a/Client/qtTeamTalk/utilui.h
+++ b/Client/qtTeamTalk/utilui.h
@@ -140,5 +140,5 @@ public:
 void saveWindowPosition(const QString& setting, QWidget* widget);
 bool restoreWindowPosition(const QString& setting, QWidget* widget);
 QStringList extractLanguages();
-void switchLanguage(const QString& language);
+bool switchLanguage(const QString& language);
 #endif


### PR DESCRIPTION
@bear101 If you are agree with changes in this PR, can you look to make settings choose at first startup to directly take effects? For now we have to restart TT or open and close preferences to apply settings choose at first startup.