### PR TITLE
Update channel path when renaming a channel

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -26,6 +26,7 @@ Server
 - Passwords of auto operator channel are forwarded to clients
 - Subscription changes are written to log file
 - Only 64-bit Windows is now supported
+- Fixed bug where bans on renamed channel has no effect
 
 Version 5.10, 2022/07/17
 Accessible Windows Client

--- a/Library/TeamTalkLib/teamtalk/server/ServerChannel.cpp
+++ b/Library/TeamTalkLib/teamtalk/server/ServerChannel.cpp
@@ -151,3 +151,12 @@ void ServerChannel::RemoveUser(int userid)
 {
     RemoveUser(userid, nullptr);
 }
+
+void ServerChannel::UpdateChannelBans()
+{
+    for (auto& b : m_bans)
+    {
+        if (b.bantype & BANTYPE_CHANNEL)
+            b.chanpath = GetChannelPath();
+    }
+}

--- a/Library/TeamTalkLib/teamtalk/server/ServerChannel.h
+++ b/Library/TeamTalkLib/teamtalk/server/ServerChannel.h
@@ -42,6 +42,7 @@ namespace teamtalk {
         void RemoveUser(int userid);
         void RemoveUser(int userid, bool* modified);
         bool ClearFromTransmitQueue(int userid);
+        void UpdateChannelBans();
     private:
         void Init();
         // userid -> last transmit time

--- a/Library/TeamTalkLib/teamtalk/server/ServerNode.cpp
+++ b/Library/TeamTalkLib/teamtalk/server/ServerNode.cpp
@@ -3686,7 +3686,10 @@ ErrorMsg ServerNode::UpdateChannel(const ChannelProp& chanprop,
         if(chanprop.name.empty())
             return ErrorMsg(TT_CMDERR_CHANNEL_ALREADY_EXISTS);
 
+        bool newname = chanprop.name != chan->GetName();
         chan->SetName(chanprop.name);
+        if (newname)
+            chan->UpdateChannelBans();
     }
     chan->SetTopic(chanprop.topic);
     chan->SetMaxDiskUsage(chanprop.diskquota);


### PR DESCRIPTION
The <channelbans> on <channel> tag contains <channel-path> which must
be updated if channel is renamed. Otherwise the BANTYPE_CHANNEL will
be invalid.

This fixes #414