### PR TITLE
Make workflow use Android NDK r21

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,6 +2,9 @@ name: Android
 
 on: [push]
 
+env:
+  ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/21.4.7075529
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Ensure to use Android NDK r21 otherwise various libraries will fail to build (e.g. OpenSSL, LibVPX).

Android NDK releases are notorious for breaking compatibility :disappointed: 