### PR TITLE
Default BUILD_TEAMTALK_CORE to ON

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Build TeamTalk 5 Java Tests
       working-directory: ${{runner.workspace}}
       run: |
-        cmake -S ${{runner.workspace}}/TeamTalk5 -B build-host
+        cmake -S ${{runner.workspace}}/TeamTalk5 -B build-host -DBUILD_TEAMTALK_CORE=OFF
         cmake --build build-host --target TeamTalk5Test
         cmake --build build-host --target TeamTalk5ProTest
         cmake --build build-host --target TeamTalk5SrvTest

--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -94,7 +94,6 @@ jobs:
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
       run: >-
            cmake $GITHUB_WORKSPACE -G Ninja
-           -DBUILD_TEAMTALK_CORE=ON
            -DCATCH_UNITTEST=ON
            -DFEATURE_PORTAUDIO=OFF
            -DFEATURE_V4L2=OFF

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -73,7 +73,6 @@ jobs:
       shell: cmd
       run: >-
         cmake -S TeamTalk5 -B output -A ${{ matrix.cmakeplatform }}
-        -DBUILD_TEAMTALK_CORE=ON
         -DCATCH_UNITTEST=ON
         -DFEATURE_LIBVPX=OFF
         -DFEATURE_WEBRTC=OFF

--- a/Build/Makefile
+++ b/Build/Makefile
@@ -24,7 +24,7 @@ android-build:
 	@echo "Testing if ANDROID_NDK_HOME environment variable is set: $(ANDROID_NDK_HOME)"
 	test -n "$(ANDROID_NDK_HOME)"
 	$(MAKE) CONFIGTYPE=$(CONFIGTYPE) \
-	CMAKE_EXTRA+="-DCMAKE_TOOLCHAIN_FILE=$(ANDROID_NDK_HOME)/build/cmake/android.toolchain.cmake -DANDROID_ABI=$(ANDROID_ABI) -DANDROID_PLATFORM=android-21 -DBUILD_TEAMTALK_CORE=ON -DBUILD_TEAMTALK_LIB=ON -DBUILD_TEAMTALK_PROLIB=ON -DBUILD_TEAMTALK_LIBRARIES=ON -DBUILD_TEAMTALK_CLIENTS=OFF -DBUILD_TEAMTALK_SERVERS=OFF -DBUILD_TEAMTALK_SRVEXE=OFF -DBUILD_TEAMTALK_PROSRVEXE=OFF -DTOOLCHAIN_ZLIB=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON" buildlib
+	CMAKE_EXTRA+="-DCMAKE_TOOLCHAIN_FILE=$(ANDROID_NDK_HOME)/build/cmake/android.toolchain.cmake -DANDROID_ABI=$(ANDROID_ABI) -DANDROID_PLATFORM=android-21 -DBUILD_TEAMTALK_LIB=ON -DBUILD_TEAMTALK_PROLIB=ON -DBUILD_TEAMTALK_LIBRARIES=ON -DBUILD_TEAMTALK_CLIENTS=OFF -DBUILD_TEAMTALK_SERVERS=OFF -DBUILD_TEAMTALK_SRVEXE=OFF -DBUILD_TEAMTALK_PROSRVEXE=OFF -DTOOLCHAIN_ZLIB=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON" buildlib
 
 android-armeabi-v7a: teamtalk-env
 	$(MAKE) ANDROID_ABI=armeabi-v7a BUILDDIR=build-$@ android-build
@@ -41,7 +41,7 @@ android-x64: teamtalk-env
 android-all: android-armeabi-v7a android-arm64-v8a android-x86 android-x64
 
 generic:
-	$(MAKE) CMAKE_EXTRA+="-DBUILD_TEAMTALK_CORE=ON" buildlib
+	$(MAKE) buildlib
 
 deb32:
 	$(MAKE) BUILDDIR=build-$@ CMAKE_EXTRA+="-DTOOLCHAIN_OPENSSL=OFF" generic
@@ -72,7 +72,6 @@ centos7:
                               -DBUILD_TEAMTALK_LIBRARIES=OFF \
                               -DBUILD_TEAMTALK_SERVERS=OFF \
                               -DBUILD_TEAMTALK_CLIENTS=OFF \
