### PR TITLE
Shortcut keys in 'Online Users' dialog

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -24,6 +24,7 @@ Default Qt Client
 - Status bar and TTS event when changing subscription
 - Checkboxes in "User Accounts" dialog replaced by tree view
 - New profile now starts with blank settings
+- Added keyboard shortcuts to "Online Users" dialog on macOS and Windows (Qt 6.4)
 - Fixed request to create folder for channel and private histories if none is specified in "Store conversation" dialog
 - Fixed username/password not being applied in "Generate .tt File" dialog
 Android Client

--- a/Client/qtTeamTalk/onlineusersdlg.h
+++ b/Client/qtTeamTalk/onlineusersdlg.h
@@ -61,6 +61,17 @@ protected:
 
 private:
     void slotTreeContextMenu(const QPoint&);
+    enum MenuAction
+    {
+        VIEW_USERINFORMATION,
+        SEND_TEXTMESSAGE,
+        OP,
+        KICK,
+        BAN,
+        MOVE
+    };
+
+    void menuAction(MenuAction ma);
     void slotUpdateSettings();
 
 private:


### PR DESCRIPTION
@CoBC I don't know if you already tried this but I'm trying to make shortcut keys work in "Online Users" dialog.

With the changes in this merge request it's possible to do operations with shortcuts. However, shortcut will only work if no user is selected in the main-window (i.e. menu items in "Users" are disabled). Any idea how to get around this?