### PR TITLE
Revert to deprecated kIOMasterPortDefault instead of kIOMainPortDefault

### DIFF
--- a/Client/qtTeamTalk/common.cpp
+++ b/Client/qtTeamTalk/common.cpp
@@ -301,7 +301,7 @@ bool isComputerIdle(int idle_secs)
 {
     int64_t os_idle_secs = 0;
     io_iterator_t iter = 0;
-    if (IOServiceGetMatchingServices(kIOMainPortDefault,
+    if (IOServiceGetMatchingServices(kIOMasterPortDefault,
                                      IOServiceMatching("IOHIDSystem"), 
                                      &iter) == KERN_SUCCESS)
     {


### PR DESCRIPTION
Otherwise crashes on macOS 11.7. Fixes #1503 