### PR TITLE
Prevent file upload outside own channel (unless admin)

### DIFF
--- a/Library/TeamTalkLib/teamtalk/server/ServerNode.cpp
+++ b/Library/TeamTalkLib/teamtalk/server/ServerNode.cpp
@@ -4086,6 +4086,9 @@ ErrorMsg ServerNode::UserRegFileTransfer(FileTransfer& transfer)
     if (!chan)
         return ErrorMsg(TT_CMDERR_CHANNEL_NOT_FOUND);
 
+    if (!chan->UserExists(user->GetUserID()) && (user->GetUserType() & USERTYPE_ADMIN) == 0)
+        return ErrorMsg(TT_CMDERR_NOT_AUTHORIZED);
+
     if(transfer.inbound)
     {
         if((user->GetUserRights() & USERRIGHT_UPLOAD_FILES) == 0)


### PR DESCRIPTION
Limit file upload to users of the channel or admins (since they're the only ones who can see the file afterwards).