### PR TITLE
Receive only one notification for long messages

### DIFF
--- a/Client/qtTeamTalk/chattextedit.cpp
+++ b/Client/qtTeamTalk/chattextedit.cpp
@@ -24,6 +24,8 @@
 #include "chattextedit.h"
 #include "settings.h"
 #include "appinfo.h"
+#include "utilsound.h"
+#include "utiltts.h"
 
 #include <QDateTime>
 #include <QTextCursor>
@@ -266,8 +268,26 @@ QString ChatTextEdit::addTextMessage(const MyTextMessage& msg)
     {
         appendPlainText(line);
     }
-
     limitText();
+    switch(msg.nMsgType)
+    {
+    case MSGTYPE_CHANNEL :
+    {
+        if (msg.nFromUserID != TT_GetMyUserID(ttInst))
+        {
+            User user;
+            if (TT_GetUser(ttInst, msg.nFromUserID, &user))
+                addTextToSpeechMessage(TTS_USER_TEXTMSG_CHANNEL, QString(tr("Channel message from %1: %2").arg(getDisplayName(user)).arg(content)));
+            playSoundEvent(SOUNDEVENT_CHANNELMSG);
+        }
+        else
+        {
+            addTextToSpeechMessage(TTS_USER_TEXTMSG_CHANNEL_SEND, QString(tr("Channel message sent: %1").arg(content)));
+            playSoundEvent(SOUNDEVENT_CHANNELMSGSENT);
+        }
+        break;
+    }
+    }
     return line;
 }
 

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -2654,19 +2654,6 @@ void MainWindow::processTextMessage(const MyTextMessage& textmsg)
             }
             writeLogEntry(m_logChan, line);
         }
-        if (textmsg.nFromUserID != TT_GetMyUserID(ttInst))
-        {
-            User user;
-            if (ui.channelsWidget->getUser(textmsg.nFromUserID, user))
-                addTextToSpeechMessage(TTS_USER_TEXTMSG_CHANNEL, QString(tr("Channel message from %1: %2").arg(getDisplayName(user)).arg(_Q(textmsg.szMessage))));
-            playSoundEvent(SOUNDEVENT_CHANNELMSG);
-        }
-        else
-        {
-            addTextToSpeechMessage(TTS_USER_TEXTMSG_CHANNEL_SEND, QString(tr("Channel message sent: %1").arg(_Q(textmsg.szMessage))));
-            playSoundEvent(SOUNDEVENT_CHANNELMSGSENT);
-        }
-
         break;
     }
     case MSGTYPE_BROADCAST :


### PR DESCRIPTION
Supposed to fix #1293, only for channel messages for now, but notifications are send three times.