### PR TITLE
Make lineEdit and spinBox readonly instead of disabled

### DIFF
--- a/Client/qtTeamTalk/channeldlg.cpp
+++ b/Client/qtTeamTalk/channeldlg.cpp
@@ -191,6 +191,7 @@ ChannelDlg::ChannelDlg(ChannelDlgType type, const Channel& chan, QWidget * paren
         ui.agcBox->setEnabled(false);
         ui.gainlevelSlider->setEnabled(false);
         ui.buttonBox->setStandardButtons(QDialogButtonBox::Close);
+        ui.buttonBox->button(QDialogButtonBox::Close)->setText(tr("&Close"));
         ui.joinchanBox->setEnabled(false);
         break;
     }
@@ -355,19 +356,19 @@ void ChannelDlg::setAudioCodecReadonly()
 
     ui.spx_srateBox->setEnabled(false);
     ui.spx_qualitySlider->setEnabled(false);
-    ui.spx_txdelaySpinBox->setEnabled(false);
+    ui.spx_txdelaySpinBox->setReadOnly(true);
 
     ui.spxvbr_srateBox->setEnabled(false);
     ui.spxvbr_qualitySlider->setEnabled(false);
-    ui.spxvbr_maxbpsSpinBox->setEnabled(false);
+    ui.spxvbr_maxbpsSpinBox->setReadOnly(true);
     ui.spxvbr_dtxBox->setEnabled(false);
-    ui.spxvbr_txdelaySpinBox->setEnabled(false);
+    ui.spxvbr_txdelaySpinBox->setReadOnly(true);
 
     ui.opus_channelsBox->setEnabled(false);
     ui.opus_appBox->setEnabled(false);
-    ui.opus_bpsSpinBox->setEnabled(false);
+    ui.opus_bpsSpinBox->setReadOnly(true);
     ui.opus_srateBox->setEnabled(false);
-    ui.opus_txdelaySpinBox->setEnabled(false);
+    ui.opus_txdelaySpinBox->setReadOnly(true);
     ui.opus_framesizeComboBox->setEnabled(false);
     ui.opus_vbrCheckBox->setEnabled(false);
     ui.opus_dtxBox->setEnabled(false);

--- a/Client/qtTeamTalk/serverpropertiesdlg.cpp
+++ b/Client/qtTeamTalk/serverpropertiesdlg.cpp
@@ -81,21 +81,21 @@ ServerPropertiesDlg::ServerPropertiesDlg(QWidget * parent/* = 0*/)
 
     if(!editable)
     {
-        ui.servernameEdit->setEnabled(false);
-        ui.maxusersSpinBox->setEnabled(false);
-        ui.motdTextEdit->setEnabled(false);
-        ui.tcpportSpinBox->setEnabled(false);
-        ui.udpportSpinBox->setEnabled(false);
-        ui.usertimeoutSpinBox->setEnabled(false);
+        ui.servernameEdit->setReadOnly(true);
+        ui.maxusersSpinBox->setReadOnly(true);
+        ui.motdTextEdit->setReadOnly(true);
+        ui.tcpportSpinBox->setReadOnly(true);
+        ui.udpportSpinBox->setReadOnly(true);
+        ui.usertimeoutSpinBox->setReadOnly(true);
         ui.autosaveBox->setEnabled(false);
-        ui.maxloginattemptsSpinBox->setEnabled(false);
-        ui.maxiploginsSpinBox->setEnabled(false);
-        ui.logindelaySpinBox->setEnabled(false);
-        ui.audtxSpinBox->setEnabled(false);
-        ui.videotxSpinBox->setEnabled(false);
-        ui.mediafiletxSpinBox->setEnabled(false);
-        ui.desktoptxSpinBox->setEnabled(false);
-        ui.totaltxSpinBox->setEnabled(false);
+        ui.maxloginattemptsSpinBox->setReadOnly(true);
+        ui.maxiploginsSpinBox->setReadOnly(true);
+        ui.logindelaySpinBox->setReadOnly(true);
+        ui.audtxSpinBox->setReadOnly(true);
+        ui.videotxSpinBox->setReadOnly(true);
+        ui.mediafiletxSpinBox->setReadOnly(true);
+        ui.desktoptxSpinBox->setReadOnly(true);
+        ui.totaltxSpinBox->setReadOnly(true);
         ui.motdChkBox->hide();
     }
     else


### PR DESCRIPTION
This allow users to see most information as possible using keyboard even if they don't have right to edit properties of channel or server.
@bear101 Do you have any idea on how to do a similar thing for checkboxes, comboboxes and sliders?