### PR TITLE
Remove <property name="locale"> it becomes AnyTerritory in Qt Creator

### DIFF
--- a/Client/qtTeamTalk/about.ui
+++ b/Client/qtTeamTalk/about.ui
@@ -13,9 +13,6 @@
   <property name="windowTitle">
    <string>About</string>
   </property>
-  <property name="locale">
-   <locale language="C" country="AnyCountry"/>
-  </property>
   <layout class="QHBoxLayout" name="horizontalLayout_2">
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">

--- a/Client/qtTeamTalk/bannedusers.ui
+++ b/Client/qtTeamTalk/bannedusers.ui
@@ -13,9 +13,6 @@
   <property name="windowTitle">
    <string>Banned Users</string>
   </property>
-  <property name="locale">
-   <locale language="C" country="AnyCountry"/>
-  </property>
   <property name="sizeGripEnabled">
    <bool>true</bool>
   </property>

--- a/Client/qtTeamTalk/channel.ui
+++ b/Client/qtTeamTalk/channel.ui
@@ -13,9 +13,6 @@
   <property name="windowTitle">
    <string>Channel</string>
   </property>
-  <property name="locale">
-   <locale language="C" country="AnyCountry"/>
-  </property>
   <property name="modal">
    <bool>true</bool>
   </property>

--- a/Client/qtTeamTalk/filetransfer.ui
+++ b/Client/qtTeamTalk/filetransfer.ui
@@ -13,9 +13,6 @@
   <property name="windowTitle">
    <string>File Transfer</string>
   </property>
-  <property name="locale">
-   <locale language="C" country="AnyCountry"/>
-  </property>
   <property name="sizeGripEnabled">
    <bool>true</bool>
   </property>

--- a/Client/qtTeamTalk/keycomp.ui
+++ b/Client/qtTeamTalk/keycomp.ui
@@ -19,9 +19,6 @@
   <property name="windowTitle">
    <string>Key Combination</string>
   </property>
-  <property name="locale">
-   <locale language="C" country="AnyCountry"/>
-  </property>
   <property name="modal">
    <bool>true</bool>
   </property>

--- a/Client/qtTeamTalk/mainwindow.ui
+++ b/Client/qtTeamTalk/mainwindow.ui
@@ -16,9 +16,6 @@
   <property name="windowTitle">
    <string notr="true"/>
   </property>
-  <property name="locale">
-   <locale language="C" country="AnyCountry"/>
-  </property>
   <property name="animated">
    <bool>false</bool>
   </property>

--- a/Client/qtTeamTalk/preferences.ui
+++ b/Client/qtTeamTalk/preferences.ui
@@ -13,9 +13,6 @@
   <property name="windowTitle">
    <string>Preferences</string>
   </property>
-  <property name="locale">
-   <locale language="C" country="AnyCountry"/>
-  </property>
   <property name="sizeGripEnabled">
    <bool>true</bool>
   </property>

--- a/Client/qtTeamTalk/serverlist.ui
+++ b/Client/qtTeamTalk/serverlist.ui
@@ -13,9 +13,6 @@
   <property name="windowTitle">
    <string>Connect to a Server</string>
   </property>
-  <property name="locale">
-   <locale language="C" country="AnyCountry"/>
-  </property>
   <property name="sizeGripEnabled">
    <bool>true</bool>
   </property>

--- a/Client/qtTeamTalk/serverproperties.ui
+++ b/Client/qtTeamTalk/serverproperties.ui
@@ -13,9 +13,6 @@
   <property name="windowTitle">
    <string>Server Properties</string>
   </property>
-  <property name="locale">
-   <locale language="C" country="AnyCountry"/>
-  </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <item>
     <layout class="QVBoxLayout" name="verticalLayout_3">

--- a/Client/qtTeamTalk/textmessage.ui
+++ b/Client/qtTeamTalk/textmessage.ui
@@ -13,9 +13,6 @@
   <property name="windowTitle">
    <string>Messages</string>
   </property>
-  <property name="locale">
-   <locale language="C" country="AnyCountry"/>
-  </property>
   <property name="sizeGripEnabled">
    <bool>true</bool>
   </property>

--- a/Client/qtTeamTalk/userdesktop.ui
+++ b/Client/qtTeamTalk/userdesktop.ui
@@ -13,9 +13,6 @@
   <property name="windowTitle">
    <string>Desktop</string>
   </property>
-  <property name="locale">
-   <locale language="C" country="AnyCountry"/>
-  </property>
   <property name="sizeGripEnabled">
    <bool>true</bool>
   </property>

--- a/Client/qtTeamTalk/userinfo.ui
+++ b/Client/qtTeamTalk/userinfo.ui
@@ -13,9 +13,6 @@
   <property name="windowTitle">
    <string>User Information</string>
   </property>
-  <property name="locale">
-   <locale language="C" country="AnyCountry"/>
-  </property>
   <layout class="QFormLayout" name="formLayout">
    <item row="0" column="0">
     <widget class="QLabel" name="label">

--- a/Client/qtTeamTalk/uservideo.ui
+++ b/Client/qtTeamTalk/uservideo.ui
@@ -13,9 +13,6 @@
   <property name="windowTitle">
    <string>Video</string>
   </property>
-  <property name="locale">
-   <locale language="C" country="AnyCountry"/>
-  </property>
   <property name="sizeGripEnabled">
    <bool>true</bool>
   </property>

--- a/Client/qtTeamTalk/uservolume.ui
+++ b/Client/qtTeamTalk/uservolume.ui
@@ -13,9 +13,6 @@
   <property name="windowTitle">
    <string>Volume</string>
   </property>
-  <property name="locale">
-   <locale language="C" country="AnyCountry"/>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <widget class="QGroupBox" name="groupBox_2">


### PR DESCRIPTION
AnyTerritory is incompatible with Qt 5 so the property should never be set.