### PR TITLE
Restore initial TTS behavior for channel and broadcast messages

### DIFF
--- a/Client/qtTeamTalk/chattextedit.h
+++ b/Client/qtTeamTalk/chattextedit.h
@@ -41,9 +41,9 @@ public:
 
     QString addTextMessage(const MyTextMessage& msg);
     void addLogMessage(const QString& msg);
+    static QString getTimeStamp(const QDateTime& tm, bool force_ts = false);
 
 private:
-    static QString getTimeStamp(const QDateTime& tm, bool force_ts = false);
     void limitText();
     QString currentUrl(const QTextCursor& cursor) const;
     bool mergeMessages(const MyTextMessage& msg, QString& content);

--- a/Client/qtTeamTalk/languages/Bulgarian.ts
+++ b/Client/qtTeamTalk/languages/Bulgarian.ts
@@ -2875,16 +2875,6 @@ p, li { white-space: pre-wrap; }
         <translation>Неуспех да добави %1 към изключенията на защитната стена на Windows.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="2751"/>
         <source>%1 is requesting desktop access</source>
         <translation>%1 поиска достъп до работния плот</translation>
@@ -3515,8 +3505,18 @@ You can download it on the page below:<byte value="xd"/>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
+        <source>Channel message from %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../mainwindow.cpp" line="2693"/>
         <source>Channel message sent: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
+        <source>Broadcast message from %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Client/qtTeamTalk/languages/Chinese_Simplified.ts
+++ b/Client/qtTeamTalk/languages/Chinese_Simplified.ts
@@ -3056,9 +3056,17 @@ p, li { white-space: pre-wrap; }
         <translation>否(&amp;N)</translation>
     </message>
     <message>
+        <source>Channel message from %1: %2</source>
+        <translation type="vanished">%1： %2</translation>
+    </message>
+    <message>
         <location filename="../mainwindow.cpp" line="2693"/>
         <source>Channel message sent: %1</source>
         <translation>我： %1</translation>
+    </message>
+    <message>
+        <source>Broadcast message from %1: %2</source>
+        <translation type="vanished">广播消息： %1： %2</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2730"/>
@@ -3312,12 +3320,12 @@ You can download it on the page below:<byte value="xd"/>
     <message>
         <location filename="../mainwindow.cpp" line="2688"/>
         <source>Channel message: %1</source>
-        <translation>%1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2710"/>
         <source>Broadcast message: %1</source>
-        <translation>广播消息： %1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2751"/>

--- a/Client/qtTeamTalk/languages/Chinese_Simplified.ts
+++ b/Client/qtTeamTalk/languages/Chinese_Simplified.ts
@@ -3056,8 +3056,9 @@ p, li { white-space: pre-wrap; }
         <translation>否(&amp;N)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
         <source>Channel message from %1: %2</source>
-        <translation type="vanished">%1： %2</translation>
+        <translation>%1： %2</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2693"/>
@@ -3065,8 +3066,9 @@ p, li { white-space: pre-wrap; }
         <translation>我： %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
         <source>Broadcast message from %1: %2</source>
-        <translation type="vanished">广播消息： %1： %2</translation>
+        <translation>广播消息： %1： %2</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2730"/>
@@ -3316,16 +3318,6 @@ You can download it on the page below:<byte value="xd"/>
         <location filename="../mainwindow.cpp" line="2586"/>
         <source>Failed to add %1 to Windows Firewall exceptions.</source>
         <translation>无法将 %1 添加到Windows防火墙例外中。</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2751"/>

--- a/Client/qtTeamTalk/languages/Chinese_Traditional.ts
+++ b/Client/qtTeamTalk/languages/Chinese_Traditional.ts
@@ -864,6 +864,9 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>ConnectDlg</name>
+</context>
+<context>
     <name>CustomVideoFmtDlg</name>
     <message>
         <location filename="../customvideofmt.ui" line="14"/>