-                              -DBUILD_TEAMTALK_CORE=ON \
                               -DSTATICCPP=OFF \
                               -DTOOLCHAIN_OPENSSL=OFF \
                               -DTOOLCHAIN_ZLIB=OFF \
@@ -94,7 +93,7 @@ mac:
 	$(MAKE) BUILDDIR=build-$@ CMAKE_EXTRA+="-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 -DCMAKE_OSX_ARCHITECTURES=\"arm64;x86_64\"" generic
 
 ios-build:
-	$(MAKE) CMAKE_EXTRA+="-DCMAKE_SYSTEM_NAME=iOS -DBUILD_TEAMTALK_CORE=ON -DBUILD_TEAMTALK_LIB=ON -DBUILD_TEAMTALK_PROLIB=ON -DBUILD_TEAMTALK_DLL=OFF -DBUILD_TEAMTALK_PRODLL=OFF -DFEATURE_OGG=OFF -DFEATURE_FFMPEG=OFF -DFEATURE_OPUSTOOLS=OFF -DBUILD_TEAMTALK_LIBRARIES=OFF -DBUILD_TEAMTALK_CLIENTS=OFF -DBUILD_TEAMTALK_SERVERS=OFF -DBUILD_TEAMTALK_SRVEXE=OFF -DBUILD_TEAMTALK_PROSRVEXE=OFF -DTOOLCHAIN_ZLIB=OFF" buildlib
+	$(MAKE) CMAKE_EXTRA+="-DCMAKE_SYSTEM_NAME=iOS -DBUILD_TEAMTALK_LIB=ON -DBUILD_TEAMTALK_PROLIB=ON -DBUILD_TEAMTALK_DLL=OFF -DBUILD_TEAMTALK_PRODLL=OFF -DFEATURE_OGG=OFF -DFEATURE_FFMPEG=OFF -DFEATURE_OPUSTOOLS=OFF -DBUILD_TEAMTALK_LIBRARIES=OFF -DBUILD_TEAMTALK_CLIENTS=OFF -DBUILD_TEAMTALK_SERVERS=OFF -DBUILD_TEAMTALK_SRVEXE=OFF -DBUILD_TEAMTALK_PROSRVEXE=OFF -DTOOLCHAIN_ZLIB=OFF" buildlib
 
 IOS_INSTALL_DIR?=$(PWD)/ios-install
 
@@ -166,7 +165,7 @@ xcodeswap-apps:
 teamtalk-jar:
 	$(MAKE) BUILDDIR=build-$@ CMAKE_EXTRA+="-DBUILD_TEAMTALK_CLIENTS=OFF -DBUILD_TEAMTALK_SERVERS=OFF -DBUILD_TEAMTALK_JNI=OFF -DBUILD_TEAMTALK_PROJNI=OFF -DBUILD_TEAMTALK_DOTNETDLL=OFF -DBUILD_TEAMTALK_PRODOTNETDLL=OFF -DBUILD_TEAMTALK_DOTNETDLL=OFF -DBUILD_TEAMTALK_PRODOTNETDLL=OFF" buildlib
 
-# TeamTalk 5 dependencies for Ubuntu 18 when using CMake option -DBUILD_TEAMTALK_CORE=ON
+# TeamTalk 5 dependencies for Ubuntu 18
 depend-ubuntu18:
 # Duplicate install in Docker/Dockerfile_ubuntu18
 	apt install qt5-default libqt5x11extras5-dev qtmultimedia5-dev \
@@ -195,13 +194,13 @@ depend-ubuntu22:
 depend-ubuntu18-android:
 	apt install doxygen ninja-build junit4 cmake openjdk-11-jdk junit4 autoconf libtool pkg-config python
 
-# TeamTalk 5 dependencies Debian 9 when using CMake option -DBUILD_TEAMTALK_CORE=ON
+# TeamTalk 5 dependencies for Debian 9
 depend-debian9:
 	apt install qt5-default qtbase5-dev libqt5x11extras5-dev qtmultimedia5-dev \
                     doxygen g++ openjdk-8-jdk \
                     qttools5-dev-tools ninja-build libpcap-dev junit4 cmake
 
