### PR TITLE
Inherit maximum users in temporary channels from server properties

### DIFF
--- a/Library/TeamTalkLib/teamtalk/server/ServerUser.cpp
+++ b/Library/TeamTalkLib/teamtalk/server/ServerUser.cpp
@@ -649,6 +649,7 @@ ErrorMsg ServerUser::HandleJoinChannel(const mstrings_t& properties)
 
     //set default settings
     chanprop.diskquota = srvprop.diskquota;
+    chanprop.maxusers = srvprop.maxusers;
 
     return m_servernode.UserJoinChannel(GetUserID(), chanprop);
 }


### PR DESCRIPTION
In the same way as disk quota.