@@ -2071,16 +2074,6 @@ p, li { white-space: pre-wrap; }
         <translation>啟動錄音失敗</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="2987"/>
         <source>Recording to file: %1</source>
         <translation>錄音到檔案: %1</translation>
@@ -2692,8 +2685,18 @@ You can download it on the page below:<byte value="xd"/>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
+        <source>Channel message from %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../mainwindow.cpp" line="2693"/>
         <source>Channel message sent: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
+        <source>Broadcast message from %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Client/qtTeamTalk/languages/Croatian.ts
+++ b/Client/qtTeamTalk/languages/Croatian.ts
@@ -3002,16 +3002,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="3756"/>
         <source>Text messages blocked by channel operator</source>
         <translation type="unfinished"></translation>
@@ -3302,8 +3292,9 @@ You can download it on the page below:<byte value="xd"/>
         <translation>&amp;Ne</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
         <source>Channel message from %1: %2</source>
-        <translation type="vanished">Poruka kanala od %1: %2</translation>
+        <translation>Poruka kanala od %1: %2</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2693"/>
@@ -3311,8 +3302,9 @@ You can download it on the page below:<byte value="xd"/>
         <translation>Poruka kanala poslana: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
         <source>Broadcast message from %1: %2</source>
-        <translation type="vanished">Javna poruka od %1: %2</translation>
+        <translation>Javna poruka od %1: %2</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2730"/>

--- a/Client/qtTeamTalk/languages/Czech.ts
+++ b/Client/qtTeamTalk/languages/Czech.ts
@@ -2077,16 +2077,6 @@ p, li { white-space: pre-wrap; }
         <translation>Chyba při záznamenávání</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="2987"/>
         <source>Recording to file: %1</source>
         <translation>Zaznamenávám do souboru: %1</translation>
@@ -2692,8 +2682,18 @@ You can download it on the page below:<byte value="xd"/>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
+        <source>Channel message from %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../mainwindow.cpp" line="2693"/>
         <source>Channel message sent: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
+        <source>Broadcast message from %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Client/qtTeamTalk/languages/Danish.ts
+++ b/Client/qtTeamTalk/languages/Danish.ts
@@ -167,6 +167,9 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>AudioStorageDlg</name>
+</context>
+<context>
     <name>BannedUsersDlg</name>
     <message>
         <location filename="../bannedusers.ui" line="14"/>
@@ -2064,16 +2067,6 @@ p, li { white-space: pre-wrap; }
         <translation>Gemmer lyd til filen: %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="3041"/>
         <source>Microphone gain is controlled by channel</source>
         <translation type="unfinished"></translation>
@@ -2597,8 +2590,18 @@ You can download it on the page below:<byte value="xd"/>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
+        <source>Channel message from %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../mainwindow.cpp" line="2693"/>
         <source>Channel message sent: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
+        <source>Broadcast message from %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Client/qtTeamTalk/languages/Dutch.ts
+++ b/Client/qtTeamTalk/languages/Dutch.ts
@@ -2054,16 +2054,6 @@ p, li { white-space: pre-wrap; }
         <translation>Opnemen naar bestand: %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="3041"/>
         <source>Microphone gain is controlled by channel</source>
         <translation type="unfinished"></translation>
@@ -2585,8 +2575,18 @@ You can download it on the page below:<byte value="xd"/>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
+        <source>Channel message from %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../mainwindow.cpp" line="2693"/>
         <source>Channel message sent: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
+        <source>Broadcast message from %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Client/qtTeamTalk/languages/English.ts
+++ b/Client/qtTeamTalk/languages/English.ts
@@ -3023,8 +3023,18 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
+        <source>Channel message from %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../mainwindow.cpp" line="2693"/>
         <source>Channel message sent: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
+        <source>Broadcast message from %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3270,16 +3280,6 @@ You can download it on the page below:<byte value="xd"/>
     <message>
         <location filename="../mainwindow.cpp" line="2586"/>
         <source>Failed to add %1 to Windows Firewall exceptions.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Client/qtTeamTalk/languages/French.ts
