### PR TITLE
Try to fix the weird TTS pronunciation

### DIFF
--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -7177,8 +7177,8 @@ void MainWindow::slotSpeakClientStats(bool checked/* = false*/)
     float rx = float(stats.nUdpBytesRecv - m_clientstats.nUdpBytesRecv);
     float tx = float(stats.nUdpBytesSent - m_clientstats.nUdpBytesSent);
     int ping = stats.nUdpPingTimeMs;
-    QString strstats = QString("RX: %1KB TX: %2KB ").arg(rx / 1024.0, 2, 'f', 2, '0').arg(tx / 1024.0, 2, 'f', 2, '0');
+    QString strstats = QString("RX: %1KB TX: %2KB").arg(rx / 1024.0, 2, 'f', 2, '0').arg(tx / 1024.0, 2, 'f', 2, '0');
     if (ping >= 0)
-        strstats += QString("PING: %3").arg(ping);
+        strstats += QString(" PING: %3").arg(ping);
     addTextToSpeechMessage(strstats);
 }

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -7177,7 +7177,7 @@ void MainWindow::slotSpeakClientStats(bool checked/* = false*/)
     float rx = float(stats.nUdpBytesRecv - m_clientstats.nUdpBytesRecv);
     float tx = float(stats.nUdpBytesSent - m_clientstats.nUdpBytesSent);
     int ping = stats.nUdpPingTimeMs;
-    QString strstats = QString("RX: %1KB TX: %2KB").arg(rx / 1024.0, 2, 'f', 2, '0').arg(tx / 1024.0, 2, 'f', 2, '0');
+    QString strstats = QString("RX: %1KB TX: %2KB ").arg(rx / 1024.0, 2, 'f', 2, '0').arg(tx / 1024.0, 2, 'f', 2, '0');
     if (ping >= 0)
         strstats += QString("PING: %3").arg(ping);
     addTextToSpeechMessage(strstats);


### PR DESCRIPTION
I'm currently using IBMTTS or known as Eloquence. When I press Control+T, it will read with the following way.
RX: 0.01KB TX: 2.70KB P I N G: 16
Q: Why it will happend?
A: Because It has no space after TX: x.xxKB and the word "PING" is all in capital letter.
Example: RX: 0.01KB TX: 2.70KBPING: 16
Fix: I add the space between the TX: %2KB and the quotation mark (").
It Should Be: RX: 0.01KB TX: 2.70KB PING: 16