### PR TITLE
Auto-operators can update non-participating channels

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -38,6 +38,8 @@ Server
 - Passwords of auto operator channel are forwarded to clients
 - Operator status is resumed after disconnect when using BearWare.dk WebLogin
 - Subscription changes are written to log file
+- Auto operators can update channels they have not joined
+- Auto operators can kick/ban from channels they have not joined
 - Only 64-bit Windows is now supported
 - Fixed bug where bans on renamed channel has no effect
 

--- a/Library/TeamTalkLib/teamtalk/Channel.h
+++ b/Library/TeamTalkLib/teamtalk/Channel.h
@@ -297,13 +297,14 @@ namespace teamtalk {
         {
             channel_t sub;
             for(size_t i=0;i<m_subChannels.size();i++)
+            {
                 if(stringcmpnocase(m_subChannels[i]->GetName(), name))
                 {
                     sub = m_subChannels[i];
                     break;
                 }
-
-                return sub;
+            }
+            return sub;
         }
         const channels_t& GetSubChannels() const
         {

--- a/Library/TeamTalkLib/teamtalk/server/ServerChannel.cpp
+++ b/Library/TeamTalkLib/teamtalk/server/ServerChannel.cpp
@@ -171,3 +171,8 @@ bool ServerChannel::IsOwner(const ServerUser& user) const
 {
     return user.GetUserAccount().IsWebLogin() && m_usernameOwner == user.GetUserAccount().username;
 }
+
+bool ServerChannel::IsAutoOperator(const ServerUser& user) const
+{
+    return user.GetUserAccount().auto_op_channels.find(user.GetUserID()) != user.GetUserAccount().auto_op_channels.end();
+}

--- a/Library/TeamTalkLib/teamtalk/server/ServerChannel.h
+++ b/Library/TeamTalkLib/teamtalk/server/ServerChannel.h
@@ -45,6 +45,7 @@ namespace teamtalk {
         void UpdateChannelBans();
         void SetOwner(const ServerUser& user);
         bool IsOwner(const ServerUser& user) const;
+        bool IsAutoOperator(const ServerUser& user) const;
     private:
         void Init();
         // userid -> last transmit time


### PR DESCRIPTION
Also kick/ban from non-participating channels.

Fixes #1496 