+++ b/Client/qtTeamTalk/languages/French.ts
@@ -3056,9 +3056,19 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Non</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
+        <source>Channel message from %1: %2</source>
+        <translation>Message de canal de %1: %2</translation>
+    </message>
+    <message>
         <location filename="../mainwindow.cpp" line="2693"/>
         <source>Channel message sent: %1</source>
         <translation>Message de canal envoyé: %1</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
+        <source>Broadcast message from %1: %2</source>
+        <translation>Message général de %1: %2</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2730"/>
@@ -3308,16 +3318,6 @@ Vous pouvez la télécharger sur la page suivante:<byte value="xd"/>
         <location filename="../mainwindow.cpp" line="2586"/>
         <source>Failed to add %1 to Windows Firewall exceptions.</source>
         <translation>Échec à l&apos;ajout de %1 à la liste des exceptions du pare-feu Windows</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation>Message de canal: %1</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation>Message général: %1</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2751"/>

--- a/Client/qtTeamTalk/languages/German.ts
+++ b/Client/qtTeamTalk/languages/German.ts
@@ -2071,16 +2071,6 @@ p, li { white-space: pre-wrap; }
         <translation>Fehler beim Starten der Aufnahme</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="2987"/>
         <source>Recording to file: %1</source>
         <translation>Aufzeichnung in Datei: %1</translation>
@@ -2696,8 +2686,9 @@ Du kannst sie auf folgender Seite herunterladen:<byte value="xd"/>
         <translation>%1 hat den Raum %2 verlassen</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
         <source>Channel message from %1: %2</source>
-        <translation type="vanished">Raumnachricht von %1: %2</translation>
+        <translation>Raumnachricht von %1: %2</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2693"/>
@@ -2705,8 +2696,9 @@ Du kannst sie auf folgender Seite herunterladen:<byte value="xd"/>
         <translation>Raumnachricht gesendet: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
         <source>Broadcast message from %1: %2</source>
-        <translation type="vanished">Server-Nachricht von %1: %2</translation>
+        <translation>Server-Nachricht von %1: %2</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2730"/>

--- a/Client/qtTeamTalk/languages/Hebrew.ts
+++ b/Client/qtTeamTalk/languages/Hebrew.ts
@@ -941,7 +941,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../desktopaccess.ui" line="78"/>
         <source>Host IP-address</source>
-        <translation type="unfinished">IP כתובת </translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktopaccess.ui" line="91"/>
@@ -2163,16 +2163,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="2757"/>
         <location filename="../mainwindow.cpp" line="4662"/>
         <source>%1 granted desktop access</source>
@@ -2710,8 +2700,18 @@ You can download it on the page below:<byte value="xd"/>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
+        <source>Channel message from %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../mainwindow.cpp" line="2693"/>
         <source>Channel message sent: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
+        <source>Broadcast message from %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5795,7 +5795,7 @@ Delete the published user account to unregister your server.</source>
     <message>
         <location filename="../serverproperties.ui" line="498"/>
         <source>Server Information</source>
-        <translation type="unfinished">הגדרות שרת</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../serverproperties.ui" line="507"/>

--- a/Client/qtTeamTalk/languages/Hungarian.ts
+++ b/Client/qtTeamTalk/languages/Hungarian.ts
@@ -2876,16 +2876,6 @@ p, li { white-space: pre-wrap; }
         <translation>%1 hozzáadása a Windows tűzfal kivételek listájához sikertelen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="2751"/>
         <source>%1 is requesting desktop access</source>
         <translation>%1 asztali hozzáférést kér</translation>
@@ -3516,8 +3506,18 @@ You can download it on the page below:<byte value="xd"/>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
+        <source>Channel message from %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../mainwindow.cpp" line="2693"/>
         <source>Channel message sent: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
