### PR TITLE
Add Makefile to ttsamplepy

### DIFF
--- a/Client/ttsamplepy/Makefile
+++ b/Client/ttsamplepy/Makefile
@@ -1,0 +1,2 @@
+all:
+	python3 ttsample.py


### PR DESCRIPTION
There is no makefile for ttsamplepy.
This PR adds one to have the same as other example.