-# TeamTalk 5 dependencies for Raspbian 10 Buster when using CMake option -DBUILD_TEAMTALK_CORE=ON
+# TeamTalk 5 dependencies for Raspbian 10 Buster
 depend-rasp10:
 	apt install qt5-default libqt5x11extras5-dev qtmultimedia5-dev \
                     libqt5texttospeech5-dev qttools5-dev-tools qttools5-dev doxygen \
@@ -209,7 +208,7 @@ depend-rasp10:
                     libssl-dev autoconf libtool pkg-config \
                     libasound2-dev wget python
 
-# TeamTalk 5 dependencies for Raspbian 11 Bullseye when using CMake option -DBUILD_TEAMTALK_CORE=ON
+# TeamTalk 5 dependencies for Raspbian 11 Bullseye
 depend-rasp11:
 	apt install qtbase5-dev libqt5x11extras5-dev qtmultimedia5-dev \
                     libqt5texttospeech5-dev qttools5-dev-tools qttools5-dev doxygen \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,12 @@ project (TeamTalk5SDK)
 #
 # Now configure an output directory, i.e. build-win32 for TeamTalk5
 # repository:
-# $ cmake -S TeamTalk5 -B teamtalk-win32 -DBUILD_TEAMTALK_CORE=ON -A Win32
+# $ cmake -S TeamTalk5 -B teamtalk-win32 -A Win32
 #
 # Afterwards build configured projects:
 # $ cmake --build teamtalk-win32
 
-option (BUILD_TEAMTALK_CORE "Build TeamTalk core library" OFF)
+option (BUILD_TEAMTALK_CORE "Build TeamTalk core library" ON)
 option (BUILD_TEAMTALK_LIBRARIES "Build TeamTalk libraries" ON)
 option (BUILD_TEAMTALK_CLIENTS "Build TeamTalk client examples" ON)
 option (BUILD_TEAMTALK_SERVERS "Build TeamTalk server examples" ON)

--- a/Library/TeamTalkLib/README.md
+++ b/Library/TeamTalkLib/README.md
@@ -115,7 +115,7 @@ Prompt for VS 2019*. Use Git to clone
 Use CMake to generate a valid build configuration in `C:\builddir`
 that will install binaries into `C:\installdir`:
 
-`cmake -DBUILD_TEAMTALK_CORE=ON -DCMAKE_INSTALL_PREFIX=C:/installdir -S C:/TeamTalk5 -B C:/builddir -A Win32`
+`cmake -DCMAKE_INSTALL_PREFIX=C:/installdir -S C:/TeamTalk5 -B C:/builddir -A Win32`
 
 Given that CMake managed to create a valid build configuration now
 start the build process:
@@ -125,7 +125,7 @@ start the build process:
 To get a Visual Studio solution file for building TeamTalk from Visual
 Studio 2019 run CMake like this:
 
-`cmake -G "Visual Studio 16 2019" -DBUILD_TEAMTALK_CORE=ON -S C:/TeamTalk5 -B C:/builddir -A Win32`
+`cmake -G "Visual Studio 16 2019" -S C:/TeamTalk5 -B C:/builddir -A Win32`
 
 Note that WebRTC dependency will create a folder in `C:\webrtc` where
 it downloads its repository.
@@ -176,7 +176,7 @@ can be activated using the CMake options prefixed `TOOLCHAIN_`.
 To e.g. have TeamTalk avoid building OPUS and instead use OPUS
 already installed on the host machine, call CMake like this:
 
-`cmake -DTOOLCHAIN_OPUS=OFF -DBUILD_TEAMTALK_CORE=ON -S TeamTalk5 -B builddir`
+`cmake -DTOOLCHAIN_OPUS=OFF -S TeamTalk5 -B builddir`
 
 The following toolchain toggles are available:
 
@@ -252,7 +252,7 @@ What features to build into the TeamTalk binaries are controlled by
 CMake options prefixed by `FEATURE_`.
 
 To e.g. have TeamTalk built without OPUS support invoke CMake like this:
-`cmake -DFEATURE_OPUS=OFF -DBUILD_TEAMTALK_CORE=ON -S TeamTalk5 -B builddir`
+`cmake -DFEATURE_OPUS=OFF -S TeamTalk5 -B builddir`
 
 The following feature toggles are available:
 


### PR DESCRIPTION
Only when using downloaded TeamTalk SDK the BUILD_TEAMTALK_CORE should be OFF.