### PR TITLE
Don't focus text message window automatically at all

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -10,7 +10,7 @@ Default Qt Client
 - Sound event when intercepted
 - TTS events when enabled/disabled voice activation and Push-To-Talk
 - Fix user text message sent and channel message sent sound not reset when changing sounds pack
-- Text message window is only focused if main window has focus when receiving a private message
+- Text message window is not automatically focused anymore
 - Fix missing label for "Media files RX/TX" on "Server statistics" dialog
 - Fix "Channel silent" sound event played out of channel
 Accessible Windows Client

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -2841,8 +2841,6 @@ void MainWindow::processTextMessage(const MyTextMessage& textmsg)
             if(dlg)
             {
                 dlg->show();
-                if (this->isActiveWindow())
-                    dlg->activateWindow();
                 dlg->raise();
             }
         }


### PR DESCRIPTION
Focusing this window automatically can cause accessibility issue.
If user write a public message and receive a private one, the end of the message will be sent to the private conversation.