+        <source>Broadcast message from %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Client/qtTeamTalk/languages/Indonesian.ts
+++ b/Client/qtTeamTalk/languages/Indonesian.ts
@@ -3036,16 +3036,6 @@ p, li { white-space: pre-wrap; }
         <translation>Transmisi suara gagal</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="4142"/>
         <source>No Sound Device</source>
         <translation>Tidak Ada Perangkat Suara</translation>
@@ -3147,8 +3137,9 @@ Anda dapat mengunduhnya pada halaman di bawah ini:<byte value="xd"/>
         <translation>&amp;Tidak</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
         <source>Channel message from %1: %2</source>
-        <translation type="vanished">Pesan saluran dari %1: %2</translation>
+        <translation>Pesan saluran dari %1: %2</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2693"/>
@@ -3156,8 +3147,9 @@ Anda dapat mengunduhnya pada halaman di bawah ini:<byte value="xd"/>
         <translation>Pesan saluran terkirim: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
         <source>Broadcast message from %1: %2</source>
-        <translation type="vanished">Pesan broadcast dari %1: %2</translation>
+        <translation>Pesan broadcast dari %1: %2</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2730"/>

--- a/Client/qtTeamTalk/languages/Italian.ts
+++ b/Client/qtTeamTalk/languages/Italian.ts
@@ -1749,16 +1749,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="4142"/>
         <source>No Sound Device</source>
         <translation type="unfinished">Nessun dispositivo audio</translation>
@@ -2694,8 +2684,9 @@ You can download it on the page below:<byte value="xd"/>
         <translation>Ban utente</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
         <source>Channel message from %1: %2</source>
-        <translation type="vanished">Messaggio del canale da %1: %2</translation>
+        <translation>Messaggio del canale da %1: %2</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2693"/>
@@ -2703,8 +2694,9 @@ You can download it on the page below:<byte value="xd"/>
         <translation>Messaggio del canale inviato: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
         <source>Broadcast message from %1: %2</source>
-        <translation type="vanished">Messaggio trasmesso da %1: %2</translation>
+        <translation>Messaggio trasmesso da %1: %2</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2730"/>

--- a/Client/qtTeamTalk/languages/Polish.ts
+++ b/Client/qtTeamTalk/languages/Polish.ts
@@ -332,12 +332,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../bearwarelogindlg.ui" line="84"/>
         <source>Username</source>
-        <translation type="unfinished">Nazwa użytkownika</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../bearwarelogindlg.ui" line="97"/>
         <source>Password</source>
-        <translation type="unfinished">Hasło</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../bearwarelogindlg.cpp" line="48"/>
@@ -2088,16 +2088,6 @@ p, li { white-space: pre-wrap; }
         <translation>Nie można rozpocząć nagrywania</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="2987"/>
         <source>Recording to file: %1</source>
         <translation>Nagrywanie do pliku %1</translation>
@@ -2533,7 +2523,7 @@ Do you wish to do this now?</source>
     <message>
         <location filename="../mainwindow.cpp" line="5586"/>
         <source>Channel</source>
-        <translation type="unfinished">Kanał</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5586"/>
@@ -2692,8 +2682,18 @@ You can download it on the page below:<byte value="xd"/>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
+        <source>Channel message from %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../mainwindow.cpp" line="2693"/>
         <source>Channel message sent: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
+        <source>Broadcast message from %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Client/qtTeamTalk/languages/Portuguese_BR.ts
+++ b/Client/qtTeamTalk/languages/Portuguese_BR.ts
@@ -2110,16 +2110,6 @@ p, li { white-space: pre-wrap; }
         <translation>Falha ao iniciar gravação</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="2987"/>
         <source>Recording to file: %1</source>
         <translation>Gravando para arquivo: %1</translation>
@@ -2729,8 +2719,9 @@ Você pode baixá-lo na página abaixo:
         <translation>%1 deixou canal %2</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
         <source>Channel message from %1: %2</source>
