### PR TITLE
Ability to start new instance in current profile

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -7,6 +7,7 @@ Accessible Windows Client
 -
 Default Qt Client
 - Option to configure sound events volume
+- Ability to start new client instance using the same profile
 Android Client
 -
 iOS Client

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -3863,11 +3863,12 @@ void MainWindow::slotClientNewInstance(bool /*checked=false*/)
     }
     
 
-    const QString newprofile = tr("New Profile"), delprofile = tr("Delete Profile");
+    const QString newprofile = tr("New Profile"), delprofile = tr("Delete Profile"), curprofile = tr("Current Profile");
     if(profiles.size() < MAX_PROFILES)
         profilenames.push_back(newprofile);
     if(profiles.size() > 0)
         profilenames.push_back(delprofile);
+    profilenames.push_back(curprofile);
 
     bool ok = false;
     QInputDialog inputDialog;
@@ -3919,6 +3920,8 @@ void MainWindow::slotClientNewInstance(bool /*checked=false*/)
             }
             else return;
         }
+        else if (choice == curprofile)
+            inipath = ttSettings->fileName();
         else 
         {
             inipath = profiles[choice];


### PR DESCRIPTION
I think this is a simpler way to start a new instance in the same profile.

With this change we can put "noconnect" argument in "Current Profile". This would solve #1297