### PR TITLE
Return Qt version on about dialog

### DIFF
--- a/Client/qtTeamTalk/aboutdlg.cpp
+++ b/Client/qtTeamTalk/aboutdlg.cpp
@@ -31,7 +31,7 @@ AboutDlg::AboutDlg(QWidget* parent)
     ui.setupUi(this);
     setWindowIcon(QIcon(APPICON));
 
-    QString compile = tr("Compiled on ") + (__DATE__ " " __TIME__ ".\r\n") +
+    QString compile = QString(tr("Compiled on %1 %2 using Qt %3.")).arg(__DATE__).arg(__TIME__).arg(QT_VERSION_STR) + "\r\n" +
         tr("Version ") + (TEAMTALK_VERSION ".\r\n");
     if(sizeof(void*) == 8)
         compile += QString(tr("TeamTalk 64-bit DLL version %1.")).arg(_Q(TT_GetVersion()));


### PR DESCRIPTION
I thought that this information can be usefull now that we have ability to build using Qt5 or Qt6. We can maybe also add the Qt's version currently using by the app? @bear101 what do you think?