### PR TITLE
Remove speak list option on Qt6

### DIFF
--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -5737,8 +5737,10 @@ void MainWindow::slotTreeSelectionChanged()
         updateChannelFiles(channelid);
     }
 #if defined(Q_OS_DARWIN)
+#if QT_VERSION >= QT_VERSION_CHECK(6,4,0)
     if (ttSettings->value(SETTINGS_TTS_SPEAKLISTS, SETTINGS_TTS_SPEAKLISTS_DEFAULT).toBool() == true)
         addTextToSpeechMessage(ui.channelsWidget->getItemText());
+#endif
 #endif
 }
 

--- a/Client/qtTeamTalk/mytreeview.cpp
+++ b/Client/qtTeamTalk/mytreeview.cpp
@@ -34,8 +34,10 @@ MyTreeView::MyTreeView(QWidget* parent/* = nullptr*/) : QTreeView(parent)
 void MyTreeView::currentChanged(const QModelIndex &current, const QModelIndex &previous)
 {
 #if defined(Q_OS_DARWIN)
+#if QT_VERSION < QT_VERSION_CHECK(6,4,0)
     if (current.isValid() && ttSettings->value(SETTINGS_TTS_SPEAKLISTS, SETTINGS_TTS_SPEAKLISTS_DEFAULT).toBool() == true)
         addTextToSpeechMessage(current.data(Qt::AccessibleTextRole).toString());
+#endif
 #endif
     QTreeView::currentChanged(current, previous);
 }

--- a/Client/qtTeamTalk/mytreeview.cpp
+++ b/Client/qtTeamTalk/mytreeview.cpp
@@ -34,7 +34,7 @@ MyTreeView::MyTreeView(QWidget* parent/* = nullptr*/) : QTreeView(parent)
 void MyTreeView::currentChanged(const QModelIndex &current, const QModelIndex &previous)
 {
 #if defined(Q_OS_DARWIN)
-#if QT_VERSION < QT_VERSION_CHECK(6,4,0)
+#if QT_VERSION >= QT_VERSION_CHECK(6,4,0)
     if (current.isValid() && ttSettings->value(SETTINGS_TTS_SPEAKLISTS, SETTINGS_TTS_SPEAKLISTS_DEFAULT).toBool() == true)
         addTextToSpeechMessage(current.data(Qt::AccessibleTextRole).toString());
 #endif

--- a/Client/qtTeamTalk/preferencesdlg.cpp
+++ b/Client/qtTeamTalk/preferencesdlg.cpp
@@ -1127,7 +1127,9 @@ void PreferencesDlg::slotSaveChanges()
 #elif defined(Q_OS_WIN)
         ttSettings->setValue(SETTINGS_TTS_SAPI, ui.ttsForceSapiChkBox->isChecked());
 #elif defined(Q_OS_DARWIN)
+#if QT_VERSION >= QT_VERSION_CHECK(6,4,0)
         ttSettings->setValue(SETTINGS_TTS_SPEAKLISTS, ui.ttsSpeakListsChkBox->isChecked());
+#endif
 #endif
         ttSettings->setValue(SETTINGS_DISPLAY_TTSHEADER, ui.ttsTreeView->header()->saveState());
     }
@@ -1599,7 +1601,9 @@ void PreferencesDlg::slotUpdateTTSTab()
         ui.label_ttsvoicevolume->show();
         ui.ttsVoiceVolumeSpinBox->show();
 #if defined(Q_OS_DARWIN)
+#if QT_VERSION < QT_VERSION_CHECK(6,4,0)
         ui.ttsSpeakListsChkBox->show();
+#endif
 #endif
         delete ttSpeech;
         ttSpeech = new QTextToSpeech(this);
@@ -1615,7 +1619,9 @@ void PreferencesDlg::slotUpdateTTSTab()
         ui.ttsVoiceComboBox->setCurrentIndex(ttSettings->value(SETTINGS_TTS_VOICE).toInt());
 
 #if defined(Q_OS_DARWIN)
+#if QT_VERSION >= QT_VERSION_CHECK(6,4,0)
         ui.ttsSpeakListsChkBox->setChecked(ttSettings->value(SETTINGS_TTS_SPEAKLISTS, SETTINGS_TTS_SPEAKLISTS_DEFAULT).toBool());
+#endif
 #endif
 #endif /* QT_TEXTTOSPEECH_LIB */
     }

--- a/Client/qtTeamTalk/settings.h
+++ b/Client/qtTeamTalk/settings.h
@@ -305,8 +305,10 @@
 #define SETTINGS_TTS_SAPI                         "texttospeech/force-sapi"
 #define SETTINGS_TTS_SAPI_DEFAULT                 false
 #elif defined(Q_OS_DARWIN)
+#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
 #define SETTINGS_TTS_SPEAKLISTS                         "texttospeech/speak-lists"
 #define SETTINGS_TTS_SPEAKLISTS_DEFAULT                 true
+#endif
 #endif
 
 #define SETTINGS_MEDIASTORAGE_MODE                  "media-storage/audio-storage-mode"


### PR DESCRIPTION
In Qt6, list are natively accessible using arrow keys on MacOS, so option to speak list using TTS is no longer useful.