### PR TITLE
Use TT_STRLEN-1 instead of 512 in buildTextMessage for TeamTalkPy

### DIFF
--- a/Library/TeamTalkPy/TeamTalk5.py
+++ b/Library/TeamTalkPy/TeamTalk5.py
@@ -1245,8 +1245,8 @@ def buildTextMessage(content: str, nMsgType: TextMsgType,
         textmsg.szFromUsername = ttstr(szFromUsername)
         textmsg.nToUserID = nToUserID
         textmsg.nChannelID = nChannelID
-        textmsg.szMessage = converted_content[0:512]
-        converted_content = converted_content[512:]
+        textmsg.szMessage = converted_content[0:TT_STRLEN-1]
+        converted_content = converted_content[TT_STRLEN-1:]
         textmsg.bMore = len(converted_content) > 0
         result.append(textmsg)
 


### PR DESCRIPTION
The same logic is applied in qTeamTalk and avoid the last character of first messages to be removed when building a long message which will be sent in multiple parts.
Also use the `TT_STRLEN` constent instead of hard-coding the value.
