### PR TITLE
Change std::regex construction to buildregex()

### DIFF
--- a/Library/TeamTalkLib/bin/ttsrv/ServerConfig.cpp
+++ b/Library/TeamTalkLib/bin/ttsrv/ServerConfig.cpp
@@ -103,12 +103,7 @@ void RemoveFacebookLogins(teamtalk::ServerXML& xmlSettings)
         UserAccount ua;
         while (xmlSettings.GetNextUser(index, ua))
         {
-            bool fbpostfix;
-#if defined(UNICODE)
-            fbpostfix = std::regex_search(ua.username.c_str(), std::wregex(ACE_TEXT("@facebook.com")));
-#else
-            fbpostfix = std::regex_search(ua.username.c_str(), std::regex("@facebook.com"));
-#endif
+            bool fbpostfix = std::regex_search(ua.username.c_str(), buildregex(ACE_TEXT("@facebook.com")));
             if (ua.username == ACE_TEXT("facebook") || fbpostfix)
             {
                 fbfound = true;
@@ -838,13 +833,8 @@ bool HasBearWareWebLogin(teamtalk::ServerXML& xmlSettings)
             return true;
 
         const ACE_TString BWREGEX = ACE_TEXT(WEBLOGIN_BEARWARE_POSTFIX) + ACE_TString(ACE_TEXT("$"));
-#if defined(UNICODE)
-        if (std::regex_search(ua.username.c_str(), std::wregex(BWREGEX.c_str())))
+        if (std::regex_search(ua.username.c_str(), buildregex(BWREGEX.c_str())))
             return true;
-#else
-        if (std::regex_search(ua.username.c_str(), std::regex(BWREGEX.c_str())))
-            return true;
-#endif
     }
     return false;
 }

--- a/Library/TeamTalkLib/mystd/MyStd.cpp
+++ b/Library/TeamTalkLib/mystd/MyStd.cpp
@@ -111,6 +111,33 @@ stdstrings_t stdtokenize(const string& source, const string& delimeters)
     return tokens; 
 }
 
+#if defined(UNICODE)
+std::wregex buildregex(const std::wstring& regexstr)
+{
+    try
+    {
+        return std::wregex(regexstr);
+    }
+    catch (const std::regex_error& )
+    {
+        return std::wregex();
+    }
+}
+#else
+std::regex buildregex(const std::string& regexstr)
+{
+    try
+    {
+        return std::regex(regexstr);
+    }
+    catch (const std::regex_error& )
+    {
+        return std::regex();
+    }
+}
+#endif
+
+
 uint32_t GETTIMESTAMP()
 {
     using namespace std::chrono;

--- a/Library/TeamTalkLib/mystd/MyStd.h
+++ b/Library/TeamTalkLib/mystd/MyStd.h
@@ -25,6 +25,7 @@
 #define MYSTD_H
 
 #include <string>
+#include <regex>
 #include <vector>
 
 #if !defined(_MSC_VER)
@@ -45,6 +46,12 @@ std::string str2lower(const std::string& str);
 
 bool strcmpnocase(const std::string& str1, const std::string& str2);
 stdstrings_t stdtokenize(const std::string& source, const std::string& delimeters);
+
+#if defined(UNICODE)
+std::wregex buildregex(const std::wstring& regexstr);
+#else
+std::regex buildregex(const std::string& regexstr);
+#endif
 
 uint32_t GETTIMESTAMP();
 

--- a/Library/TeamTalkLib/teamtalk/Common.cpp
+++ b/Library/TeamTalkLib/teamtalk/Common.cpp
@@ -49,11 +49,7 @@ namespace teamtalk
     {
 #if defined(ENABLE_TEAMTALKPRO)
         ACE_TString bwregex = ACE_TEXT(WEBLOGIN_BEARWARE_POSTFIX) + ACE_TString(ACE_TEXT("$"));
-#if defined(UNICODE)
-        return std::regex_search(username.c_str(), std::wregex(bwregex.c_str()));
-#else
-        return std::regex_search(username.c_str(), std::regex(bwregex.c_str()));
-#endif
+        return std::regex_search(username.c_str(), buildregex(bwregex.c_str()));
 #else
         return false;
 #endif

--- a/Library/TeamTalkLib/teamtalk/Common.h
+++ b/Library/TeamTalkLib/teamtalk/Common.h
@@ -309,13 +309,7 @@ namespace teamtalk {
             if((bantype & BANTYPE_IPADDR) && ipaddr.length())
             {
                 ACE_TString rgx = ACE_TEXT("^") + ipaddr + ACE_TEXT("$");
-#if defined(UNICODE)
-                match &= std::regex_search(user.ipaddr.c_str(), std::wregex(rgx.c_str()));
-#else
-                // equality not nescessary when debian7 is no longer supported
-                match &= std::regex_search(user.ipaddr.c_str(), std::regex(rgx.c_str())) ||
-                    user.ipaddr == ipaddr;
-#endif
+                match &= std::regex_search(user.ipaddr.c_str(), buildregex(rgx.c_str()));
             }
             if((bantype & BANTYPE_USERNAME))
                 match &= username == user.username;


### PR DESCRIPTION
This prevents std::regex_error exception on invalid regex