### PR TITLE
Convert overloaded nativeEvent to Qt6

### DIFF
--- a/Client/qtTeamTalk/keycompdlg.cpp
+++ b/Client/qtTeamTalk/keycompdlg.cpp
@@ -58,8 +58,13 @@ KeyCompDlg::~KeyCompDlg()
 
 #if defined(Q_OS_WIN32) && QT_VERSION >= QT_VERSION_CHECK(5,0,0)
 
-bool KeyCompDlg::nativeEvent(const QByteArray& eventType, void* message,
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+bool MainWindow::nativeEvent(const QByteArray& eventType, void* message,
+                             long* result)
+#else
+bool MainWindow::nativeEvent(const QByteArray& eventType, void* message,
                              qintptr* result)
+#endif
 {
     MSG* msg = reinterpret_cast<MSG*>(message);
 

--- a/Client/qtTeamTalk/keycompdlg.cpp
+++ b/Client/qtTeamTalk/keycompdlg.cpp
@@ -59,7 +59,7 @@ KeyCompDlg::~KeyCompDlg()
 #if defined(Q_OS_WIN32) && QT_VERSION >= QT_VERSION_CHECK(5,0,0)
 
 bool KeyCompDlg::nativeEvent(const QByteArray& eventType, void* message,
-                             long* result)
+                             qintptr* result)
 {
     MSG* msg = reinterpret_cast<MSG*>(message);
 

--- a/Client/qtTeamTalk/keycompdlg.cpp
+++ b/Client/qtTeamTalk/keycompdlg.cpp
@@ -59,10 +59,10 @@ KeyCompDlg::~KeyCompDlg()
 #if defined(Q_OS_WIN32) && QT_VERSION >= QT_VERSION_CHECK(5,0,0)
 
 #if QT_VERSION < QT_VERSION_CHECK(6,0,0)
-bool MainWindow::nativeEvent(const QByteArray& eventType, void* message,
+bool KeyCompDlg::nativeEvent(const QByteArray& eventType, void* message,
                              long* result)
 #else
-bool MainWindow::nativeEvent(const QByteArray& eventType, void* message,
+bool KeyCompDlg::nativeEvent(const QByteArray& eventType, void* message,
                              qintptr* result)
 #endif
 {

--- a/Client/qtTeamTalk/keycompdlg.h
+++ b/Client/qtTeamTalk/keycompdlg.h
@@ -43,7 +43,7 @@ public:
 protected:
 #if defined(Q_OS_WIN32) && QT_VERSION >= QT_VERSION_CHECK(5,0,0)
     bool nativeEvent(const QByteArray& eventType, void* message,
-                     long* result);
+                     qintptr* result);
 #elif defined(Q_OS_WIN32)
     bool winEvent(MSG *message, long *result);
 #elif defined(Q_OS_LINUX) || defined(Q_OS_DARWIN)

--- a/Client/qtTeamTalk/keycompdlg.h
+++ b/Client/qtTeamTalk/keycompdlg.h
@@ -42,8 +42,13 @@ public:
 
 protected:
 #if defined(Q_OS_WIN32) && QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+    bool nativeEvent(const QByteArray& eventType, void* message,
+                     long* result);
+#else
     bool nativeEvent(const QByteArray& eventType, void* message,
                      qintptr* result);
+#endif
 #elif defined(Q_OS_WIN32)
     bool winEvent(MSG *message, long *result);
 #elif defined(Q_OS_LINUX) || defined(Q_OS_DARWIN)

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -2526,9 +2526,13 @@ void MainWindow::changeEvent(QEvent* event )
 }
 
 #if defined(Q_OS_WIN32) && QT_VERSION >= QT_VERSION_CHECK(5,0,0)
-
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+bool MainWindow::nativeEvent(const QByteArray& eventType, void* message,
+                             long* result)
+#else
 bool MainWindow::nativeEvent(const QByteArray& eventType, void* message,
                              qintptr* result)
+#endif
 {
     MSG* msg = reinterpret_cast<MSG*>(message);
     if(msg->message == WM_TEAMALK_CLIENTEVENT)

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -2528,7 +2528,7 @@ void MainWindow::changeEvent(QEvent* event )
 #if defined(Q_OS_WIN32) && QT_VERSION >= QT_VERSION_CHECK(5,0,0)
 
 bool MainWindow::nativeEvent(const QByteArray& eventType, void* message,
-                             long* result)
+                             qintptr* result)
 {
     MSG* msg = reinterpret_cast<MSG*>(message);
     if(msg->message == WM_TEAMALK_CLIENTEVENT)

--- a/Client/qtTeamTalk/mainwindow.h
+++ b/Client/qtTeamTalk/mainwindow.h
@@ -124,8 +124,13 @@ protected:
     void closeEvent(QCloseEvent* event) override;
 
 #if defined(Q_OS_WIN32) && QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+    bool nativeEvent(const QByteArray& eventType, void* message,
+                     long* result);
+#else
     bool nativeEvent(const QByteArray& eventType, void* message,
                      qintptr* result);
+#endif
 #endif
 private:
     Ui::MainWindow ui;

--- a/Client/qtTeamTalk/mainwindow.h
+++ b/Client/qtTeamTalk/mainwindow.h
@@ -125,7 +125,7 @@ protected:
 
 #if defined(Q_OS_WIN32) && QT_VERSION >= QT_VERSION_CHECK(5,0,0)
     bool nativeEvent(const QByteArray& eventType, void* message,
-                     long* result);
+                     qintptr* result);
 #endif
 private:
     Ui::MainWindow ui;


### PR DESCRIPTION
According to the Qt documentation, nativeEvent now use qintptr* result instead of long* result. This PR make this change.