### PR TITLE
Ability to use BUILD_TEAMTALK_CORE in Ninja builds on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 ./*.sln
 ./*.bat
-build-*
 CMakeFiles
 CMakeLists.txt.user
 TAGS

--- a/Build/.gitignore
+++ b/Build/.gitignore
@@ -1,1 +1,1 @@
-/build*
+/build-*

--- a/Client/TeamTalkClassic/CMakeLists.txt
+++ b/Client/TeamTalkClassic/CMakeLists.txt
@@ -19,8 +19,13 @@ include (ttclassic.cmake)
 if (MSVC)
 
   set (PLATFORMTOOLSET "/property:PlatformToolset=v142")
-  
+
   if (${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+
+    if (NOT CMAKE_VS_PLATFORM_NAME)
+      set (CMAKE_VS_PLATFORM_NAME x64)
+    endif()
+
     ExternalProject_Add(tinyxml-classic-src
       GIT_REPOSITORY    https://github.com/bear101/tinyxml
       GIT_TAG           224ab4ea35ded8ee95f13c84c30592abf5292af8
@@ -33,7 +38,12 @@ if (MSVC)
       BUILD_BYPRODUCTS  <SOURCE_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/tinyxmld.lib <SOURCE_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/tinyxml.lib
       )
   else()
-    ExternalProject_Add(tinyxml-classic-src
+
+      if (NOT CMAKE_VS_PLATFORM_NAME)
+        set (CMAKE_VS_PLATFORM_NAME win32)
+      endif()
+
+      ExternalProject_Add(tinyxml-classic-src
       GIT_REPOSITORY    https://github.com/bear101/tinyxml
       GIT_TAG           224ab4ea35ded8ee95f13c84c30592abf5292af8
       UPDATE_COMMAND    ""
@@ -53,7 +63,7 @@ if (MSVC)
   set_target_properties(tinyxml-classic PROPERTIES
     IMPORTED_LOCATION_DEBUG ${SOURCE_DIR}/lib/${CMAKE_VS_PLATFORM_NAME}/tinyxmld.lib
     IMPORTED_LOCATION ${SOURCE_DIR}/lib/${CMAKE_VS_PLATFORM_NAME}/tinyxml.lib)
-  
+
   option (BUILD_TEAMTALK_CLIENT_MFC_EXAMPLE "Build TeamTalk 5 Classic for TeamTalk 5 Standard Edition" ON)
   option (BUILD_TEAMTALK_PROCLIENT_MFC_EXAMPLE "Build TeamTalk 5 Classic Pro for TeamTalk 5 Professional Edition" ON)
 

--- a/Client/TeamTalkClassic/CMakeLists.txt
+++ b/Client/TeamTalkClassic/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project (TeamTalk5Classic)
 
+include(CMakeDependentOption)
+
 function(set_output_dir target dir)
   set_target_properties (${target} PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${dir}
@@ -64,8 +66,14 @@ if (MSVC)
     IMPORTED_LOCATION_DEBUG ${SOURCE_DIR}/lib/${CMAKE_VS_PLATFORM_NAME}/tinyxmld.lib
     IMPORTED_LOCATION ${SOURCE_DIR}/lib/${CMAKE_VS_PLATFORM_NAME}/tinyxml.lib)
 
-  option (BUILD_TEAMTALK_CLIENT_MFC_EXAMPLE "Build TeamTalk 5 Classic for TeamTalk 5 Standard Edition" ON)
-  option (BUILD_TEAMTALK_PROCLIENT_MFC_EXAMPLE "Build TeamTalk 5 Classic Pro for TeamTalk 5 Professional Edition" ON)
+  if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
+    set (VS_BUILD 1)
+  else()
+    set (VS_BUILD 0)
+  endif()
+
+  cmake_dependent_option (BUILD_TEAMTALK_CLIENT_MFC_EXAMPLE "Build TeamTalk 5 Classic for TeamTalk 5 Standard Edition" ON "VS_BUILD" OFF)
+  cmake_dependent_option (BUILD_TEAMTALK_PROCLIENT_MFC_EXAMPLE "Build TeamTalk 5 Classic Pro for TeamTalk 5 Professional Edition" ON "VS_BUILD" OFF)
 
   set(CMAKE_MFC_FLAG 1)
 

--- a/Client/TeamTalkClassic/CMakeLists.txt
+++ b/Client/TeamTalkClassic/CMakeLists.txt
@@ -30,6 +30,7 @@ if (MSVC)
       BUILD_COMMAND     msbuild -maxCpuCount ${PLATFORMTOOLSET} /p:Platform=x64 tinyxml.sln -target:tinyxml /property:Configuration=Debug
       COMMAND           msbuild -maxCpuCount ${PLATFORMTOOLSET} /p:Platform=x64 tinyxml.sln -target:tinyxml /property:Configuration=Release
       INSTALL_COMMAND   ""
+      BUILD_BYPRODUCTS  <SOURCE_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/tinyxmld.lib <SOURCE_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/tinyxml.lib
       )
   else()
     ExternalProject_Add(tinyxml-classic-src
@@ -41,6 +42,7 @@ if (MSVC)
       BUILD_COMMAND     msbuild -maxCpuCount ${PLATFORMTOOLSET} /p:Platform=win32 tinyxml.sln -target:tinyxml /property:Configuration=Debug
       COMMAND           msbuild -maxCpuCount ${PLATFORMTOOLSET} /p:Platform=win32 tinyxml.sln -target:tinyxml /property:Configuration=Release
       INSTALL_COMMAND   ""
+      BUILD_BYPRODUCTS  <SOURCE_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/tinyxmld.lib <SOURCE_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/tinyxml.lib
       )
   endif()
   ExternalProject_Get_Property(tinyxml-classic-src SOURCE_DIR)

--- a/Client/qtTeamTalk/qt/CMakeLists.txt
+++ b/Client/qtTeamTalk/qt/CMakeLists.txt
@@ -9,6 +9,11 @@ set (QT_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/install CACHE STRING "Install
 
 if (MSVC)
   if (${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+
+    if (NOT CMAKE_VS_PLATFORM_NAME)
+      set (CMAKE_VS_PLATFORM_NAME x64)
+    endif()
+
     ExternalProject_Add(Qt-openssl-src
       PREFIX            ${QT_BUILD_PREFIX}
       GIT_REPOSITORY    https://github.com/bear101/openssl
@@ -24,6 +29,11 @@ if (MSVC)
     ExternalProject_Get_Property(Qt-openssl-src INSTALL_DIR)
     set (OPENSSL_DIR ${INSTALL_DIR})
   else()
+
+    if (NOT CMAKE_VS_PLATFORM_NAME)
+      set (CMAKE_VS_PLATFORM_NAME win32)
+    endif()
+
     ExternalProject_Add(Qt-openssl-src
       PREFIX            ${QT_BUILD_PREFIX}
       GIT_REPOSITORY    https://github.com/bear101/openssl

--- a/Library/TeamTalkLib/build/ace/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/ace/CMakeLists.txt
@@ -46,6 +46,14 @@ if (MSVC)
         INSTALL_COMMAND   cd <SOURCE_DIR>
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\install.bat <INSTALL_DIR>
         DEPENDS           openssl-src
+        BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/ACEsd.lib
+                          <INSTALL_DIR>/lib/ACEs.lib
+                          <INSTALL_DIR>/lib/ACE_SSLsd.lib
+                          <INSTALL_DIR>/lib/ACE_SSLs.lib
+                          <INSTALL_DIR>/lib/ACE_INetsd.lib
+                          <INSTALL_DIR>/lib/ACE_INets.lib
+                          <INSTALL_DIR>/lib/ACE_INet_SSLsd.lib
+                          <INSTALL_DIR>/lib/ACE_INet_SSLs.lib
         )
       ExternalProject_Get_Property(ACE-src INSTALL_DIR)
     else()
@@ -76,6 +84,14 @@ if (MSVC)
         INSTALL_COMMAND   cd <SOURCE_DIR>
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\install.bat <INSTALL_DIR>
         DEPENDS           openssl-src
+        BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/ACEsd.lib
+                          <INSTALL_DIR>/lib/ACEs.lib
+                          <INSTALL_DIR>/lib/ACE_SSLsd.lib
+                          <INSTALL_DIR>/lib/ACE_SSLs.lib
+                          <INSTALL_DIR>/lib/ACE_INetsd.lib
+                          <INSTALL_DIR>/lib/ACE_INets.lib
+                          <INSTALL_DIR>/lib/ACE_INet_SSLsd.lib
+                          <INSTALL_DIR>/lib/ACE_INet_SSLs.lib
         )
       ExternalProject_Get_Property(ACE-src INSTALL_DIR)
     endif()

--- a/Library/TeamTalkLib/build/libvpx/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/libvpx/CMakeLists.txt
@@ -21,14 +21,16 @@ if (MSVC)
     endif()
 
     if (${CMAKE_SIZEOF_VOID_P} EQUAL 8)
-      find_program(YASM_EXE_WIN64_PATH yasm.exe PATHS C:/tt5dist/yasm/x64)
-      if (YASM_EXE_WIN64_PATH-NOTFOUND)
+      find_path(YASM_EXE_DIRECTORY yasm.exe PATHS C:/tt5dist/yasm/x64)
+      if (YASM_EXE_DIRECTORY-NOTFOUND)
         message(WARNING "yasm.exe is required to build libvpx. See https://yasm.tortall.net")
       else()
-        message("Found YASM for libvpx here: ${YASM_EXE_WIN64_PATH}")
+        message("Found YASM for libvpx here: ${YASM_EXE_DIRECTORY}")
       endif()
 
-      set (CMAKE_MSVCIDE_RUN_PATH C:/tt5dist/yasm/x64)
+      file (TO_NATIVE_PATH ${YASM_EXE_DIRECTORY} YASM_EXE_DIRECTORY_NATIVE)
+      set (LIBVPX_WIN_TARGET x86_64-win64-vs16)
+      configure_file(${CMAKE_CURRENT_LIST_DIR}/build-libvpx-win.bat_sample ${CMAKE_CURRENT_BINARY_DIR}/build-libvpx-win64.bat @ONLY)
 
       ExternalProject_Add(libvpx-src
         GIT_REPOSITORY    https://github.com/bear101/libvpx
@@ -36,27 +38,27 @@ if (MSVC)
         UPDATE_COMMAND    ""
         PREFIX            ${TOOLCHAIN_BUILD_PREFIX}/libvpx
         CONFIGURE_COMMAND ""
-        BUILD_COMMAND     IF EXIST build-x64 rmdir /Q /S build-x64
-        COMMAND           mkdir build-x64
-        COMMAND           C:\\cygwin64\\bin\\bash.exe --login -c "cd $OLDPWD/build-x64 && ../configure --target=x86_64-win64-vs16 --disable-examples --disable-docs --enable-static-msvcrt --disable-unit-tests && make"
+        BUILD_COMMAND     ${CMAKE_CURRENT_BINARY_DIR}/build-libvpx-win64.bat
         INSTALL_DIR       ${TOOLCHAIN_INSTALL_PREFIX_LIBVPX}
         INSTALL_COMMAND   cd <SOURCE_DIR>
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_headers.bat <INSTALL_DIR>
-        COMMAND           cd <SOURCE_DIR>/build-x64
+        COMMAND           cd <SOURCE_DIR>/build-${LIBVPX_WIN_TARGET}
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_libs.bat x64 <INSTALL_DIR>
         BUILD_IN_SOURCE   TRUE
         BUILD_BYPRODUCTS  <INSTALL_DIR>/${CMAKE_VS_PLATFORM_NAME}/Debug/vpxmtd.lib
                           <INSTALL_DIR>/${CMAKE_VS_PLATFORM_NAME}/Release/vpxmt.lib
         )
     else()
-      find_program(YASM_EXE_WIN32_PATH yasm.exe PATHS C:/tt5dist/yasm/win32)
-      if (YASM_EXE_WIN32_PATH-NOTFOUND)
+      find_path(YASM_EXE_DIRECTORY yasm.exe PATHS C:/tt5dist/yasm/win32)
+      if (YASM_EXE_DIRECTORY-NOTFOUND)
         message(WARNING "yasm.exe is required to build libvpx. See https://yasm.tortall.net")
       else()
-        message("Found YASM for libvpx here: ${YASM_EXE_WIN32_PATH}")
+        message("Found YASM.exe for libvpx here: ${YASM_EXE_DIRECTORY}")
       endif()
 
-      set (CMAKE_MSVCIDE_RUN_PATH C:/tt5dist/yasm/win32)
+      file (TO_NATIVE_PATH ${YASM_EXE_DIRECTORY} YASM_EXE_DIRECTORY_NATIVE)
+      set (LIBVPX_WIN_TARGET x86-win32-vs16)
+      configure_file(${CMAKE_CURRENT_LIST_DIR}/build-libvpx-win.bat_sample ${CMAKE_CURRENT_BINARY_DIR}/build-libvpx-win32.bat @ONLY)
 
       ExternalProject_Add(libvpx-src
         GIT_REPOSITORY    https://github.com/bear101/libvpx
@@ -64,13 +66,11 @@ if (MSVC)
         UPDATE_COMMAND    ""
         PREFIX            ${TOOLCHAIN_BUILD_PREFIX}/libvpx
         CONFIGURE_COMMAND ""
-        BUILD_COMMAND     IF EXIST build-win32 rmdir /Q /S build-win32
-        COMMAND           mkdir build-win32
-        COMMAND           C:\\cygwin64\\bin\\bash.exe --login -c "cd $OLDPWD/build-win32 && ../configure --target=x86-win32-vs16 --disable-examples --disable-docs --enable-static-msvcrt --disable-unit-tests && make"
+        BUILD_COMMAND     ${CMAKE_CURRENT_BINARY_DIR}/build-libvpx-win32.bat
         INSTALL_DIR       ${TOOLCHAIN_INSTALL_PREFIX_LIBVPX}
         INSTALL_COMMAND   cd <SOURCE_DIR>
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_headers.bat <INSTALL_DIR>
-        COMMAND           cd <SOURCE_DIR>/build-win32
+        COMMAND           cd <SOURCE_DIR>/build-${LIBVPX_WIN_TARGET}
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_libs.bat win32 <INSTALL_DIR>
         BUILD_IN_SOURCE   TRUE
         BUILD_BYPRODUCTS  <INSTALL_DIR>/${CMAKE_VS_PLATFORM_NAME}/Debug/vpxmtd.lib

--- a/Library/TeamTalkLib/build/libvpx/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/libvpx/CMakeLists.txt
@@ -45,6 +45,8 @@ if (MSVC)
         COMMAND           cd <SOURCE_DIR>/build-x64
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_libs.bat x64 <INSTALL_DIR>
         BUILD_IN_SOURCE   TRUE
+        BUILD_BYPRODUCTS  <INSTALL_DIR>/${CMAKE_VS_PLATFORM_NAME}/Debug/vpxmtd.lib
+                          <INSTALL_DIR>/${CMAKE_VS_PLATFORM_NAME}/Release/vpxmt.lib
         )
     else()
       find_program(YASM_EXE_WIN32_PATH yasm.exe PATHS C:/tt5dist/yasm/win32)
@@ -71,6 +73,8 @@ if (MSVC)
         COMMAND           cd <SOURCE_DIR>/build-win32
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_libs.bat win32 <INSTALL_DIR>
         BUILD_IN_SOURCE   TRUE
+        BUILD_BYPRODUCTS  <INSTALL_DIR>/${CMAKE_VS_PLATFORM_NAME}/Debug/vpxmtd.lib
+                          <INSTALL_DIR>/${CMAKE_VS_PLATFORM_NAME}/Release/vpxmt.lib
         )
     endif()
     ExternalProject_Get_Property(libvpx-src INSTALL_DIR)

--- a/Library/TeamTalkLib/build/libvpx/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/libvpx/CMakeLists.txt
@@ -21,6 +21,11 @@ if (MSVC)
     endif()
 
     if (${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+
+      if (NOT CMAKE_VS_PLATFORM_NAME)
+        set (CMAKE_VS_PLATFORM_NAME x64)
+      endif()
+
       find_path(YASM_EXE_DIRECTORY yasm.exe PATHS C:/tt5dist/yasm/x64)
       if (YASM_EXE_DIRECTORY-NOTFOUND)
         message(WARNING "yasm.exe is required to build libvpx. See https://yasm.tortall.net")
@@ -49,6 +54,11 @@ if (MSVC)
                           <INSTALL_DIR>/${CMAKE_VS_PLATFORM_NAME}/Release/vpxmt.lib
         )
     else()
+
+      if (NOT CMAKE_VS_PLATFORM_NAME)
+        set (CMAKE_VS_PLATFORM_NAME win32)
+      endif()
+
       find_path(YASM_EXE_DIRECTORY yasm.exe PATHS C:/tt5dist/yasm/win32)
       if (YASM_EXE_DIRECTORY-NOTFOUND)
         message(WARNING "yasm.exe is required to build libvpx. See https://yasm.tortall.net")
@@ -95,7 +105,7 @@ if (MSVC)
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
   if (TOOLCHAIN_BUILD_EXTERNALPROJECTS)
-    
+
     ExternalProject_Add(libvpx-arm64-src
       GIT_REPOSITORY    https://github.com/bear101/libvpx
       GIT_TAG           v1.11.0
@@ -127,7 +137,7 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
       BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/libvpx.a
       )
     ExternalProject_Get_Property(libvpx-intel-src INSTALL_DIR)
-    
+
     # Use 'lipo' to create universal binary
     file(MAKE_DIRECTORY ${TOOLCHAIN_INSTALL_PREFIX_LIBVPX}/lib)
     file(MAKE_DIRECTORY ${TOOLCHAIN_INSTALL_PREFIX_LIBVPX}/include)
@@ -141,7 +151,7 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
     add_custom_target (libvpx-src DEPENDS ${TOOLCHAIN_INSTALL_PREFIX_LIBVPX}/lib/libvpx.a
       ${TOOLCHAIN_INSTALL_PREFIX_LIBVPX}/include/vpx/vpx_codec.h)
-    set (INSTALL_DIR ${TOOLCHAIN_INSTALL_PREFIX_LIBVPX})    
+    set (INSTALL_DIR ${TOOLCHAIN_INSTALL_PREFIX_LIBVPX})
   else()
     set (INSTALL_DIR ${TOOLCHAIN_INSTALL_PREFIX_LIBVPX})
   endif(TOOLCHAIN_BUILD_EXTERNALPROJECTS)
@@ -206,7 +216,7 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   else()
     set (LIBVPX_TARGET --target=x86_64-linux-gcc)
   endif()
-  
+
   if (TOOLCHAIN_BUILD_EXTERNALPROJECTS)
     ExternalProject_Add(libvpx-src
       GIT_REPOSITORY    https://github.com/bear101/libvpx
@@ -249,7 +259,7 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Android")
 
   set (LIBVPX_EXPORT export PATH=${CMAKE_ANDROID_NDK}/toolchains/llvm/prebuilt/linux-x86_64/bin:$ENV{PATH})
-  
+
   if ("armeabi-v7a" STREQUAL "${ANDROID_ABI}")
     list (APPEND LIBVPX_EXPORT && export CROSS=arm-linux-androideabi-)
     list (APPEND LIBVPX_EXPORT && export CC=clang\ --target=armv7a-linux-android${ANDROID_PLATFORM_LEVEL})
@@ -273,7 +283,7 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Android")
   else()
     message(FATAL_ERROR "Unknown Android architecture")
   endif()
-  
+
   if (TOOLCHAIN_BUILD_EXTERNALPROJECTS)
     ExternalProject_Add(libvpx-src
       GIT_REPOSITORY    https://github.com/bear101/libvpx
@@ -312,5 +322,5 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Android")
       target_link_options(libvpx INTERFACE "-Wl,-Bsymbolic")
     endif()
   endif()
-  
+
 endif()

--- a/Library/TeamTalkLib/build/libvpx/build-libvpx-win.bat_sample
+++ b/Library/TeamTalkLib/build/libvpx/build-libvpx-win.bat_sample
@@ -1,0 +1,4 @@
+SET PATH=@YASM_EXE_DIRECTORY_NATIVE@;%PATH%;
+IF EXIST build-@LIBVPX_WIN_TARGET@ RMDIR /Q /S build-@LIBVPX_WIN_TARGET@
+MKDIR build-@LIBVPX_WIN_TARGET@
+@CYGWIN_BASH_EXE_PATH@ --login -c "cd $OLDPWD/build-@LIBVPX_WIN_TARGET@ && ../configure --target=@LIBVPX_WIN_TARGET@ --disable-examples --disable-docs --enable-static-msvcrt --disable-unit-tests && make"

--- a/Library/TeamTalkLib/build/ogg/0001-Add-d-suffix-to-debug-build-and-switch-to-MT.patch
+++ b/Library/TeamTalkLib/build/ogg/0001-Add-d-suffix-to-debug-build-and-switch-to-MT.patch
@@ -1,0 +1,36 @@
+From 2a98db07b2d27c7e457fdd6c7240e362a870fb8b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bj=C3=B8rn=20Damstedt=20Rasmussen?= <contact@bearware.dk>
+Date: Wed, 25 Nov 2020 20:28:54 +0100
+Subject: [PATCH] Add 'd' suffix to debug build and switch to /MT
+
+---
+ CMakeLists.txt | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 54a13c0..00497c5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -104,6 +104,19 @@ set_target_properties(
+     PUBLIC_HEADER "${OGG_HEADERS}"
+ )
+ 
++if (MSVC)
++    foreach (flag_var
++      CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
++      CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
++      CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
++      CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
++    if (${flag_var} MATCHES "/MD")
++      STRING(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
++    endif()
++    endforeach(flag_var)
++    set_property(TARGET ogg PROPERTY OUTPUT_NAME_DEBUG oggd)
++endif()
++
+ if(BUILD_FRAMEWORK)
+     set_target_properties(ogg PROPERTIES
+         FRAMEWORK TRUE
+-- 
+2.32.0
+

--- a/Library/TeamTalkLib/build/ogg/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/ogg/CMakeLists.txt
@@ -23,6 +23,8 @@ if (MSVC)
       INSTALL_DIR       ${TOOLCHAIN_INSTALL_PREFIX_OGG}
       INSTALL_COMMAND   ${CMAKE_COMMAND} --build . --target install --config Debug
       COMMAND           ${CMAKE_COMMAND} --build . --target install --config Release
+      BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/oggd.lib
+                        <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/ogg.lib
       )
     ExternalProject_Get_Property(ogg-src INSTALL_DIR)
     file(MAKE_DIRECTORY ${INSTALL_DIR}/include)

--- a/Library/TeamTalkLib/build/ogg/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/ogg/CMakeLists.txt
@@ -14,7 +14,8 @@ if (MSVC)
   if (TOOLCHAIN_BUILD_EXTERNALPROJECTS)
     ExternalProject_Add(ogg-src
       GIT_REPOSITORY    https://github.com/bear101/ogg
-      GIT_TAG           49d8bab
+      GIT_TAG           v1.3.3
+      PATCH_COMMAND     git apply ${CMAKE_CURRENT_LIST_DIR}/0001-Add-d-suffix-to-debug-build-and-switch-to-MT.patch
       UPDATE_COMMAND    ""
       PREFIX            ${TOOLCHAIN_BUILD_PREFIX}/ogg
       CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
@@ -23,8 +24,8 @@ if (MSVC)
       INSTALL_DIR       ${TOOLCHAIN_INSTALL_PREFIX_OGG}
       INSTALL_COMMAND   ${CMAKE_COMMAND} --build . --target install --config Debug
       COMMAND           ${CMAKE_COMMAND} --build . --target install --config Release
-      BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/oggd.lib
-                        <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/ogg.lib
+      BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/oggd.lib
+                        <INSTALL_DIR>/lib/ogg.lib
       )
     ExternalProject_Get_Property(ogg-src INSTALL_DIR)
     file(MAKE_DIRECTORY ${INSTALL_DIR}/include)

--- a/Library/TeamTalkLib/build/openssl/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/openssl/CMakeLists.txt
@@ -26,6 +26,7 @@ if (MSVC)
         COMMAND           nmake
         INSTALL_DIR       ${TOOLCHAIN_INSTALL_PREFIX_OPENSSL}
         INSTALL_COMMAND   nmake install
+        BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/libcrypto.lib <INSTALL_DIR>/lib/libssl.lib
         )
     else()
       ExternalProject_Add(openssl-src
@@ -39,6 +40,7 @@ if (MSVC)
         COMMAND           nmake
         INSTALL_DIR       ${TOOLCHAIN_INSTALL_PREFIX_OPENSSL}
         INSTALL_COMMAND   nmake install
+        BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/libcrypto.lib <INSTALL_DIR>/lib/libssl.lib
         )
     endif()
     ExternalProject_Get_Property(openssl-src INSTALL_DIR)

--- a/Library/TeamTalkLib/build/opus/0001-Add-d-suffix-to-debug-build-and-MT-option.patch
+++ b/Library/TeamTalkLib/build/opus/0001-Add-d-suffix-to-debug-build-and-MT-option.patch
@@ -1,0 +1,36 @@
+From f13b99afbf8a12a81d4f039647757d588e2cd132 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bj=C3=B8rn=20Damstedt=20Rasmussen?= <contact@bearware.dk>
+Date: Wed, 25 Nov 2020 20:51:24 +0100
+Subject: [PATCH] Add 'd' suffix to debug build and /MT option
+
+---
+ CMakeLists.txt | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 17ee3fc2..5a32effd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -165,6 +165,19 @@ set(Opus_PUBLIC_HEADER
+     ${CMAKE_CURRENT_SOURCE_DIR}/include/opus_projection.h
+     ${CMAKE_CURRENT_SOURCE_DIR}/include/opus_types.h)
+ 
++if (MSVC)
++    set_property(TARGET opus PROPERTY OUTPUT_NAME_DEBUG opusd)
++    foreach (flag_var
++      CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
++      CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
++      CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
++      CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
++    if (${flag_var} MATCHES "/MD")
++      STRING(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
++    endif()
++    endforeach(flag_var)
++endif()
++
+ set_target_properties(opus
+                       PROPERTIES SOVERSION
+                                  ${OPUS_LIBRARY_VERSION_MAJOR}
+-- 
+2.32.0
+

--- a/Library/TeamTalkLib/build/opus/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/opus/CMakeLists.txt
@@ -23,6 +23,8 @@ if (MSVC)
       INSTALL_DIR       ${TOOLCHAIN_INSTALL_PREFIX_OPUS}
       INSTALL_COMMAND   ${CMAKE_COMMAND} --build . --target install --config Debug
       COMMAND           ${CMAKE_COMMAND} --build . --target install --config Release
+      BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/opusd.lib
+                        <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/opus.lib
       )
     ExternalProject_Get_Property(opus-src INSTALL_DIR)
     file(MAKE_DIRECTORY ${INSTALL_DIR}/include)

--- a/Library/TeamTalkLib/build/opus/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/opus/CMakeLists.txt
@@ -14,7 +14,8 @@ if (MSVC)
   if (TOOLCHAIN_BUILD_EXTERNALPROJECTS)
     ExternalProject_Add(opus-src
       GIT_REPOSITORY    https://github.com/bear101/opus
-      GIT_TAG           5e292322
+      GIT_TAG           v1.3.1
+      PATCH_COMMAND     git apply ${CMAKE_CURRENT_LIST_DIR}/0001-Add-d-suffix-to-debug-build-and-MT-option.patch
       UPDATE_COMMAND    ""
       PREFIX            ${TOOLCHAIN_BUILD_PREFIX}/opus
       CMAKE_ARGS        -DAVX_SUPPORTED=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
@@ -23,8 +24,8 @@ if (MSVC)
       INSTALL_DIR       ${TOOLCHAIN_INSTALL_PREFIX_OPUS}
       INSTALL_COMMAND   ${CMAKE_COMMAND} --build . --target install --config Debug
       COMMAND           ${CMAKE_COMMAND} --build . --target install --config Release
-      BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/opusd.lib
-                        <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/opus.lib
+      BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/opusd.lib
+                        <INSTALL_DIR>/lib/opus.lib
       )
     ExternalProject_Get_Property(opus-src INSTALL_DIR)
     file(MAKE_DIRECTORY ${INSTALL_DIR}/include)

--- a/Library/TeamTalkLib/build/portaudio/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/portaudio/CMakeLists.txt
@@ -23,6 +23,8 @@ if (MSVC)
       INSTALL_DIR       ${TOOLCHAIN_INSTALL_PREFIX_PORTAUDIO}
       INSTALL_COMMAND   ${CMAKE_COMMAND} --build . --target install --config Debug
       COMMAND           ${CMAKE_COMMAND} --build . --target install --config Release
+      BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/portaudiod.lib
+                        <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/portaudio.lib
       )
     ExternalProject_Get_Property(portaudio-src INSTALL_DIR)
     file(MAKE_DIRECTORY ${INSTALL_DIR}/include)

--- a/Library/TeamTalkLib/build/speex/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/speex/CMakeLists.txt
@@ -27,6 +27,8 @@ if (MSVC)
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_headers.bat <INSTALL_DIR>
         COMMAND           cd <SOURCE_DIR>
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_libs.bat lib <INSTALL_DIR>
+        BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/libspeexd.lib
+                          <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/libspeex_sse2.lib
         )
       ExternalProject_Get_Property(speex-src INSTALL_DIR)
     else()
@@ -44,6 +46,8 @@ if (MSVC)
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_headers.bat <INSTALL_DIR>
         COMMAND           cd <SOURCE_DIR>
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_libs.bat lib <INSTALL_DIR>
+        BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/libspeexd.lib
+                          <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/libspeex_sse2.lib
         )
       ExternalProject_Get_Property(speex-src INSTALL_DIR)
     endif()

--- a/Library/TeamTalkLib/build/speex/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/speex/CMakeLists.txt
@@ -13,6 +13,11 @@ set (TOOLCHAIN_INSTALL_PREFIX_SPEEX ${TOOLCHAIN_INSTALL_PREFIX}/speex)
 if (MSVC)
   if (TOOLCHAIN_BUILD_EXTERNALPROJECTS)
     if (${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+
+      if (NOT CMAKE_VS_PLATFORM_NAME)
+        set (CMAKE_VS_PLATFORM_NAME x64)
+      endif()
+
       ExternalProject_Add(speex-src
         GIT_REPOSITORY    https://github.com/bear101/speex
         GIT_TAG           62ad6a6
@@ -32,6 +37,11 @@ if (MSVC)
         )
       ExternalProject_Get_Property(speex-src INSTALL_DIR)
     else()
+
+      if (NOT CMAKE_VS_PLATFORM_NAME)
+        set (CMAKE_VS_PLATFORM_NAME win32)
+      endif()
+
       ExternalProject_Add(speex-src
         GIT_REPOSITORY    https://github.com/bear101/speex
         GIT_TAG           62ad6a6

--- a/Library/TeamTalkLib/build/speexdsp/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/speexdsp/CMakeLists.txt
@@ -27,6 +27,8 @@ if (MSVC)
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_headers.bat <INSTALL_DIR>
         COMMAND           cd <SOURCE_DIR>
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_libs.bat lib <INSTALL_DIR>
+        BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/libspeexdspd.lib
+                          <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/libspeexdsp_sse.lib
         )
       ExternalProject_Get_Property(speexdsp-src INSTALL_DIR)
     else()
@@ -44,6 +46,8 @@ if (MSVC)
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_headers.bat <INSTALL_DIR>
         COMMAND           cd <SOURCE_DIR>
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_libs.bat lib <INSTALL_DIR>
+        BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/libspeexdspd.lib
+                          <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/libspeexdsp_sse.lib
         )
       ExternalProject_Get_Property(speexdsp-src INSTALL_DIR)
     endif()

--- a/Library/TeamTalkLib/build/speexdsp/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/speexdsp/CMakeLists.txt
@@ -13,6 +13,11 @@ set (TOOLCHAIN_INSTALL_PREFIX_SPEEXDSP ${TOOLCHAIN_INSTALL_PREFIX}/speexdsp)
 if (MSVC)
   if (TOOLCHAIN_BUILD_EXTERNALPROJECTS)
     if (${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+
+      if (NOT CMAKE_VS_PLATFORM_NAME)
+        set (CMAKE_VS_PLATFORM_NAME x64)
+      endif()
+
       ExternalProject_Add(speexdsp-src
         GIT_REPOSITORY    https://github.com/bear101/speexdsp
         GIT_TAG           2907b00
@@ -32,6 +37,11 @@ if (MSVC)
         )
       ExternalProject_Get_Property(speexdsp-src INSTALL_DIR)
     else()
+
+      if (NOT CMAKE_VS_PLATFORM_NAME)
+        set (CMAKE_VS_PLATFORM_NAME win32)
+      endif()
+
       ExternalProject_Add(speexdsp-src
         GIT_REPOSITORY    https://github.com/bear101/speexdsp
         GIT_TAG           2907b00

--- a/Library/TeamTalkLib/build/tinyxml/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/tinyxml/CMakeLists.txt
@@ -11,9 +11,13 @@ include(ExternalProject)
 set (TOOLCHAIN_INSTALL_PREFIX_TINYXML ${TOOLCHAIN_INSTALL_PREFIX}/tinyxml)
 
 if (MSVC)
-
   if (TOOLCHAIN_BUILD_EXTERNALPROJECTS)
     if (${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+
+      if (NOT CMAKE_VS_PLATFORM_NAME)
+        set (CMAKE_VS_PLATFORM_NAME x64)
+      endif()
+
       ExternalProject_Add(tinyxml-src
         GIT_REPOSITORY    https://github.com/bear101/tinyxml
         GIT_TAG           224ab4ea35ded8ee95f13c84c30592abf5292af8
@@ -32,6 +36,11 @@ if (MSVC)
                           <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/tinyxml.lib
         )
     else()
+
+      if (NOT CMAKE_VS_PLATFORM_NAME)
+        set (CMAKE_VS_PLATFORM_NAME win32)
+      endif()
+
       ExternalProject_Add(tinyxml-src
         GIT_REPOSITORY    https://github.com/bear101/tinyxml
         GIT_TAG           224ab4ea35ded8ee95f13c84c30592abf5292af8

--- a/Library/TeamTalkLib/build/tinyxml/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/tinyxml/CMakeLists.txt
@@ -28,6 +28,8 @@ if (MSVC)
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_headers.bat <INSTALL_DIR>
         COMMAND           cd <SOURCE_DIR>
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_libs.bat lib <INSTALL_DIR>
+        BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/tinyxmld.lib
+                          <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/tinyxml.lib
         )
     else()
       ExternalProject_Add(tinyxml-src
@@ -44,6 +46,8 @@ if (MSVC)
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_headers.bat <INSTALL_DIR>
         COMMAND           cd <SOURCE_DIR>
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_libs.bat lib <INSTALL_DIR>
+        BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/tinyxmld.lib
+                          <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/tinyxml.lib
         )
     endif()
     ExternalProject_Get_Property(tinyxml-src INSTALL_DIR)

--- a/Library/TeamTalkLib/build/webrtc/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/webrtc/CMakeLists.txt
@@ -51,18 +51,18 @@ if (MSVC)
       )
     ExternalProject_Get_Property(depot-tools SOURCE_DIR)
     set (DEPOTTOOLS_DIR ${SOURCE_DIR})
-
-    set (CMAKE_MSVCIDE_RUN_PATH ${DEPOTTOOLS_DIR})
+    file (TO_NATIVE_PATH ${DEPOTTOOLS_DIR} DEPOTTOOLS_DIR_NATIVE)
 
     if (NOT EXISTS ${WEBRTC_SOURCE_ROOT})
       message (WARNING "WebRTC is not present in ${WEBRTC_SOURCE_ROOT}. Downloading... This takes a loooong time")
       set (WEBRTC_FETCH_CMD1 SET DEPOT_TOOLS_WIN_TOOLCHAIN=0)
-      set (WEBRTC_FETCH_CMD2 cd ${WEBRTC_FETCH_PATH})
-      set (WEBRTC_FETCH_CMD3 CALL fetch --nohooks webrtc)
-      set (WEBRTC_FETCH_CMD4 CALL gclient sync --with_branch_heads --with_tags)
-      set (WEBRTC_FETCH_CMD5 cd ${WEBRTC_SOURCE_ROOT})
-      set (WEBRTC_FETCH_CMD6 CALL git checkout branch-heads/4332)
-      set (WEBRTC_FETCH_CMD7 CALL gclient sync -D)
+      set (WEBRTC_FETCH_CMD2 SET PATH=${DEPOTTOOLS_DIR_NATIVE}$<SEMICOLON>%PATH%$<SEMICOLON>)
+      set (WEBRTC_FETCH_CMD3 cd ${WEBRTC_FETCH_PATH})
+      set (WEBRTC_FETCH_CMD4 CALL fetch --nohooks webrtc)
+      set (WEBRTC_FETCH_CMD5 CALL gclient sync --with_branch_heads --with_tags)
+      set (WEBRTC_FETCH_CMD6 cd ${WEBRTC_SOURCE_ROOT})
+      set (WEBRTC_FETCH_CMD7 CALL git checkout branch-heads/4332)
+      set (WEBRTC_FETCH_CMD8 CALL gclient sync -D)
       set (WEBRTC_PATCH_CMD1 cd ${WEBRTC_SOURCE_ROOT})
       set (WEBRTC_PATCH_CMD2 CALL git apply ${CMAKE_CURRENT_LIST_DIR}\\libteamtalk-r4332.patch)
     else()
@@ -73,6 +73,7 @@ if (MSVC)
       set (WEBRTC_FETCH_CMD5 echo "Skipping WebRTC fetching")
       set (WEBRTC_FETCH_CMD6 echo "Skipping WebRTC fetching")
       set (WEBRTC_FETCH_CMD7 echo "Skipping WebRTC fetching")
+      set (WEBRTC_FETCH_CMD8 echo "Skipping WebRTC fetching")
       set (WEBRTC_PATCH_CMD1 echo "Skipping WebRTC patching")
       set (WEBRTC_PATCH_CMD2 echo "Skipping WebRTC patching")
     endif()
@@ -85,11 +86,13 @@ if (MSVC)
       COMMAND           ${WEBRTC_FETCH_CMD5}
       COMMAND           ${WEBRTC_FETCH_CMD6}
       COMMAND           ${WEBRTC_FETCH_CMD7}
+      COMMAND           ${WEBRTC_FETCH_CMD8}
       PATCH_COMMAND     ${WEBRTC_PATCH_CMD1}
       COMMAND           ${WEBRTC_PATCH_CMD2}
       UPDATE_COMMAND    ""
       INSTALL_DIR       ${WEBRTC_INSTALL_ROOT}
       CONFIGURE_COMMAND SET DEPOT_TOOLS_WIN_TOOLCHAIN=0
+      COMMAND           SET PATH=${DEPOTTOOLS_DIR_NATIVE}$<SEMICOLON>%PATH%$<SEMICOLON>
       COMMAND           cd ${WEBRTC_SOURCE_ROOT}
       COMMAND           CALL gn gen <INSTALL_DIR>\\lib\\debug
       COMMAND           CALL gn gen <INSTALL_DIR>\\lib\\release

--- a/Library/TeamTalkLib/build/webrtc/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/webrtc/CMakeLists.txt
@@ -78,6 +78,9 @@ if (MSVC)
       set (WEBRTC_PATCH_CMD2 echo "Skipping WebRTC patching")
     endif()
 
+    # WebRTC for Windows depends on Windows SDK v10.0.20348.0. This
+    # can be downloaded from Visual Studio Installer
+
     ExternalProject_Add(webrtc-src
       DOWNLOAD_COMMAND  ${WEBRTC_FETCH_CMD1}
       COMMAND           ${WEBRTC_FETCH_CMD2}

--- a/Library/TeamTalkLib/build/zlib/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/zlib/CMakeLists.txt
@@ -13,6 +13,11 @@ set (TOOLCHAIN_INSTALL_PREFIX_ZLIB ${TOOLCHAIN_INSTALL_PREFIX}/zlib)
 if (MSVC)
   if (TOOLCHAIN_BUILD_EXTERNALPROJECTS)
     if (${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+
+      if (NOT CMAKE_VS_PLATFORM_NAME)
+        set (CMAKE_VS_PLATFORM_NAME x64)
+      endif()
+
       ExternalProject_Add(zlib-src
         GIT_REPOSITORY    https://github.com/bear101/zlib
         GIT_TAG           56c3219
@@ -31,6 +36,11 @@ if (MSVC)
                           <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/zlib.lib
         )
     else()
+
+      if (NOT CMAKE_VS_PLATFORM_NAME)
+        set (CMAKE_VS_PLATFORM_NAME win32)
+      endif()
+
       ExternalProject_Add(zlib-src
         GIT_REPOSITORY    https://github.com/bear101/zlib
         GIT_TAG           56c3219

--- a/Library/TeamTalkLib/build/zlib/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/zlib/CMakeLists.txt
@@ -27,6 +27,8 @@ if (MSVC)
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_headers.bat <INSTALL_DIR>
         COMMAND           cd <SOURCE_DIR>
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_libs.bat lib <INSTALL_DIR>
+        BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/zlibd.lib
+                          <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/zlib.lib
         )
     else()
       ExternalProject_Add(zlib-src
@@ -43,6 +45,8 @@ if (MSVC)
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_headers.bat <INSTALL_DIR>
         COMMAND           cd <SOURCE_DIR>
         COMMAND           ${CMAKE_CURRENT_LIST_DIR}\\..\\install_libs.bat lib <INSTALL_DIR>
+        BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/zlibd.lib
+                          <INSTALL_DIR>/lib/${CMAKE_VS_PLATFORM_NAME}/zlib.lib
         )
     endif()
     ExternalProject_Get_Property(zlib-src INSTALL_DIR)


### PR DESCRIPTION
Previously CMAKE_VS_PLATFORM_NAME was expected to be set in order to compile. However, CMAKE_VS_PLATFORM_NAME is not set by Ninja on Windows. With the changes in this merge request the CMAKE_VS_PLATFORM_NAME variable is no longer required.

Also ACE, OPUS, OGG has switched to patching instead of pointing to a git-hash. This makes it easier to upgrade these dependencies.

A side effect is also that it should be possible to build from Qt Creator on Windows.