### PR TITLE
Rename "Cancel" button to "Close" on text message dialog

### DIFF
--- a/Client/qtTeamTalk/textmessage.ui
+++ b/Client/qtTeamTalk/textmessage.ui
@@ -133,7 +133,7 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>&amp;Cancel</string>
+        <string>&amp;Close</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
I think "Close" is more logic than "Cancel" in this dialog because we don't really cancel anything, but we close text message window using this button.