### PR TITLE
Display Qt version used

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -13,6 +13,7 @@ Default Qt Client
 - See OS used by client in "User Information" dialog
 - "Entry name" in "Connect to a Server" dialog now shows server list name
 - "Entry name" is now default file name for saving .tt file in "Generate .tt File" dialog
+- See Qt version on "About" dialog
 - Fixed username/password not being applied in "Generate .tt File" dialog
 Android Client
 -

--- a/Client/qtTeamTalk/aboutdlg.cpp
+++ b/Client/qtTeamTalk/aboutdlg.cpp
@@ -31,7 +31,7 @@ AboutDlg::AboutDlg(QWidget* parent)
     ui.setupUi(this);
     setWindowIcon(QIcon(APPICON));
 
-    QString compile = QString(tr("Compiled on %1 %2 using Qt %3.")).arg(__DATE__).arg(__TIME__).arg(QT_VERSION_STR) + "\r\n" +
+    QString compile = QString(tr("Compiled on %1 %2 using Qt %3 (Qt %4 used by this instance).")).arg(__DATE__).arg(__TIME__).arg(QT_VERSION_STR).arg(qVersion()) + "\r\n" +
         tr("Version ") + (TEAMTALK_VERSION ".\r\n");
     if(sizeof(void*) == 8)
         compile += QString(tr("TeamTalk 64-bit DLL version %1.")).arg(_Q(TT_GetVersion()));


### PR DESCRIPTION
PR #1436 added display of Qt's version used when building. This PR also display version used by the app when running.