### PR TITLE
It is now possible to send tts-messages as Accessibility announcements

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/TTSWrapper.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/TTSWrapper.java
@@ -28,7 +28,8 @@ import android.media.AudioAttributes;
 import android.os.Build;
 import android.speech.tts.TextToSpeech;
 import android.speech.tts.TextToSpeech.EngineInfo;
-
+import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityManager;
 import java.util.Collections;
 import java.util.List;
 
@@ -37,6 +38,7 @@ public class TTSWrapper {
     private static TextToSpeech tts;
     public static final String defaultEngineName = "com.google.android.tts"; // should be got from getDefaultEngine method.
     private Context mContext;
+    public Boolean useAnnouncements;
     private String mCurrentEngineName = defaultEngineName;
 
     public TTSWrapper(Context context) {
@@ -62,7 +64,17 @@ public class TTSWrapper {
     }
 
     public void speak(String text) {
+        if (this.useAnnouncements) {
+            AccessibilityManager manager = (AccessibilityManager) mContext.getSystemService(Context.ACCESSIBILITY_SERVICE);
+            if (manager.isEnabled()) {
+                AccessibilityEvent e = AccessibilityEvent.obtain();
+                e.setEventType(AccessibilityEvent.TYPE_ANNOUNCEMENT);
+                e.getText().add(text);
+                manager.sendAccessibilityEvent(e);
+            }
+        } else {
             tts.speak(text, TextToSpeech.QUEUE_ADD, null, null);
+        }
     }
 
     public static List<EngineInfo> getEngines() {

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -484,6 +484,7 @@ implements TeamTalkConnectionListener,
         getWindow().getDecorView().setKeepScreenOn(prefs.getBoolean("keep_screen_on_checkbox", false));
 
         createStatusTimer();
+        ttsWrapper.useAnnouncements = prefs.getBoolean("pref_use_announcements", false);
         ttsWrapper.setAccessibilityStream(prefs.getBoolean("pref_a11y_volume", false));
         ttsWrapper.switchEngine(prefs.getString("pref_speech_engine", TTSWrapper.defaultEngineName));
     }

--- a/Client/TeamTalkAndroid/src/main/res/values/strings.xml
+++ b/Client/TeamTalkAndroid/src/main/res/values/strings.xml
@@ -85,6 +85,8 @@
     <string name="pref_summary_speech_engine">Select one of the installed speech engines, different from system settings</string>
     <string name="pref_title_a11y_volume">Use accessibility volume stream</string>
     <string name="pref_summary_a11y_volume">Text to speech messages will be played through accessibility volume stream</string>
+    <string name="pref_title_use_announcements">Use announcement event</string>
+    <string name="pref_summary_use_announcements">Text-to-speech messages will be announced through currently running accessibility service</string>
     <string name="pref_title_server_login">User logs on the server</string>
     <string name="pref_summary_server_login">Announce name of user logging in</string>
     <string name="pref_title_server_logout">User logs out of the server</string>

--- a/Client/TeamTalkAndroid/src/main/res/xml/pref_tts.xml
+++ b/Client/TeamTalkAndroid/src/main/res/xml/pref_tts.xml
@@ -16,6 +16,12 @@
         android:summary="@string/pref_summary_a11y_volume"
         android:title="@string/pref_title_a11y_volume" />
 
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="pref_use_announcements"
+        android:summary="@string/pref_summary_use_announcements"
+        android:title="@string/pref_title_use_announcements" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
which will be cought and spoken by running accessibility service

Needs to be tested.
In my testing, while speaking, it may skip some events.
Don't know how to resolve it yet.