-        <translation type="vanished">Mensagem do canal de %1: %2</translation>
+        <translation>Mensagem do canal de %1: %2</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2693"/>
@@ -2738,8 +2729,9 @@ Você pode baixá-lo na página abaixo:
         <translation>Mensagem do canal enviada: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
         <source>Broadcast message from %1: %2</source>
-        <translation type="vanished">Mensagem de transmissão de %1: %2</translation>
+        <translation>Mensagem de transmissão de %1: %2</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2730"/>

--- a/Client/qtTeamTalk/languages/Portuguese_EU.ts
+++ b/Client/qtTeamTalk/languages/Portuguese_EU.ts
@@ -2071,16 +2071,6 @@ p, li { white-space: pre-wrap; }
         <translation>Falha ao iniciar gravação</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="2987"/>
         <source>Recording to file: %1</source>
         <translation>A gravar para ficheiro: %1</translation>
@@ -2692,8 +2682,18 @@ You can download it on the page below:<byte value="xd"/>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
+        <source>Channel message from %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../mainwindow.cpp" line="2693"/>
         <source>Channel message sent: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
+        <source>Broadcast message from %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Client/qtTeamTalk/languages/Russian.ts
+++ b/Client/qtTeamTalk/languages/Russian.ts
@@ -2909,16 +2909,6 @@ p, li { white-space: pre-wrap; }
         <translation>Не удалось добавить %1 в исключения брандмауэра Windows.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="2751"/>
         <source>%1 is requesting desktop access</source>
         <translation>%1 запрашивает доступ к рабочему столу</translation>
@@ -3259,20 +3249,6 @@ Do you wish to do this now?</source>
         <translation>Сетевое сообщение отправлено: %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="7002"/>
-        <source>New version available: %1<byte value="xd"/>
-You can download it on the page below:<byte value="xd"/>
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="7027"/>
-        <source>New beta version available: %1<byte value="xd"/>
-You can download it on the page below:<byte value="xd"/>
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="2019"/>
         <location filename="../mainwindow.cpp" line="2020"/>
         <source>Server configuration saved</source>
@@ -3408,12 +3384,6 @@ You can download it on the page below:<byte value="xd"/>
         <translation>Заблокировать пользователя в канале</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="6909"/>
-        <source>The file %1 contains %2 setup information.<byte value="xd"/>
-Should these settings be applied?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="6990"/>
         <source>A new version of %1 is available: %2. Do you wish to open the download page now?</source>
         <translation>Доступна новая версия %1: %2. Вы хотите открыть страницу загрузки прямо сейчас?</translation>
@@ -3424,10 +3394,11 @@ Should these settings be applied?</source>
         <translation>Доступна новая версия</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="7002"/>
         <source>New version available: %1
 You can download it on the page below:
 %2</source>
-        <translation type="vanished">Доступна новая версия: %1
+        <translation>Доступна новая версия: %1
 Вы можете скачать её на странице ниже:
 %2</translation>
     </message>
@@ -3442,10 +3413,11 @@ You can download it on the page below:
         <translation>Доступна новая бета-версия</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="7027"/>
         <source>New beta version available: %1
 You can download it on the page below:
 %2</source>
-        <translation type="vanished">Доступна новая бета-версия: %1
+        <translation>Доступна новая бета-версия: %1
 Вы можете скачать её на странице ниже:
 %2</translation>
     </message>
@@ -3643,8 +3615,9 @@ You can download it on the page below:
         <translation>Сбой передачи голоса</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
         <source>Channel message from %1: %2</source>
-        <translation type="vanished">Сообщение канала от %1: %2</translation>
+        <translation>Сообщение канала от %1: %2</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2693"/>
@@ -3652,8 +3625,9 @@ You can download it on the page below:
         <translation>Сообщение канала отправлено: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
         <source>Broadcast message from %1: %2</source>
-        <translation type="vanished">Сетевое сообщение от %1: %2</translation>
+        <translation>Сетевое сообщение от %1: %2</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2730"/>
@@ -3976,9 +3950,10 @@ You can download it on the page below:
         <translation>Не удалось извлечь информацию хоста из %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="6909"/>
         <source>The file %1 contains %2 setup information.
 Should these settings be applied?</source>
