### PR TITLE
Don't close sound devices on disconnect

### DIFF
--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -1957,14 +1957,6 @@ void MainWindow::Disconnect()
 {
     TT_Disconnect(ttInst);
 
-    if(TT_GetFlags(ttInst) & CLIENT_SNDINOUTPUT_DUPLEX)
-        TT_CloseSoundDuplexDevices(ttInst);
-    else
-    {
-        TT_CloseSoundInputDevice(ttInst);
-        TT_CloseSoundOutputDevice(ttInst);
-    }
-
     // sync user settings to cache
     auto users = ui.channelsWidget->getUsers();
     for (int uid : users)


### PR DESCRIPTION
Doing so will prevent sound events from being played after disconnect when using one-by-one or overlapped (using TeamTalk sound device).

This fixes #1650 