### PR TITLE
Add onInternalError to TeamTalkPy

### DIFF
--- a/Library/TeamTalkPy/TeamTalk5.py
+++ b/Library/TeamTalkPy/TeamTalk5.py
@@ -1325,6 +1325,8 @@ class TeamTalk(object):
             self.onBannedUser(msg.banneduser)
         if event == ClientEvent.CLIENTEVENT_CMD_SERVERSTATISTICS:
             self.onServerStatistics(msg.serverstatistics)
+        if event == ClientEvent.CLIENTEVENT_INTERNAL_ERROR:
+            self.onInternalError(msg.clienterrormsg)
 
     def getMessage(self, nWaitMS: int = -1):
         msg = TTMessage()
@@ -1675,4 +1677,7 @@ class TeamTalk(object):
         pass
 
     def onServerStatistics(self, serverstatistics: ServerStatistics):
+        pass
+
+    def onInternalError(self, clienterrormsg: ClientErrorMsg):
         pass


### PR DESCRIPTION
Called when client event is CLIENTEVENT_INTERNAL_ERROR