-        <translation type="vanished">Файл %1 содержит %2 Конфигурационные данные.
+        <translation>Файл %1 содержит %2 Конфигурационные данные.
 Следует ли применять эти настройки?</translation>
     </message>
     <message>

--- a/Client/qtTeamTalk/languages/Slovak.ts
+++ b/Client/qtTeamTalk/languages/Slovak.ts
@@ -2077,16 +2077,6 @@ p, li { white-space: pre-wrap; }
         <translation>Zlyhalo spustenie nahrávania</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="2987"/>
         <source>Recording to file: %1</source>
         <translation>Nahrávanie do súboru: %1</translation>
@@ -2692,8 +2682,18 @@ You can download it on the page below:<byte value="xd"/>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
+        <source>Channel message from %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../mainwindow.cpp" line="2693"/>
         <source>Channel message sent: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
+        <source>Broadcast message from %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Client/qtTeamTalk/languages/Slovenian.ts
+++ b/Client/qtTeamTalk/languages/Slovenian.ts
@@ -941,7 +941,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../desktopaccess.ui" line="78"/>
         <source>Host IP-address</source>
-        <translation type="unfinished">Host IP-naslov</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktopaccess.ui" line="91"/>
@@ -2077,16 +2077,6 @@ p, li { white-space: pre-wrap; }
         <translation>Napaka pri začetku snemanja</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="2987"/>
         <source>Recording to file: %1</source>
         <translation>Snemam v datoteko %1</translation>
@@ -2692,8 +2682,18 @@ You can download it on the page below:<byte value="xd"/>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
+        <source>Channel message from %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../mainwindow.cpp" line="2693"/>
         <source>Channel message sent: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
+        <source>Broadcast message from %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Client/qtTeamTalk/languages/Spanish.ts
+++ b/Client/qtTeamTalk/languages/Spanish.ts
@@ -2875,16 +2875,6 @@ p, li { white-space: pre-wrap; }
         <translation>Fallo al incluir %1 en la lista de excepciones del Firewall de Windows</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="2751"/>
         <source>%1 is requesting desktop access</source>
         <translation>%1 solicita acceso al escritorio</translation>
@@ -3515,8 +3505,18 @@ You can download it on the page below:<byte value="xd"/>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
+        <source>Channel message from %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../mainwindow.cpp" line="2693"/>
         <source>Channel message sent: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
+        <source>Broadcast message from %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Client/qtTeamTalk/languages/Thai.ts
+++ b/Client/qtTeamTalk/languages/Thai.ts
@@ -2078,16 +2078,6 @@ p, li { white-space: pre-wrap; }
         <translation>ไม่สามารถเริ่มทำการบันทึกได้</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../mainwindow.cpp" line="2987"/>
         <source>Recording to file: %1</source>
         <translation>กำลังบันทึกลงไฟล์ %1</translation>
@@ -2693,8 +2683,18 @@ You can download it on the page below:<byte value="xd"/>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
+        <source>Channel message from %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../mainwindow.cpp" line="2693"/>
         <source>Channel message sent: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
+        <source>Broadcast message from %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Client/qtTeamTalk/languages/Turkish.ts
+++ b/Client/qtTeamTalk/languages/Turkish.ts
@@ -3056,8 +3056,9 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Hayır</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2688"/>
         <source>Channel message from %1: %2</source>
-        <translation type="vanished">%1 kullanıcısından kanal iletisi: %2</translation>
+        <translation>%1 kullanıcısından kanal iletisi: %2</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2693"/>
@@ -3065,8 +3066,9 @@ p, li { white-space: pre-wrap; }
         <translation>Gönderilen kanal iletisi: %1</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2710"/>
         <source>Broadcast message from %1: %2</source>
