### PR TITLE
Fix startup sounds

### DIFF
--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -661,7 +661,7 @@ void MainWindow::loadSettings()
     slotMeEnablePushToTalk(ptt);
     bool vox = ttSettings->value(SETTINGS_GENERAL_VOICEACTIVATED,
                                  SETTINGS_GENERAL_VOICEACTIVATED_DEFAULT).toBool();
-    slotMeEnableVoiceActivation(vox);
+    enableVoiceActivation(vox, SOUNDEVENT_VOICEACTON, SOUNDEVENT_VOICEACTOFF);
 
     //load shortcuts
     loadHotKeys();


### PR DESCRIPTION
Following PR #1383, sounds played at startup has changed. This PR call enableVoiceActivation directly with correct sounds at startup instead of slotMeEnableVoiceActivation.