### PR TITLE
Use monotonic timer instead of absolute timer

### DIFF
--- a/Library/TeamTalkLib/bin/ttsrv/Main.cpp
+++ b/Library/TeamTalkLib/bin/ttsrv/Main.cpp
@@ -29,9 +29,11 @@
 #include <TeamTalkDefs.h>
 #include <teamtalk/Log.h>
 
-#include <ace/NT_Service.h>
+#include <ace/High_Res_Timer.h>
 #include <ace/Init_ACE.h>
+#include <ace/NT_Service.h>
 #include <ace/Select_Reactor.h>
+#include <ace/Timer_Heap.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -273,7 +275,9 @@ int RunServer(
     no_sigpipe.register_action (SIGPIPE, &original_action);
 
     int ret = ACE::set_handle_limit(-1);//client handler (must be BIG)
-    ACE_Select_Reactor selectReactor;
+    ACE_Timer_Heap timerheap;
+    timerheap.set_time_policy(&ACE_High_Res_Timer::gettimeofday_hr);
+    ACE_Select_Reactor selectReactor(nullptr, &timerheap);
     ACE_Reactor tcpReactor(&selectReactor);
     ACE_Reactor::instance(&tcpReactor);
     ACE_Reactor::instance()->owner (ACE_OS::thr_self ());

--- a/Library/TeamTalkLib/teamtalk/client/ClientNodeBase.cpp
+++ b/Library/TeamTalkLib/teamtalk/client/ClientNodeBase.cpp
@@ -37,9 +37,10 @@ using namespace teamtalk;
 #endif
 
 ClientNodeBase::ClientNodeBase()
-    : m_reactor(new ACE_Select_Reactor(), true) //Ensure we don't use ACE_WFMO_Reactor!!!
+    : m_reactor(new ACE_Select_Reactor(nullptr, &m_timer_queue), true) //Ensure we don't use ACE_WFMO_Reactor!!!
     , m_reactor_thread(INVALID_THREAD_ID)
 {
+    m_timer_queue.set_time_policy(&ACE_High_Res_Timer::gettimeofday_hr);
     this->reactor(&m_reactor);
 }
 

--- a/Library/TeamTalkLib/teamtalk/client/ClientNodeBase.h
+++ b/Library/TeamTalkLib/teamtalk/client/ClientNodeBase.h
@@ -31,7 +31,9 @@
 #include <codec/MediaUtil.h>
 #include <teamtalk/PacketLayout.h>
 
+#include <ace/High_Res_Timer.h>
 #include <ace/Reactor.h>
+#include <ace/Timer_Heap.h>
 
 #include <condition_variable>
 #include <mutex>
@@ -126,6 +128,8 @@ namespace teamtalk {
         // Thread func running ClientNode's main event-loop
         int svc(void) override;
 
+        //timer queue we can change to high-resolution timer (monotomic)
+        ACE_Timer_Heap m_timer_queue;
         //the reactor associated with this client instance
         ACE_Reactor m_reactor;
         ACE_thread_t m_reactor_thread;


### PR DESCRIPTION
 Use monotonic timer (ACE_High_Res_Timer ) instead of absolute timer for ACE_Reactor::schedule_timer(), i.e. change ACE_Timer_Queue on ACE_Reactor to use gettimeofday_hr() instead of gettimeofday().

Fixes #1346 