### PR TITLE
Implement some moderation function to TeamTalkPy

### DIFF
--- a/Library/TeamTalkPy/TeamTalk5.py
+++ b/Library/TeamTalkPy/TeamTalk5.py
@@ -1372,8 +1372,23 @@ class TeamTalk(object):
     def doTextMessage(self, msg: TextMessage) -> int:
         return _DoTextMessage(self._tt, msg)
 
+    def doChannelOp(self, nUserID: int, nChannelID: int, bMakeOperator: bool) -> int:
+        return _DoChannelOp(self._tt, nUserID, nChannelID, bMakeOperator)
+
     def doKickUser(self, nUserID: int, nChannelID: int) -> int:
         return _DoKickUser(self._tt, nUserID, nChannelID)
+
+    def doMoveUser(self, nUserID: int, nChannelID: int) -> int:
+        return _DoMoveUser(self._tt, nUserID, nChannelID)
+
+    def doBanUser(self, nUserID: int, nChannelID: int) -> int:
+        return _DoBanUser(self._tt, nUserID, nChannelID)
+
+    def doBanIPAddress(self, szIPAddress, nChannelID: int) -> int:
+        return _DoBanIPAddress(self._tt, szIPAddress, nChannelID)
+
+    def doUnBanUser(self, szIPAddress, nChannelID: int) -> int:
+        return _DoUnBanUser(self._tt, szIPAddress, nChannelID)
 
     def getServerProperties(self) -> ServerProperties:
         srvprops = ServerProperties()

--- a/Library/TeamTalkPy/TeamTalk5.py
+++ b/Library/TeamTalkPy/TeamTalk5.py
@@ -1375,6 +1375,9 @@ class TeamTalk(object):
     def doChannelOp(self, nUserID: int, nChannelID: int, bMakeOperator: bool) -> int:
         return _DoChannelOp(self._tt, nUserID, nChannelID, bMakeOperator)
 
+    def doChannelOpEx(self, nUserID: int, nChannelID: int, szOpPassword, bMakeOperator: bool):
+        return _DoChannelOpEx(self._tt, nUserID, nChannelID, szOpPassword, bMakeOperator)
+
     def doKickUser(self, nUserID: int, nChannelID: int) -> int:
         return _DoKickUser(self._tt, nUserID, nChannelID)
 
@@ -1384,11 +1387,20 @@ class TeamTalk(object):
     def doBanUser(self, nUserID: int, nChannelID: int) -> int:
         return _DoBanUser(self._tt, nUserID, nChannelID)
 
+    def doBanUserEx(self, nUserID: int, uBanTypes: BanType) -> int:
+        return _DoBanUserEx(self._tt, nUserID, uBanTypes)
+
+    def doBan(self, lpBannedUser: BannedUser) -> int:
+        return _DoBan(self._tt, lpBannedUser)
+
     def doBanIPAddress(self, szIPAddress, nChannelID: int) -> int:
         return _DoBanIPAddress(self._tt, szIPAddress, nChannelID)
 
     def doUnBanUser(self, szIPAddress, nChannelID: int) -> int:
         return _DoUnBanUser(self._tt, szIPAddress, nChannelID)
+
+    def doUnbanUserEx(self, lpBannedUser: BannedUser) -> int:
+        return _DoUnBanUserEx(self._tt, lpBannedUser)
 
     def getServerProperties(self) -> ServerProperties:
         srvprops = ServerProperties()


### PR DESCRIPTION
Implement the following methods to TeamTalkPy:
* doChannelOp
* doMoveUser
* doBanUser
* doBanIPAddress
* doUnBanUser

Some asked function in #1781 are in this PR, by @lbk2907 and @yukie-nobuharu
@DalisonCPU as you did not reply, I managed to implement DoMoveUser.