-        <translation type="vanished">%1 kullanıcısından yayınlanan ileti: %2</translation>
+        <translation>%1 kullanıcısından yayınlanan ileti: %2</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2730"/>
@@ -3316,16 +3318,6 @@ Aşağıdaki sayfadan indirebilirsiniz:<byte value="xd"/>
         <location filename="../mainwindow.cpp" line="2586"/>
         <source>Failed to add %1 to Windows Firewall exceptions.</source>
         <translation>%1 öğesini Windows Güvenlik Duvarı ayrıcalıklarına ekleme başarısız.</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2688"/>
-        <source>Channel message: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2710"/>
-        <source>Broadcast message: %1</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2751"/>

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -2690,7 +2690,9 @@ void MainWindow::processTextMessage(const MyTextMessage& textmsg)
         }
         else
         {
-            addTextToSpeechMessage(TTS_USER_TEXTMSG_CHANNEL_SEND, QString(tr("Channel message sent: %1").arg(line.remove(ui.chatEdit->getTimeStamp(textmsg.receiveTime)).remove(getDisplayName(user)).remove("<>\r\n"))));
+            User user;
+            if (ui.channelsWidget->getUser(TT_GetMyUserID(ttInst), user))
+                addTextToSpeechMessage(TTS_USER_TEXTMSG_CHANNEL_SEND, QString(tr("Channel message sent: %1").arg(line.remove(ui.chatEdit->getTimeStamp(textmsg.receiveTime)).remove(getDisplayName(user)).remove("<>\r\n"))));
             playSoundEvent(SOUNDEVENT_CHANNELMSGSENT);
         }
 

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -2685,7 +2685,7 @@ void MainWindow::processTextMessage(const MyTextMessage& textmsg)
         {
             User user;
             if (ui.channelsWidget->getUser(textmsg.nFromUserID, user))
-                addTextToSpeechMessage(TTS_USER_TEXTMSG_CHANNEL, QString(tr("Channel message: %1").arg(line)));
+                addTextToSpeechMessage(TTS_USER_TEXTMSG_CHANNEL, QString(tr("Channel message from %1: %2").arg(getDisplayName(user)).arg(line.remove(ui.chatEdit->getTimeStamp(textmsg.receiveTime)).remove(getDisplayName(user)).remove("<>\r\n"))));
             playSoundEvent(SOUNDEVENT_CHANNELMSG);
         }
         else
@@ -2707,7 +2707,7 @@ void MainWindow::processTextMessage(const MyTextMessage& textmsg)
 
         User user;
         if (ui.channelsWidget->getUser(textmsg.nFromUserID, user) && user.nUserID != TT_GetMyUserID(ttInst))
-            addTextToSpeechMessage(TTS_USER_TEXTMSG_BROADCAST, QString(tr("Broadcast message: %1").arg(line)));
+            addTextToSpeechMessage(TTS_USER_TEXTMSG_BROADCAST, QString(tr("Broadcast message from %1: %2").arg(getDisplayName(user)).arg(line.remove(ui.chatEdit->getTimeStamp(textmsg.receiveTime)).remove(getDisplayName(user)).remove("<>\r\n"))));
         playSoundEvent(SOUNDEVENT_BROADCASTMSG);
         break;
     }

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -2690,7 +2690,7 @@ void MainWindow::processTextMessage(const MyTextMessage& textmsg)
         }
         else
         {
-            addTextToSpeechMessage(TTS_USER_TEXTMSG_CHANNEL_SEND, QString(tr("Channel message sent: %1").arg(line)));
+            addTextToSpeechMessage(TTS_USER_TEXTMSG_CHANNEL_SEND, QString(tr("Channel message sent: %1").arg(line.remove(ui.chatEdit->getTimeStamp(textmsg.receiveTime)).remove(getDisplayName(user)).remove("<>\r\n"))));
             playSoundEvent(SOUNDEVENT_CHANNELMSGSENT);
         }
 


### PR DESCRIPTION
I made a workaround to restore initial TTS behavior for channel and broadcast messages. Simply get the full string and remove display name and eventually timestamp from it.