### PR TITLE
Separate event callback for each ClientEvent

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/DesktopAdapter.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/DesktopAdapter.java
@@ -33,6 +33,7 @@ import dk.bearware.MediaFileInfo;
 import dk.bearware.User;
 import dk.bearware.UserState;
 import dk.bearware.backend.TeamTalkService;
+import dk.bearware.events.ClientEventListener;
 import dk.bearware.events.UserListener;
 import dk.bearware.gui.Utils;
 import android.content.Context;
@@ -41,7 +42,7 @@ import android.view.LayoutInflater;
 
 public class DesktopAdapter
 extends MediaAdapter
-implements UserListener
+implements ClientEventListener.OnUserDesktopWindowListener
 {
     public static final String TAG = "bearware";
 
@@ -54,7 +55,7 @@ implements UserListener
     
     public void setTeamTalkService(TeamTalkService service) {
         super.setTeamTalkService(service);
-        service.registerUserListener(this);
+        service.getEventHandler().registerOnUserDesktopWindow(this, true);
 
         Vector<User> vecusers = Utils.getUsers(ttservice.getUsers());
         for(User user : vecusers) {
@@ -65,7 +66,7 @@ implements UserListener
     
     public void clearTeamTalkService(TeamTalkService service) {
         super.clearTeamTalkService(service);
-        service.unregisterUserListener(this);
+        service.getEventHandler().unregisterListener(this);
     }
     
     public Bitmap extractUserBitmap(int userid, Bitmap prev_bmp) {
@@ -91,35 +92,9 @@ implements UserListener
     }
 
     @Override
-    public void onUserStateChange(User user) {
-        
-//        this.updateUserStreamState(user, UserState.USERSTATE_DESKTOP);
-    }
-
-    @Override
-    public void onUserVideoCapture(int nUserID, int nStreamID) {
-    }
-
-    @Override
-    public void onUserMediaFileVideo(int nUserID, int nStreamID) {
-    }
-
-    @Override
     public void onUserDesktopWindow(int nUserID, int nStreamID) {
         //only update if user is expanded (bitmap is being displayed)
         if(media_sessions.indexOfKey(nUserID) >= 0)
             updateUserBitmap(nUserID);
-    }
-    
-    @Override
-    public void onUserDesktopCursor(int nUserID, DesktopInput desktopinput) {
-    }
-
-    @Override
-    public void onUserRecordMediaFile(int nUserID, MediaFileInfo mediafileinfo) {
-    }
-
-    @Override
-    public void onUserAudioBlock(int nUserID, int nStreamType) {
     }
 }

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/FileListAdapter.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/FileListAdapter.java
@@ -23,28 +23,6 @@
 
 package dk.bearware.data;
 
-import java.io.File;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Vector;
-
-import dk.bearware.AudioInputProgress;
-import dk.bearware.Channel;
-import dk.bearware.ClientErrorMsg;
-import dk.bearware.FileTransfer;
-import dk.bearware.FileTransferStatus;
-import dk.bearware.MediaFileInfo;
-import dk.bearware.RemoteFile;
-import dk.bearware.SoundDevice;
-import dk.bearware.TeamTalkBase;
-import dk.bearware.backend.TeamTalkService;
-import dk.bearware.events.ClientListener;
-import dk.bearware.gui.AccessibilityAssistant;
-import dk.bearware.gui.R;
-import dk.bearware.gui.Utils;
-
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -65,9 +43,27 @@ import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import java.io.File;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Vector;
+
+import dk.bearware.Channel;
+import dk.bearware.FileTransfer;
+import dk.bearware.FileTransferStatus;
+import dk.bearware.RemoteFile;
+import dk.bearware.TeamTalkBase;
+import dk.bearware.backend.TeamTalkService;
+import dk.bearware.events.ClientEventListener;
+import dk.bearware.gui.AccessibilityAssistant;
+import dk.bearware.gui.R;
+import dk.bearware.gui.Utils;
+
 public class FileListAdapter
 extends BaseAdapter
-implements ClientListener, Comparator<RemoteFile> {
+implements Comparator<RemoteFile>, ClientEventListener.OnFileTransferListener {
 
     private static final int REMOTE_FILE_VIEW_TYPE = 0,
         FILE_TRANSFER_VIEW_TYPE = 1,
@@ -135,10 +131,10 @@ implements ClientListener, Comparator<RemoteFile> {
         downloads.clear();
         uploads.clear();
         if (ttService != null)
-            ttService.unregisterClientListener(this);
+            ttService.getEventHandler().unregisterListener(this);
         if (service != null) {
             ttClient = service.getTTInstance();
-            service.registerClientListener(this);
+            service.getEventHandler().registerOnFileTransfer(this, true);
         }
         ttService = service;
     }
@@ -342,68 +338,6 @@ implements ClientListener, Comparator<RemoteFile> {
         convertView.setAccessibilityDelegate(accessibilityAssistant);
         return convertView;
     }
-
-    @Override
-    public void onLocalMediaFile(MediaFileInfo mediaFileInfo) {
-
-    }
-
-    @Override
-    public void onAudioInput(AudioInputProgress audioInputProgress, int i) {
-
-    }
-
-    @Override
-    public void onSoundDeviceAdded(SoundDevice soundDevice) {
-
-    }
-
-    @Override
-    public void onSoundDeviceRemoved(SoundDevice soundDevice) {
-
-    }
-
-    @Override
-    public void onSoundDeviceUnplugged(SoundDevice soundDevice) {
-
-    }
-
-    @Override
-    public void onSoundDeviceNewDefaultInput(SoundDevice soundDevice) {
-
-    }
-
-    @Override
-    public void onSoundDeviceNewDefaultOutput(SoundDevice soundDevice) {
-
-    }
-
-    @Override
-    public void onSoundDeviceNewDefaultInputComDevice(SoundDevice soundDevice) {
-
-    }
-
-    @Override
-    public void onSoundDeviceNewDefaultOutputComDevice(SoundDevice soundDevice) {
-
-    }
-
-    @Override
-    public void onInternalError(ClientErrorMsg clienterrormsg) {
-    }
-
-    @Override
-    public void onVoiceActivation(boolean bVoiceActive) {
-    }
-
-    @Override
-    public void onHotKeyToggle(int nHotKeyID, boolean bActive) {
-    }
-
-    @Override
-    public void onHotKeyTest(int nVkCode, boolean bActive) {
-    }
-
     @SuppressLint("NewApi") @SuppressWarnings("fallthrough")
     @Override
     public void onFileTransfer(FileTransfer transfer) {
@@ -494,15 +428,6 @@ implements ClientListener, Comparator<RemoteFile> {
             }
         }
     }
-
-    @Override
-    public void onDesktopWindowTransfer(int nSessionID, int nTransferRemaining) {
-    }
-
-    @Override
-    public void onStreamMediaFile(MediaFileInfo mediafileinfo) {
-    }
-
 
     @Override
     public int compare(RemoteFile f1, RemoteFile f2) {

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/MediaAdapter.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/MediaAdapter.java
@@ -23,21 +23,6 @@
 
 package dk.bearware.data;
 
-import java.nio.ByteBuffer;
-import java.util.LinkedList;
-import java.util.Vector;
-
-import dk.bearware.BitmapFormat;
-import dk.bearware.DesktopInput;
-import dk.bearware.DesktopWindow;
-import dk.bearware.MediaFileInfo;
-import dk.bearware.User;
-import dk.bearware.UserState;
-import dk.bearware.VideoFrame;
-import dk.bearware.backend.TeamTalkService;
-import dk.bearware.events.UserListener;
-import dk.bearware.gui.R;
-import dk.bearware.gui.Utils;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.os.AsyncTask;
@@ -50,9 +35,26 @@ import android.widget.BaseExpandableListAdapter;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import java.nio.ByteBuffer;
+import java.util.LinkedList;
+import java.util.Vector;
+
+import dk.bearware.BitmapFormat;
+import dk.bearware.DesktopWindow;
+import dk.bearware.User;
+import dk.bearware.UserState;
+import dk.bearware.VideoFrame;
+import dk.bearware.backend.TeamTalkService;
+import dk.bearware.events.ClientEventListener;
+import dk.bearware.gui.R;
+import dk.bearware.gui.Utils;
+
 public class MediaAdapter
 extends BaseExpandableListAdapter
-implements UserListener {
+implements ClientEventListener.OnUserStateChangeListener,
+ClientEventListener.OnUserVideoCaptureListener,
+ClientEventListener.OnUserMediaFileVideoListener,
+ClientEventListener.OnUserDesktopWindowListener {
 	
     public static final String TAG = "bearware";
 
@@ -78,9 +80,12 @@ implements UserListener {
         display_users.clear();
         media_sessions.clear();
         ttservice = service;
-        
-        service.registerUserListener(this);
-        
+
+        service.getEventHandler().registerOnUserStateChange(this, true);
+        service.getEventHandler().registerOnUserVideoCapture(this, true);
+        service.getEventHandler().registerOnUserMediaFileVideo(this, true);
+        service.getEventHandler().registerOnUserDesktopWindow(this, true);
+
         Vector<User> vecusers = Utils.getUsers(ttservice.getUsers());
         for(User user : vecusers) {
             if((user.uUserState & UserState.USERSTATE_DESKTOP) == UserState.USERSTATE_DESKTOP)
@@ -95,6 +100,8 @@ implements UserListener {
     public void clearTeamTalkService(TeamTalkService service) {
         display_users.clear();
         media_sessions.clear();
+
+        service.getEventHandler().unregisterListener(this);
         
         synchronized (updatequeue) {
             updatequeue.clear();
@@ -467,27 +474,5 @@ implements UserListener {
         if(media_sessions.indexOfKey(session_id) >= 0)
             updateUserBitmap(session_id);
 	}
-
-	@Override
-	public void onUserDesktopCursor(int nUserID, DesktopInput desktopinput) {
-	}
-
-    @Override
-    public void onUserDesktopInput(int i, DesktopInput desktopInput) {
-
-    }
-
-    @Override
-	public void onUserRecordMediaFile(int nUserID, MediaFileInfo mediafileinfo) {
-	}
-
-	@Override
-	public void onUserAudioBlock(int nUserID, int nStreamType) {
-	}
-
-    @Override
-    public void onUserFirstVoiceStreamPacket(User user, int i) {
-
-    }
 
 }

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/MediaFileVideoAdapter.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/MediaFileVideoAdapter.java
@@ -32,6 +32,7 @@ import dk.bearware.User;
 import dk.bearware.UserState;
 import dk.bearware.VideoFrame;
 import dk.bearware.backend.TeamTalkService;
+import dk.bearware.events.ClientEventListener;
 import dk.bearware.events.UserListener;
 import dk.bearware.gui.Utils;
 import android.content.Context;
@@ -39,7 +40,7 @@ import android.graphics.Bitmap;
 import android.util.Log;
 
 public class MediaFileVideoAdapter extends MediaAdapter 
-implements UserListener {
+implements ClientEventListener.OnUserStateChangeListener, ClientEventListener.OnUserMediaFileVideoListener{
 
     public static final String TAG = "bearware";
 
@@ -50,7 +51,8 @@ implements UserListener {
     public void setTeamTalkService(TeamTalkService service) {
         super.setTeamTalkService(service);
         
-        service.registerUserListener(this);
+        service.getEventHandler().registerOnUserStateChange(this, true);
+        service.getEventHandler().registerOnUserMediaFileVideo(this, true);
 
         Vector<User> vecusers = Utils.getUsers(ttservice.getUsers());
         for(User user : vecusers) {
@@ -61,7 +63,7 @@ implements UserListener {
     
     public void clearTeamTalkService(TeamTalkService service) {
         super.clearTeamTalkService(service);
-        service.unregisterUserListener(this);
+        service.getEventHandler().unregisterListener(this);
     }
 
     @Override
@@ -96,10 +98,6 @@ implements UserListener {
     }
 
     @Override
-    public void onUserVideoCapture(int nUserID, int nStreamID) {
-    }
-
-    @Override
     public void onUserMediaFileVideo(int nUserID, int nStreamID) {
         //only update if user is expanded (bitmap is being displayed)
         if(media_sessions.indexOfKey(nUserID) >= 0)
@@ -107,21 +105,4 @@ implements UserListener {
         
         Log.d(TAG, "#" + nUserID + " video stream " + nStreamID);
     }
-
-    @Override
-    public void onUserDesktopWindow(int nUserID, int nStreamID) {
-    }
-
-    @Override
-    public void onUserDesktopCursor(int nUserID, DesktopInput desktopinput) {
-    }
-
-    @Override
-    public void onUserRecordMediaFile(int nUserID, MediaFileInfo mediafileinfo) {
-    }
-
-    @Override
-    public void onUserAudioBlock(int nUserID, int nStreamType) {
-    }
-
 }

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/WebcamAdapter.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/WebcamAdapter.java
@@ -32,13 +32,14 @@ import dk.bearware.User;
 import dk.bearware.UserState;
 import dk.bearware.VideoFrame;
 import dk.bearware.backend.TeamTalkService;
+import dk.bearware.events.ClientEventListener;
 import dk.bearware.events.UserListener;
 import dk.bearware.gui.Utils;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.view.LayoutInflater;
 
-public class WebcamAdapter extends MediaAdapter implements UserListener {
+public class WebcamAdapter extends MediaAdapter implements ClientEventListener.OnUserVideoCaptureListener {
 
     public static final String TAG = "bearware";
 
@@ -52,7 +53,7 @@ public class WebcamAdapter extends MediaAdapter implements UserListener {
     public void setTeamTalkService(TeamTalkService service) {
         super.setTeamTalkService(service);
 
-        service.registerUserListener(this);
+        service.getEventHandler().registerOnUserVideoCapture(this, true);
 
         Vector<User> vecusers = Utils.getUsers(service.getUsers());
         for(User user : vecusers) {
@@ -63,7 +64,7 @@ public class WebcamAdapter extends MediaAdapter implements UserListener {
 
     public void clearTeamTalkService(TeamTalkService service) {
         super.clearTeamTalkService(service);
-        service.unregisterUserListener(this);
+        service.getEventHandler().unregisterListener(this);
     }
 
     @Override
@@ -89,35 +90,10 @@ public class WebcamAdapter extends MediaAdapter implements UserListener {
     }
 
     @Override
-    public void onUserStateChange(User user) {
-//        this.updateUserStreamState(user, UserState.USERSTATE_VIDEOCAPTURE);
-    }
-
-    @Override
     public void onUserVideoCapture(int nUserID, int nStreamID) {
 //        Log.d(TAG, "New webcam frame from #" + nUserID + " stream " + nStreamID + " " + Integer.toHexString(this.hashCode()));
         // only update if user is expanded (bitmap is being displayed)
         if (media_sessions.indexOfKey(nUserID) >= 0)
             updateUserBitmap(nUserID);
-    }
-
-    @Override
-    public void onUserMediaFileVideo(int nUserID, int nStreamID) {
-    }
-
-    @Override
-    public void onUserDesktopWindow(int nUserID, int nStreamID) {
-    }
-
-    @Override
-    public void onUserDesktopCursor(int nUserID, DesktopInput desktopinput) {
-    }
-
-    @Override
-    public void onUserRecordMediaFile(int nUserID, MediaFileInfo mediafileinfo) {
-    }
-
-    @Override
-    public void onUserAudioBlock(int nUserID, int nStreamType) {
     }
 }

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ChannelPropActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ChannelPropActivity.java
@@ -36,6 +36,7 @@ import dk.bearware.UserAccount;
 import dk.bearware.backend.TeamTalkConnection;
 import dk.bearware.backend.TeamTalkConnectionListener;
 import dk.bearware.backend.TeamTalkService;
+import dk.bearware.events.ClientEventListener;
 import dk.bearware.events.CommandListener;
 import android.content.Context;
 import android.content.Intent;
@@ -52,7 +53,7 @@ import android.widget.Toast;
 
 public class ChannelPropActivity
 extends AppCompatActivity
-implements TeamTalkConnectionListener, CommandListener {
+implements TeamTalkConnectionListener, ClientEventListener.OnCmdErrorListener, ClientEventListener.OnCmdSuccessListener {
 
     public static final String TAG = "bearware";
 
@@ -244,7 +245,8 @@ implements TeamTalkConnectionListener, CommandListener {
         ttservice = service;
         ttclient = ttservice.getTTInstance();
 
-        service.registerCommandListener(ChannelPropActivity.this);
+        service.getEventHandler().registerOnCmdError(this, true);
+        service.getEventHandler().registerOnCmdSuccess(this, true);
 
         if (channel == null) {
             int channelid = getIntent().getExtras().getInt(EXTRA_CHANNELID);
@@ -285,7 +287,7 @@ implements TeamTalkConnectionListener, CommandListener {
 
     @Override
     public void onServiceDisconnected(TeamTalkService service) {
-        service.unregisterCommandListener(ChannelPropActivity.this);            
+        service.getEventHandler().unregisterListener(this);
     }
 
     int updateCmdId = 0;
@@ -301,91 +303,5 @@ implements TeamTalkConnectionListener, CommandListener {
     public void onCmdSuccess(int cmdId) {
         setResult(RESULT_OK);
         finish();
-    }
-
-    @Override
-    public void onCmdProcessing(int cmdId, boolean complete) {
-    }
-
-    @Override
-    public void onCmdMyselfLoggedIn(int my_userid, UserAccount useraccount) {
-    }
-
-    @Override
-    public void onCmdMyselfLoggedOut() {
-    }
-
-    @Override
-    public void onCmdMyselfKickedFromChannel() {
-    }
-
-    @Override
-    public void onCmdMyselfKickedFromChannel(User kicker) {
-    }
-
-    @Override
-    public void onCmdUserLoggedIn(User user) {
-    }
-
-    @Override
-    public void onCmdUserLoggedOut(User user) {
-    }
-
-    @Override
-    public void onCmdUserUpdate(User user) {
-    }
-
-    @Override
-    public void onCmdUserJoinedChannel(User user) {
-    }
-
-    @Override
-    public void onCmdUserLeftChannel(int channelid, User user) {
-    }
-
-    @Override
-    public void onCmdUserTextMessage(TextMessage textmessage) {
-    }
-
-    @Override
-    public void onCmdChannelNew(Channel channel) {
-    }
-
-    @Override
-    public void onCmdChannelUpdate(Channel channel) {
-    }
-
-    @Override
-    public void onCmdChannelRemove(Channel channel) {
-    }
-
-    @Override
-    public void onCmdServerUpdate(ServerProperties serverproperties) {
-    }
-
-    @Override
-    public void onCmdFileNew(RemoteFile remotefile) {
-    }
-
-    @Override
-    public void onCmdFileRemove(RemoteFile remotefile) {
-    }
-
-    @Override
-    public void onCmdUserAccount(UserAccount useraccount) {
-    }
-
-    @Override
-    public void onCmdBannedUser(BannedUser banneduser) {
-    }
-
-    @Override
-    public void onCmdUserAccountNew(UserAccount userAccount) {
-
-    }
-
-    @Override
-    public void onCmdUserAccountRemove(UserAccount userAccount) {
-
     }
 }

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerEntryActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerEntryActivity.java
@@ -42,25 +42,20 @@ import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceScreen;
 
-import dk.bearware.BannedUser;
-import dk.bearware.Channel;
-import dk.bearware.ClientErrorMsg;
-import dk.bearware.RemoteFile;
-import dk.bearware.ServerProperties;
 import dk.bearware.TeamTalkBase;
-import dk.bearware.TextMessage;
-import dk.bearware.User;
 import dk.bearware.UserAccount;
 import dk.bearware.backend.TeamTalkConnection;
 import dk.bearware.backend.TeamTalkConnectionListener;
 import dk.bearware.backend.TeamTalkService;
 import dk.bearware.data.AppInfo;
 import dk.bearware.data.ServerEntry;
-import dk.bearware.events.CommandListener;
+import dk.bearware.events.ClientEventListener;
 
 public class ServerEntryActivity
 extends AppCompatActivity
-implements OnPreferenceChangeListener, TeamTalkConnectionListener, CommandListener {
+implements OnPreferenceChangeListener,
+        TeamTalkConnectionListener,
+        ClientEventListener.OnCmdMyselfLoggedInListener {
 
     public static final String TAG = "bearware";
 
@@ -113,7 +108,7 @@ implements OnPreferenceChangeListener, TeamTalkConnectionListener, CommandListen
             ttservice.resetState();
             ttclient.closeSoundInputDevice();
             ttclient.closeSoundOutputDevice();
-            ttservice.registerCommandListener(this);
+            ttservice.getEventHandler().registerOnCmdMyselfLoggedIn(this, true);
         }
     }
 
@@ -121,7 +116,7 @@ implements OnPreferenceChangeListener, TeamTalkConnectionListener, CommandListen
     protected void onPause() {
         super.onPause();
         if (mConnection.isBound())
-            ttservice.unregisterCommandListener(this);
+            ttservice.getEventHandler().registerOnCmdMyselfLoggedIn(this, false);
     }
 
     @Override
@@ -309,24 +304,12 @@ implements OnPreferenceChangeListener, TeamTalkConnectionListener, CommandListen
     public void onServiceConnected(TeamTalkService service) {
         ttservice = service;
         ttclient = service.getTTInstance();
-        service.registerCommandListener(this);
+        service.getEventHandler().registerOnCmdMyselfLoggedIn(this, true);
     }
 
     @Override
     public void onServiceDisconnected(TeamTalkService service) {
-        service.unregisterCommandListener(this);
-    }
-
-    @Override
-    public void onCmdError(int cmdId, ClientErrorMsg errmsg) {
-    }
-
-    @Override
-    public void onCmdSuccess(int cmdId) {
-    }
-
-    @Override
-    public void onCmdProcessing(int cmdId, boolean complete) {
+        service.getEventHandler().unregisterListener(this);
     }
 
     @Override
@@ -334,85 +317,6 @@ implements OnPreferenceChangeListener, TeamTalkConnectionListener, CommandListen
         Intent intent = new Intent(getBaseContext(), MainActivity.class);
         startActivity(intent.putExtra(ServerEntry.KEY_SERVERNAME, serverentry.servername));
     }
-
-    @Override
-    public void onCmdMyselfLoggedOut() {
-    }
-
-    @Override
-    public void onCmdMyselfKickedFromChannel() {
-    }
-
-    @Override
-    public void onCmdMyselfKickedFromChannel(User kicker) {
-    }
-
-    @Override
-    public void onCmdUserLoggedIn(User user) {
-    }
-
-    @Override
-    public void onCmdUserLoggedOut(User user) {
-    }
-
-    @Override
-    public void onCmdUserUpdate(User user) {
-    }
-
-    @Override
-    public void onCmdUserJoinedChannel(User user) {
-    }
-
-    @Override
-    public void onCmdUserLeftChannel(int channelid, User user) {
-    }
-
-    @Override
-    public void onCmdUserTextMessage(TextMessage textmessage) {
-    }
-
-    @Override
-    public void onCmdChannelNew(Channel channel) {
-    }
-
-    @Override
-    public void onCmdChannelUpdate(Channel channel) {
-    }
-
-    @Override
-    public void onCmdChannelRemove(Channel channel) {
-    }
-
-    @Override
-    public void onCmdServerUpdate(ServerProperties serverproperties) {
-    }
-
-    @Override
-    public void onCmdFileNew(RemoteFile remotefile) {
-    }
-
-    @Override
-    public void onCmdFileRemove(RemoteFile remotefile) {
-    }
-
-    @Override
-    public void onCmdUserAccount(UserAccount useraccount) {
-    }
-
-    @Override
-    public void onCmdBannedUser(BannedUser banneduser) {
-    }
-
-    @Override
-    public void onCmdUserAccountNew(UserAccount userAccount) {
-
-    }
-
-    @Override
-    public void onCmdUserAccountRemove(UserAccount userAccount) {
-
-    }
-
 
     private Preference findPreference(CharSequence key) {
         return ((PreferenceFragmentCompat) getSupportFragmentManager().findFragmentById(android.R.id.content)).findPreference(key);

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerListActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerListActivity.java
@@ -66,15 +66,8 @@ import java.util.Vector;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
-import dk.bearware.BannedUser;
-import dk.bearware.Channel;
-import dk.bearware.ClientErrorMsg;
 import dk.bearware.Constants;
-import dk.bearware.RemoteFile;
-import dk.bearware.ServerProperties;
 import dk.bearware.TeamTalkBase;
-import dk.bearware.TextMessage;
-import dk.bearware.User;
 import dk.bearware.UserAccount;
 import dk.bearware.backend.TeamTalkConnection;
 import dk.bearware.backend.TeamTalkConnectionListener;
@@ -83,11 +76,15 @@ import dk.bearware.data.AppInfo;
 import dk.bearware.data.Permissions;
 import dk.bearware.data.Preferences;
 import dk.bearware.data.ServerEntry;
-import dk.bearware.events.CommandListener;
+import dk.bearware.events.ClientEventListener;
 
 public class ServerListActivity
 extends AppCompatActivity
-implements AdapterView.OnItemClickListener, AdapterView.OnItemLongClickListener, TeamTalkConnectionListener, CommandListener, Comparator<ServerEntry> {
+        implements AdapterView.OnItemClickListener,
+        AdapterView.OnItemLongClickListener,
+        TeamTalkConnectionListener,
+        Comparator<ServerEntry>,
+        ClientEventListener.OnCmdMyselfLoggedInListener {
 
     TeamTalkConnection mConnection;
     TeamTalkService ttservice;
@@ -128,7 +125,7 @@ implements AdapterView.OnItemClickListener, AdapterView.OnItemLongClickListener,
             ttservice.resetState();
             ttclient.closeSoundInputDevice();
             ttclient.closeSoundOutputDevice();
-            ttservice.registerCommandListener(this);
+            ttservice.getEventHandler().registerOnCmdMyselfLoggedIn(this, true);
 
             // Connect to server if 'serverentry' is specified.
             // Connection to server is either started here or in onServiceConnected()
@@ -154,7 +151,7 @@ implements AdapterView.OnItemClickListener, AdapterView.OnItemLongClickListener,
     protected void onPause() {
         super.onPause();
         if (mConnection.isBound())
-            ttservice.unregisterCommandListener(this);
+            ttservice.getEventHandler().unregisterListener(this);
     }
 
 
@@ -651,7 +648,7 @@ implements AdapterView.OnItemClickListener, AdapterView.OnItemLongClickListener,
         ttservice = service;
         ttclient = service.getTTInstance();
 
-        service.registerCommandListener(this);
+        service.getEventHandler().registerOnCmdMyselfLoggedIn(this, true);
 
         // Connect to server if 'serverentry' is specified.
         // Connection to server is either started here or in onResume()
@@ -676,20 +673,9 @@ implements AdapterView.OnItemClickListener, AdapterView.OnItemLongClickListener,
 
     @Override
     public void onServiceDisconnected(TeamTalkService service) {
-        service.unregisterCommandListener(this);
+        service.getEventHandler().unregisterListener(this);
     }
 
-    @Override
-    public void onCmdError(int cmdId, ClientErrorMsg errmsg) {
-    }
-
-    @Override
-    public void onCmdSuccess(int cmdId) {
-    }
-
-    @Override
-    public void onCmdProcessing(int cmdId, boolean complete) {
-    }
 
     @Override
     public void onCmdMyselfLoggedIn(int my_userid, UserAccount useraccount) {
@@ -699,84 +685,6 @@ implements AdapterView.OnItemClickListener, AdapterView.OnItemLongClickListener,
 
             serverentry = null;
         }
-    }
-
-    @Override
-    public void onCmdMyselfLoggedOut() {
-    }
-
-    @Override
-    public void onCmdMyselfKickedFromChannel() {
-    }
-
-    @Override
-    public void onCmdMyselfKickedFromChannel(User kicker) {
-    }
-
-    @Override
-    public void onCmdUserLoggedIn(User user) {
-    }
-
-    @Override
-    public void onCmdUserLoggedOut(User user) {
-    }
-
-    @Override
-    public void onCmdUserUpdate(User user) {
-    }
-
-    @Override
-    public void onCmdUserJoinedChannel(User user) {
-    }
-
-    @Override
-    public void onCmdUserLeftChannel(int channelid, User user) {
-    }
-
-    @Override
-    public void onCmdUserTextMessage(TextMessage textmessage) {
-    }
-
-    @Override
-    public void onCmdChannelNew(Channel channel) {
-    }
-
-    @Override
-    public void onCmdChannelUpdate(Channel channel) {
-    }
-
-    @Override
-    public void onCmdChannelRemove(Channel channel) {
-    }
-
-    @Override
-    public void onCmdServerUpdate(ServerProperties serverproperties) {
-    }
-
-    @Override
-    public void onCmdFileNew(RemoteFile remotefile) {
-    }
-
-    @Override
-    public void onCmdFileRemove(RemoteFile remotefile) {
-    }
-
-    @Override
-    public void onCmdUserAccount(UserAccount useraccount) {
-    }
-
-    @Override
-    public void onCmdBannedUser(BannedUser banneduser) {
-    }
-
-    @Override
-    public void onCmdUserAccountNew(UserAccount userAccount) {
-
-    }
-
-    @Override
-    public void onCmdUserAccountRemove(UserAccount userAccount) {
-
     }
 
     @Override

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/TextMessageActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/TextMessageActivity.java
@@ -36,25 +36,19 @@ import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
-import dk.bearware.BannedUser;
-import dk.bearware.Channel;
-import dk.bearware.ClientErrorMsg;
-import dk.bearware.RemoteFile;
-import dk.bearware.ServerProperties;
 import dk.bearware.TeamTalkBase;
 import dk.bearware.TextMessage;
 import dk.bearware.TextMsgType;
 import dk.bearware.User;
-import dk.bearware.UserAccount;
 import dk.bearware.backend.TeamTalkConnection;
 import dk.bearware.backend.TeamTalkConnectionListener;
 import dk.bearware.backend.TeamTalkService;
 import dk.bearware.data.MyTextMessage;
 import dk.bearware.data.TextMessageAdapter;
-import dk.bearware.events.CommandListener;
+import dk.bearware.events.ClientEventListener;
 
 public class TextMessageActivity
-extends AppCompatActivity implements TeamTalkConnectionListener, CommandListener {
+extends AppCompatActivity implements TeamTalkConnectionListener, ClientEventListener.OnCmdUserTextMessageListener {
 
     public static final String TAG = "bearware";
     
@@ -171,11 +165,16 @@ extends AppCompatActivity implements TeamTalkConnectionListener, CommandListener
             }
         });
         
-        service.registerCommandListener(this);
+        service.getEventHandler().registerOnCmdUserTextMessage(this, true);
         
         updateTitle();
     }
-    
+
+    @Override
+    public void onServiceDisconnected(TeamTalkService service) {
+        service.getEventHandler().registerOnCmdUserTextMessage(this, false);
+    }
+
     void updateTitle() {
         String title = getResources().getString(R.string.title_activity_text_message);
         int userid = this.getIntent().getExtras().getInt(EXTRA_USERID);
@@ -188,109 +187,13 @@ extends AppCompatActivity implements TeamTalkConnectionListener, CommandListener
     }
 
     @Override
-    public void onServiceDisconnected(TeamTalkService service) {
-        service.unregisterCommandListener(this);
-    }
-
-    @Override
-    public void onCmdError(int cmdId, ClientErrorMsg errmsg) {
-    }
-
-    @Override
-    public void onCmdSuccess(int cmdId) {
-    }
-
-    @Override
-    public void onCmdProcessing(int cmdId, boolean complete) {
-    }
-
-    @Override
-    public void onCmdMyselfLoggedIn(int my_userid, UserAccount useraccount) {
-    }
-
-    @Override
-    public void onCmdMyselfLoggedOut() {
-    }
-
-    @Override
-    public void onCmdMyselfKickedFromChannel() {
-    }
-
-    @Override
-    public void onCmdMyselfKickedFromChannel(User kicker) {
-    }
-
-    @Override
-    public void onCmdUserLoggedIn(User user) {
-    }
-
-    @Override
-    public void onCmdUserLoggedOut(User user) {
-    }
-
-    @Override
-    public void onCmdUserUpdate(User user) {
-        updateTitle();
-    }
-
-    @Override
-    public void onCmdUserJoinedChannel(User user) {
-    }
-
-    @Override
-    public void onCmdUserLeftChannel(int channelid, User user) {
-    }
-
-    @Override
     public void onCmdUserTextMessage(TextMessage textmessage) {
-        int userid = this.getIntent().getExtras().getInt(EXTRA_USERID);
+        int userid = TextMessageActivity.this.getIntent().getExtras().getInt(EXTRA_USERID);
         if(adapter != null && textmessage.nFromUserID == userid &&
-           textmessage.nMsgType == TextMsgType.MSGTYPE_USER) {
+                textmessage.nMsgType == TextMsgType.MSGTYPE_USER) {
             accessibilityAssistant.lockEvents();
             adapter.notifyDataSetChanged();
             accessibilityAssistant.unlockEvents();
         }
-    }
-
-    @Override
-    public void onCmdChannelNew(Channel channel) {
-    }
-
-    @Override
-    public void onCmdChannelUpdate(Channel channel) {
-    }
-
-    @Override
-    public void onCmdChannelRemove(Channel channel) {
-    }
-
-    @Override
-    public void onCmdServerUpdate(ServerProperties serverproperties) {
-    }
-
-    @Override
-    public void onCmdFileNew(RemoteFile remotefile) {
-    }
-
-    @Override
-    public void onCmdFileRemove(RemoteFile remotefile) {
-    }
-
-    @Override
-    public void onCmdUserAccount(UserAccount useraccount) {
-    }
-
-    @Override
-    public void onCmdBannedUser(BannedUser banneduser) {
-    }
-
-    @Override
-    public void onCmdUserAccountNew(UserAccount userAccount) {
-
-    }
-
-    @Override
-    public void onCmdUserAccountRemove(UserAccount userAccount) {
-
     }
 }

--- a/Library/TeamTalkJNI/CMakeLists.txt
+++ b/Library/TeamTalkJNI/CMakeLists.txt
@@ -148,6 +148,7 @@ if (Java_FOUND)
     src/dk/bearware/events/ClientListener.java
     src/dk/bearware/events/CommandListener.java
     src/dk/bearware/events/ConnectionListener.java
+    src/dk/bearware/events/ClientEventListener.java
     src/dk/bearware/events/TeamTalkEventHandler.java
     src/dk/bearware/events/UserListener.java
     src/dk/bearware/FileTransfer.java

--- a/Library/TeamTalkJNI/src/dk/bearware/events/ClientEventListener.java
+++ b/Library/TeamTalkJNI/src/dk/bearware/events/ClientEventListener.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2005-2018, BearWare.dk
+ *
+ * Contact Information:
+ *
+ * Bjoern D. Rasmussen
+ * Kirketoften 5
+ * DK-8260 Viby J
+ * Denmark
+ * Email: contact@bearware.dk
+ * Phone: +45 20 20 54 59
+ * Web: http://www.bearware.dk
+ *
+ * This source code is part of the TeamTalk SDK owned by
+ * BearWare.dk. Use of this file, or its compiled unit, requires a
+ * TeamTalk SDK License Key issued by BearWare.dk.
+ *
+ * The TeamTalk SDK License Agreement along with its Terms and
+ * Conditions are outlined in the file License.txt included with the
+ * TeamTalk SDK distribution.
+ *
+ */
+
+package dk.bearware.events;
+
+import dk.bearware.AudioInputProgress;
+import dk.bearware.BannedUser;
+import dk.bearware.Channel;
+import dk.bearware.ClientErrorMsg;
+import dk.bearware.DesktopInput;
+import dk.bearware.FileTransfer;
+import dk.bearware.MediaFileInfo;
+import dk.bearware.RemoteFile;
+import dk.bearware.ServerProperties;
+import dk.bearware.SoundDevice;
+import dk.bearware.TextMessage;
+import dk.bearware.User;
+import dk.bearware.UserAccount;
+
+public interface ClientEventListener {
+
+    interface OnConnectSuccessListener {
+        void onConnectSuccess();
+    }
+    interface OnEncryptionErrorListener {
+        void onEncryptionError(int opensslErrorNo, ClientErrorMsg errmsg);
+    }
+    interface OnConnectFailedListener {
+        void onConnectFailed();
+    }
+    interface OnConnectionLostListener {
+        void onConnectionLost();
+    }
+    interface OnMaxPayloadUpdateListener {
+        void onMaxPayloadUpdate(int payload_size);
+    }
+
+    interface OnCmdErrorListener {
+        void onCmdError(int cmdId, ClientErrorMsg errmsg);
+    }
+    interface OnCmdSuccessListener {
+        void onCmdSuccess(int cmdId);
+    }
+    interface OnCmdProcessingListener {
+        void onCmdProcessing(int cmdId, boolean complete);
+    }
+    interface OnCmdMyselfLoggedInListener {
+        void onCmdMyselfLoggedIn(int my_userid, UserAccount useraccount);
+    }
+    interface OnCmdMyselfLoggedOutListener {
+        void onCmdMyselfLoggedOut();
+    }
+    interface OnCmdMyselfKickedFromChannelListener {
+        void onCmdMyselfKickedFromChannel();
+        void onCmdMyselfKickedFromChannel(User kicker);
+    }
+    interface OnCmdUserLoggedInListener {
+        void onCmdUserLoggedIn(User user);
+    }
+    interface OnCmdUserLoggedOutListener {
+        void onCmdUserLoggedOut(User user);
+    }
+    interface OnCmdUserUpdateListener {
+        void onCmdUserUpdate(User user);
+    }
+    interface OnCmdUserJoinedChannelListener {
+        void onCmdUserJoinedChannel(User user);
+    }
+    interface OnCmdUserLeftChannelListener {
+        void onCmdUserLeftChannel(int channelid, User user);
+    }
+    interface OnCmdUserTextMessageListener {
+        void onCmdUserTextMessage(TextMessage textmessage);
+    }
+    interface OnCmdChannelNewListener {
+        void onCmdChannelNew(Channel channel);
+    }
+    interface OnCmdChannelUpdateListener {
+        void onCmdChannelUpdate(Channel channel);
+    }
+    interface OnCmdChannelRemoveListener {
+        void onCmdChannelRemove(Channel channel);
+    }
+    interface OnCmdServerUpdateListener {
+        void onCmdServerUpdate(ServerProperties serverproperties);
+    }
+    interface OnCmdFileNewListener {
+        void onCmdFileNew(RemoteFile remotefile);
+    }
+    interface OnCmdFileRemoveListener {
+        void onCmdFileRemove(RemoteFile remotefile);
+    }
+    interface OnCmdUserAccountListener {
+        void onCmdUserAccount(UserAccount useraccount);
+    }
+    interface OnCmdBannedUserListener {
+        void onCmdBannedUser(BannedUser banneduser);
+    }
+    interface OnCmdUserAccountNewListener {
+        void onCmdUserAccountNew(UserAccount useraccount);
+    }
+    interface OnCmdUserAccountRemoveListener {
+        void onCmdUserAccountRemove(UserAccount useraccount);
+    }
+
+    interface OnUserStateChangeListener {
+        void onUserStateChange(User user);
+    }
+    interface OnUserVideoCaptureListener {
+        void onUserVideoCapture(int nUserID, int nStreamID);
+    }
+    interface OnUserMediaFileVideoListener {
+        void onUserMediaFileVideo(int nUserID, int nStreamID);
+    }
+    interface OnUserDesktopWindowListener {
+        void onUserDesktopWindow(int nUserID, int nStreamID);
+    }
+    interface OnUserDesktopCursorListener {
+        void onUserDesktopCursor(int nUserID, DesktopInput desktopinput);
+    }
+    interface OnUserDesktopInputListener {
+        void onUserDesktopInput(int nUserID, DesktopInput desktopinput);
+    }
+    interface OnUserRecordMediaFileListener {
+        void onUserRecordMediaFile(int nUserID, MediaFileInfo mediafileinfo);
+    }
+    interface OnUserAudioBlockListener {
+        void onUserAudioBlock(int nUserID, int nStreamType);
+    }
+    interface OnUserFirstVoiceStreamPacketListener {
+        void onUserFirstVoiceStreamPacket(User user, int nStreamID);
+    }
+
+    interface OnInternalErrorListener {
+        void onInternalError(ClientErrorMsg clienterrormsg);
+    }
+    interface OnVoiceActivationListener {
+        void onVoiceActivation(boolean bVoiceActive);
+    }
+    interface OnHotKeyToggleListener {
+        void onHotKeyToggle(int nHotKeyID, boolean bActive);
+    }
+    interface OnHotKeyTestListener {
+        void onHotKeyTest(int nVkCode, boolean bActive);
+    }
+    interface OnFileTransferListener {
+        void onFileTransfer(FileTransfer filetransfer);
+    }
+    interface OnDesktopWindowTransferListener {
+        void onDesktopWindowTransfer(int nSessionID, int nTransferRemaining);
+    }
+    interface OnStreamMediaFileListener {
+        void onStreamMediaFile(MediaFileInfo mediafileinfo);
+    }
+    interface OnLocalMediaFileListener {
+        void onLocalMediaFile(MediaFileInfo mediafileinfo);
+    }
+    interface OnAudioInputListener {
+        void onAudioInput(AudioInputProgress aip, int nStreamID);
+    }
+    interface OnSoundDeviceAddedListener {
+        void onSoundDeviceAdded(SoundDevice sounddevice);
+    }
+    interface OnSoundDeviceRemovedListener {
+        void onSoundDeviceRemoved(SoundDevice sounddevice);
+    }
+    interface OnSoundDeviceUnpluggedListener {
+        void onSoundDeviceUnplugged(SoundDevice sounddevice);
+    }
+    interface OnSoundDeviceNewDefaultInputListener {
+        void onSoundDeviceNewDefaultInput(SoundDevice sounddevice);
+    }
+    interface OnSoundDeviceNewDefaultOutputListener {
+        void onSoundDeviceNewDefaultOutput(SoundDevice sounddevice);
+    }
+    interface OnSoundDeviceNewDefaultInputComDeviceListener {
+        void onSoundDeviceNewDefaultInputComDevice(SoundDevice sounddevice);
+    }
+    interface OnSoundDeviceNewDefaultOutputComDeviceListener {
+        void onSoundDeviceNewDefaultOutputComDevice(SoundDevice sounddevice);
+    }
+}

--- a/Library/TeamTalkJNI/src/dk/bearware/events/ClientListener.java
+++ b/Library/TeamTalkJNI/src/dk/bearware/events/ClientListener.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2018, BearWare.dk
- * 
+ *
  * Contact Information:
  *
  * Bjoern D. Rasmussen
@@ -23,28 +23,20 @@
 
 package dk.bearware.events;
 
-import dk.bearware.AudioInputProgress;
-import dk.bearware.ClientErrorMsg;
-import dk.bearware.FileTransfer;
-import dk.bearware.MediaFileInfo;
-import dk.bearware.SoundDevice;
-
-public interface ClientListener {
-
-    public void onInternalError(ClientErrorMsg clienterrormsg);
-    public void onVoiceActivation(boolean bVoiceActive);
-    public void onHotKeyToggle(int nHotKeyID, boolean bActive);
-    public void onHotKeyTest(int nVkCode, boolean bActive);
-    public void onFileTransfer(FileTransfer filetransfer);
-    public void onDesktopWindowTransfer(int nSessionID, int nTransferRemaining);
-    public void onStreamMediaFile(MediaFileInfo mediafileinfo);
-    public void onLocalMediaFile(MediaFileInfo mediafileinfo);
-    public void onAudioInput(AudioInputProgress aip, int nStreamID);
-    public void onSoundDeviceAdded(SoundDevice sounddevice);
-    public void onSoundDeviceRemoved(SoundDevice sounddevice);
-    public void onSoundDeviceUnplugged(SoundDevice sounddevice);
-    public void onSoundDeviceNewDefaultInput(SoundDevice sounddevice);
-    public void onSoundDeviceNewDefaultOutput(SoundDevice sounddevice);
-    public void onSoundDeviceNewDefaultInputComDevice(SoundDevice sounddevice);
-    public void onSoundDeviceNewDefaultOutputComDevice(SoundDevice sounddevice);
-}
+public interface ClientListener
+    extends ClientEventListener.OnInternalErrorListener
+    , ClientEventListener.OnVoiceActivationListener
+    , ClientEventListener.OnHotKeyToggleListener
+    , ClientEventListener.OnHotKeyTestListener
+    , ClientEventListener.OnFileTransferListener
+    , ClientEventListener.OnDesktopWindowTransferListener
+    , ClientEventListener.OnStreamMediaFileListener
+    , ClientEventListener.OnLocalMediaFileListener
+    , ClientEventListener.OnAudioInputListener
+    , ClientEventListener.OnSoundDeviceAddedListener
+    , ClientEventListener.OnSoundDeviceRemovedListener
+    , ClientEventListener.OnSoundDeviceUnpluggedListener
+    , ClientEventListener.OnSoundDeviceNewDefaultInputListener
+    , ClientEventListener.OnSoundDeviceNewDefaultOutputListener
+    , ClientEventListener.OnSoundDeviceNewDefaultInputComDeviceListener
+    , ClientEventListener.OnSoundDeviceNewDefaultOutputComDeviceListener {}

--- a/Library/TeamTalkJNI/src/dk/bearware/events/CommandListener.java
+++ b/Library/TeamTalkJNI/src/dk/bearware/events/CommandListener.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2018, BearWare.dk
- * 
+ *
  * Contact Information:
  *
  * Bjoern D. Rasmussen
@@ -23,47 +23,26 @@
 
 package dk.bearware.events;
 
-import dk.bearware.Channel;
-import dk.bearware.ClientErrorMsg;
-import dk.bearware.RemoteFile;
-import dk.bearware.ServerProperties;
-import dk.bearware.TextMessage;
-import dk.bearware.User;
-import dk.bearware.UserAccount;
-import dk.bearware.BannedUser;
-
-public interface CommandListener {
-
-    public void onCmdError(int cmdId, ClientErrorMsg errmsg);
-    public void onCmdSuccess(int cmdId);
-    public void onCmdProcessing(int cmdId, boolean complete);
-    
-    public void onCmdMyselfLoggedIn(int my_userid, UserAccount useraccount);
-    public void onCmdMyselfLoggedOut();
-    public void onCmdMyselfKickedFromChannel();
-    public void onCmdMyselfKickedFromChannel(User kicker);
-    
-    public void onCmdUserLoggedIn(User user);
-    public void onCmdUserLoggedOut(User user);
-    public void onCmdUserUpdate(User user);
-    
-    public void onCmdUserJoinedChannel(User user);
-    public void onCmdUserLeftChannel(int channelid, User user);
-    
-    public void onCmdUserTextMessage(TextMessage textmessage);
- 
-    public void onCmdChannelNew(Channel channel);
-    public void onCmdChannelUpdate(Channel channel);
-    public void onCmdChannelRemove(Channel channel);
-    
-    public void onCmdServerUpdate(ServerProperties serverproperties);
-    
-    public void onCmdFileNew(RemoteFile remotefile);
-    public void onCmdFileRemove(RemoteFile remotefile);
-
-    public void onCmdUserAccount(UserAccount useraccount);
-    public void onCmdBannedUser(BannedUser banneduser);
-    public void onCmdUserAccountNew(UserAccount useraccount);
-    public void onCmdUserAccountRemove(UserAccount useraccount);
-}
-    
+public interface CommandListener
+    extends ClientEventListener.OnCmdErrorListener
+    , ClientEventListener.OnCmdSuccessListener
+    , ClientEventListener.OnCmdProcessingListener
+    , ClientEventListener.OnCmdMyselfLoggedInListener
+    , ClientEventListener.OnCmdMyselfLoggedOutListener
+    , ClientEventListener.OnCmdMyselfKickedFromChannelListener
+    , ClientEventListener.OnCmdUserLoggedInListener
+    , ClientEventListener.OnCmdUserLoggedOutListener
+    , ClientEventListener.OnCmdUserUpdateListener
+    , ClientEventListener.OnCmdUserJoinedChannelListener
+    , ClientEventListener.OnCmdUserLeftChannelListener
+    , ClientEventListener.OnCmdUserTextMessageListener
+    , ClientEventListener.OnCmdChannelNewListener
+    , ClientEventListener.OnCmdChannelUpdateListener
+    , ClientEventListener.OnCmdChannelRemoveListener
+    , ClientEventListener.OnCmdServerUpdateListener
+    , ClientEventListener.OnCmdFileNewListener
+    , ClientEventListener.OnCmdFileRemoveListener
+    , ClientEventListener.OnCmdUserAccountListener
+    , ClientEventListener.OnCmdBannedUserListener
+    , ClientEventListener.OnCmdUserAccountNewListener
+    , ClientEventListener.OnCmdUserAccountRemoveListener { }

--- a/Library/TeamTalkJNI/src/dk/bearware/events/ConnectionListener.java
+++ b/Library/TeamTalkJNI/src/dk/bearware/events/ConnectionListener.java
@@ -23,14 +23,10 @@
 
 package dk.bearware.events;
 
-import dk.bearware.ClientErrorMsg;
-
-public interface ConnectionListener {
-
-    public void onConnectSuccess();
-    public void onEncryptionError(int opensslErrorNo, ClientErrorMsg errmsg);
-    public void onConnectFailed();
-    public void onConnectionLost();
-    public void onMaxPayloadUpdate(int payload_size);
-
+public interface ConnectionListener
+    extends ClientEventListener.OnConnectSuccessListener
+    , ClientEventListener.OnEncryptionErrorListener
+    , ClientEventListener.OnConnectFailedListener
+    , ClientEventListener.OnConnectionLostListener
+    , ClientEventListener.OnMaxPayloadUpdateListener {
 }

--- a/Library/TeamTalkJNI/src/dk/bearware/events/TeamTalkEventHandler.java
+++ b/Library/TeamTalkJNI/src/dk/bearware/events/TeamTalkEventHandler.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2018, BearWare.dk
- * 
+ *
  * Contact Information:
  *
  * Bjoern D. Rasmussen
@@ -23,7 +23,9 @@
 
 package dk.bearware.events;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 
 import dk.bearware.AudioInputProgress;
@@ -44,461 +46,683 @@ import dk.bearware.User;
 import dk.bearware.UserAccount;
 
 public class TeamTalkEventHandler {
-    
-    List<ConnectionListener> conListener = new Vector<ConnectionListener>();
-    List<CommandListener> cmdListener = new Vector<CommandListener>();
-    List<UserListener> userListener = new Vector<UserListener>();
-    List<ClientListener> clientListener = new Vector<ClientListener>();
 
+    abstract class ProcessTTMessage {
+        public Object o;
+        ProcessTTMessage(Object o) { this.o = o; }
+        abstract void processTTMessage(TTMessage pMsg);
+    }
+
+    Map<Integer, Vector<ProcessTTMessage>> listeners = new HashMap<>();
+
+    private Vector<ProcessTTMessage> get(int event) {
+        Vector<ProcessTTMessage> v = listeners.get(event);
+        if (v == null) {
+            v = new Vector<>();
+            listeners.put(event, v);
+        }
+        return v;
+    }
+
+    private Vector<ProcessTTMessage> remove(int event, Object l) {
+        Vector<ProcessTTMessage> v = get(event);
+        for (int i=0;i<v.size();) {
+            if (v.get(i).o == l)
+                v.remove(i);
+            else ++i;
+        }
+        return v;
+    }
+
+    private void register(int event, Object l, boolean enable, ProcessTTMessage p) {
+        Vector<ProcessTTMessage> v = remove(event, l);
+        if (enable) {
+            v.add(p);
+        }
+    }
+
+    public void unregisterListener(Object l) {
+        for (int key : listeners.keySet())
+            remove(key, l);
+    }
+
+    /** @deprecated use registerOn* methods instead */
+    @Deprecated
     public void addConnectionListener(ConnectionListener l) {
-        removeConnectionListener(l); // ensure no duplicates
-        conListener.add(l);
+        registerOnConnectSuccessListener(l, true);
+        registerOnEncryptionErrorListener(l, true);
+        registerOnConnectFailedListener(l, true);
+        registerOnConnectionLostListener(l, true);
+        registerOnMaxPayloadUpdateListener(l, true);
     }
-
-    public void addCommandListener(CommandListener l) {
-        removeCommandListener(l);
-        cmdListener.add(l);
-    }
-
-    public void addUserListener(UserListener l) {
-        removeUserListener(l);
-        userListener.add(l);
-    }
-
-    public void addClientListener(ClientListener l) {
-        removeClientListener(l);
-        clientListener.add(l);
-    }
-
+    /** @deprecated use registerOn* methods instead */
+    @Deprecated
     public void removeConnectionListener(ConnectionListener l) {
-        conListener.remove(l);
+        registerOnConnectSuccessListener(l, false);
+        registerOnEncryptionErrorListener(l, false);
+        registerOnConnectFailedListener(l, false);
+        registerOnConnectionLostListener(l, false);
+        registerOnMaxPayloadUpdateListener(l, false);
     }
 
+    public void registerOnConnectSuccessListener(ClientEventListener.OnConnectSuccessListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CON_SUCCESS, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    l.onConnectSuccess();
+                }
+            });
+    }
+    public void registerOnEncryptionErrorListener(ClientEventListener.OnEncryptionErrorListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CON_CRYPT_ERROR, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    l.onEncryptionError(pMsg.nSource, pMsg.clienterrormsg);
+                }
+            });
+    }
+    public void registerOnConnectFailedListener(ClientEventListener.OnConnectFailedListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CON_FAILED, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    l.onConnectFailed();
+                }
+            });
+    }
+    public void registerOnConnectionLostListener(ClientEventListener.OnConnectionLostListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CON_LOST, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    l.onConnectionLost();
+                }
+            });
+    }
+    public void registerOnMaxPayloadUpdateListener(ClientEventListener.OnMaxPayloadUpdateListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CON_MAX_PAYLOAD_UPDATED, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    l.onMaxPayloadUpdate(pMsg.nPayloadSize);
+                }
+            });
+    }
+
+    /** @deprecated use registerOnCmd* methods instead */
+    @Deprecated
+    public void addCommandListener(CommandListener l) {
+        registerOnCmdProcessing(l, true);
+        registerOnCmdError(l, true);
+        registerOnCmdSuccess(l, true);
+        registerOnCmdMyselfLoggedIn(l, true);
+        registerOnCmdMyselfLoggedOut(l, true);
+        registerOnCmdMyselfKickedFromChannel(l, true);
+        registerOnCmdUserLoggedIn(l, true);
+        registerOnCmdUserLoggedOut(l, true);
+        registerOnCmdUserUpdate(l, true);
+        registerOnCmdUserJoinedChannel(l, true);
+        registerOnCmdUserLeftChannel(l, true);
+        registerOnCmdUserTextMessage(l, true);
+        registerOnCmdChannelNew(l, true);
+        registerOnCmdChannelUpdate(l, true);
+        registerOnCmdChannelRemove(l, true);
+        registerOnCmdServerUpdate(l, true);
+        registerOnCmdFileNew(l, true);
+        registerOnCmdFileRemove(l, true);
+        registerOnCmdUserAccount(l, true);
+        registerOnCmdUserAccountNew(l, true);
+        registerOnCmdUserAccountRemove(l, true);
+        registerOnCmdBannedUser(l, true);
+    }
+    /** @deprecated use registerOnCmd* methods instead */
+    @Deprecated
     public void removeCommandListener(CommandListener l) {
-        cmdListener.remove(l);
+        registerOnCmdProcessing(l, false);
+        registerOnCmdError(l, false);
+        registerOnCmdSuccess(l, false);
+        registerOnCmdMyselfLoggedIn(l, false);
+        registerOnCmdMyselfLoggedOut(l, false);
+        registerOnCmdMyselfKickedFromChannel(l, false);
+        registerOnCmdUserLoggedIn(l, false);
+        registerOnCmdUserLoggedOut(l, false);
+        registerOnCmdUserUpdate(l, false);
+        registerOnCmdUserJoinedChannel(l, false);
+        registerOnCmdUserLeftChannel(l, false);
+        registerOnCmdUserTextMessage(l, false);
+        registerOnCmdChannelNew(l, false);
+        registerOnCmdChannelUpdate(l, false);
+        registerOnCmdChannelRemove(l, false);
+        registerOnCmdServerUpdate(l, false);
+        registerOnCmdFileNew(l, false);
+        registerOnCmdFileRemove(l, false);
+        registerOnCmdUserAccount(l, false);
+        registerOnCmdUserAccountNew(l, false);
+        registerOnCmdUserAccountRemove(l, false);
+        registerOnCmdBannedUser(l, false);
+    }
+    public void registerOnCmdProcessing(ClientEventListener.OnCmdProcessingListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_PROCESSING, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__TTBOOL);
+                    l.onCmdProcessing(pMsg.nSource, !pMsg.bActive);
+                }
+            });
+    }
+    public void registerOnCmdError(ClientEventListener.OnCmdErrorListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_ERROR, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__CLIENTERRORMSG);
+                    l.onCmdError(pMsg.nSource, pMsg.clienterrormsg);
+                }
+            });
+    }
+    public void registerOnCmdSuccess(ClientEventListener.OnCmdSuccessListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_SUCCESS, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    l.onCmdSuccess(pMsg.nSource);
+                }
+            });
+    }
+    public void registerOnCmdMyselfLoggedIn(ClientEventListener.OnCmdMyselfLoggedInListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_MYSELF_LOGGEDIN, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__USERACCOUNT);
+                    l.onCmdMyselfLoggedIn(pMsg.nSource, pMsg.useraccount);
+                }
+            });
+    }
+    public void registerOnCmdMyselfLoggedOut(ClientEventListener.OnCmdMyselfLoggedOutListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_MYSELF_LOGGEDOUT, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    l.onCmdMyselfLoggedOut();
+                }
+            });
+    }
+    public void registerOnCmdMyselfKickedFromChannel(ClientEventListener.OnCmdMyselfKickedFromChannelListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_MYSELF_KICKED, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    if(pMsg.ttType == TTType.__NONE)
+                        l.onCmdMyselfKickedFromChannel();
+                    else if(pMsg.ttType == TTType.__USER)
+                        l.onCmdMyselfKickedFromChannel(pMsg.user);
+                }
+            });
+    }
+    public void registerOnCmdUserLoggedIn(ClientEventListener.OnCmdUserLoggedInListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_USER_LOGGEDIN, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__USER);
+                    User user = pMsg.user;
+                    l.onCmdUserLoggedIn(user);
+                }
+            });
+    }
+    public void registerOnCmdUserLoggedOut(ClientEventListener.OnCmdUserLoggedOutListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_USER_LOGGEDOUT, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__USER);
+                    User user = pMsg.user;
+                    l.onCmdUserLoggedOut(user);
+                }
+            });
+    }
+    public void registerOnCmdUserUpdate(ClientEventListener.OnCmdUserUpdateListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_USER_UPDATE, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__USER);
+                    User user = pMsg.user;
+                    l.onCmdUserUpdate(user);
+                }
+            });
+    }
+    public void registerOnCmdUserJoinedChannel(ClientEventListener.OnCmdUserJoinedChannelListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_USER_JOINED, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__USER);
+                    User user = pMsg.user;
+                    l.onCmdUserJoinedChannel(user);
+                }
+            });
+    }
+    public void registerOnCmdUserLeftChannel(ClientEventListener.OnCmdUserLeftChannelListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_USER_LEFT, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__USER);
+                    User user = pMsg.user;
+                    l.onCmdUserLeftChannel(pMsg.nSource, user);
+                }
+            });
+    }
+    public void registerOnCmdUserTextMessage(ClientEventListener.OnCmdUserTextMessageListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_USER_TEXTMSG, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__TEXTMESSAGE);
+                    TextMessage msg = pMsg.textmessage;
+                    l.onCmdUserTextMessage(msg);
+                }
+            });
+    }
+    public void registerOnCmdChannelNew(ClientEventListener.OnCmdChannelNewListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_CHANNEL_NEW, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__CHANNEL);
+                    l.onCmdChannelNew(pMsg.channel);
+                }
+            });
+    }
+    public void registerOnCmdChannelUpdate(ClientEventListener.OnCmdChannelUpdateListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_CHANNEL_UPDATE, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__CHANNEL);
+                    l.onCmdChannelUpdate(pMsg.channel);
+                }
+            });
+    }
+    public void registerOnCmdChannelRemove(ClientEventListener.OnCmdChannelRemoveListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_CHANNEL_REMOVE, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__CHANNEL);
+                    l.onCmdChannelRemove(pMsg.channel);
+                }
+            });
+    }
+    public void registerOnCmdServerUpdate(ClientEventListener.OnCmdServerUpdateListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_SERVER_UPDATE, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__SERVERPROPERTIES);
+                    l.onCmdServerUpdate(pMsg.serverproperties);
+                }
+            });
+    }
+    public void registerOnCmdFileNew(ClientEventListener.OnCmdFileNewListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_FILE_NEW, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__REMOTEFILE);
+                    l.onCmdFileNew(pMsg.remotefile);
+                }
+            });
+    }
+    public void registerOnCmdFileRemove(ClientEventListener.OnCmdFileRemoveListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_FILE_REMOVE, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__REMOTEFILE);
+                    l.onCmdFileRemove(pMsg.remotefile);
+                }
+            });
+    }
+    public void registerOnCmdUserAccount(ClientEventListener.OnCmdUserAccountListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_USERACCOUNT, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__USERACCOUNT);
+                    l.onCmdUserAccount(pMsg.useraccount);
+                }
+            });
+    }
+    public void registerOnCmdUserAccountNew(ClientEventListener.OnCmdUserAccountNewListener l, boolean enable) {
+        register( ClientEvent.CLIENTEVENT_CMD_USERACCOUNT_NEW, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__USERACCOUNT);
+                    l.onCmdUserAccountNew(pMsg.useraccount);
+                }
+            });
+    }
+    public void registerOnCmdUserAccountRemove(ClientEventListener.OnCmdUserAccountRemoveListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_USERACCOUNT_REMOVE, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__USERACCOUNT);
+                    l.onCmdUserAccountRemove(pMsg.useraccount);
+                }
+            });
+    }
+    public void registerOnCmdBannedUser(ClientEventListener.OnCmdBannedUserListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_CMD_BANNEDUSER, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__BANNEDUSER);
+                    l.onCmdBannedUser(pMsg.banneduser);
+                }
+            });
     }
 
+    /** @deprecated use registerOnUser* methods instead */
+    @Deprecated
+    public void addUserListener(UserListener l) {
+        registerOnUserStateChange(l, true);
+        registerOnUserVideoCapture(l, true);
+        registerOnUserMediaFileVideo(l, true);
+        registerOnUserDesktopWindow(l, true);
+        registerOnUserDesktopCursor(l, true);
+        registerOnUserDesktopInput(l, true);
+        registerOnUserRecordMediaFile(l, true);
+        registerOnUserAudioBlock(l, true);
+        registerOnUserFirstVoiceStreamPacket(l, true);
+    }
+    /** @deprecated use registerOnUser* methods instead */
+    @Deprecated
     public void removeUserListener(UserListener l) {
-        userListener.remove(l);
+        registerOnUserStateChange(l, false);
+        registerOnUserVideoCapture(l, false);
+        registerOnUserMediaFileVideo(l, false);
+        registerOnUserDesktopWindow(l, false);
+        registerOnUserDesktopCursor(l, false);
+        registerOnUserDesktopInput(l, false);
+        registerOnUserRecordMediaFile(l, false);
+        registerOnUserAudioBlock(l, false);
+        registerOnUserFirstVoiceStreamPacket(l, false);
+    }
+    public void registerOnUserStateChange(ClientEventListener.OnUserStateChangeListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_USER_STATECHANGE, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__USER);
+                    l.onUserStateChange(pMsg.user);
+                }
+            });
+    }
+    public void registerOnUserVideoCapture(ClientEventListener.OnUserVideoCaptureListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_USER_VIDEOCAPTURE, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__INT32);
+                    int nUserID = pMsg.nSource;
+                    int nStreamID = pMsg.nStreamID;
+                    l.onUserVideoCapture(nUserID, nStreamID);
+                }
+            });
+    }
+    public void registerOnUserMediaFileVideo(ClientEventListener.OnUserMediaFileVideoListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_USER_MEDIAFILE_VIDEO, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__INT32);
+                    int nUserID = pMsg.nSource;
+                    int nStreamID = pMsg.nStreamID;
+                    l.onUserMediaFileVideo(nUserID, nStreamID);
+                }
+            });
+    }
+    public void registerOnUserDesktopWindow(ClientEventListener.OnUserDesktopWindowListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_USER_DESKTOPWINDOW, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__INT32);
+                    int nUserID = pMsg.nSource;
+                    int nStreamID = pMsg.nStreamID;
+                    l.onUserDesktopWindow(nUserID, nStreamID);
+                }
+            });
+    }
+    public void registerOnUserDesktopCursor(ClientEventListener.OnUserDesktopCursorListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_USER_DESKTOPCURSOR, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__DESKTOPINPUT);
+                    int nUserID = pMsg.nSource;
+                    l.onUserDesktopCursor(nUserID, pMsg.desktopinput);
+                }
+            });
+    }
+    public void registerOnUserDesktopInput(ClientEventListener.OnUserDesktopInputListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_USER_DESKTOPINPUT, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__DESKTOPINPUT);
+                    int nUserID = pMsg.nSource;
+                    l.onUserDesktopInput(nUserID, pMsg.desktopinput);
+                }
+            });
+    }
+    public void registerOnUserRecordMediaFile(ClientEventListener.OnUserRecordMediaFileListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_USER_RECORD_MEDIAFILE, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__NONE);
+                    int nUserID = pMsg.nSource;
+                    l.onUserRecordMediaFile(nUserID, pMsg.mediafileinfo);
+                }
+            });
+    }
+    public void registerOnUserAudioBlock(ClientEventListener.OnUserAudioBlockListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_USER_AUDIOBLOCK, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__STREAMTYPE);
+                    int nUserID = pMsg.nSource;
+                    l.onUserAudioBlock(nUserID, pMsg.nStreamType);
+                }
+            });
+    }
+    public void registerOnUserFirstVoiceStreamPacket(ClientEventListener.OnUserFirstVoiceStreamPacketListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_USER_FIRSTVOICESTREAMPACKET, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert(pMsg.ttType == TTType.__USER);
+                    User user = pMsg.user;
+                    l.onUserFirstVoiceStreamPacket(user, pMsg.nSource);
+                }
+            });
     }
 
-    public void removeClientListener(ClientListener l) {
-        clientListener.remove(l);
+    /** @deprecated use registerOn* methods instead */
+    @Deprecated
+    public void addClientListener(ClientListener l) {
+        registerOnInternalError(l, true);
+        registerOnVoiceActivation(l, true);
+        registerOnHotKeyToggle(l, true);
+        registerOnHotKeyTest(l, true);
+        registerOnFileTransfer(l, true);
+        registerOnDesktopWindowTransfer(l, true);
+        registerOnStreamMediaFile(l, true);
+        registerOnLocalMediaFile(l, true);
+        registerOnAudioInput(l, true);
+        registerOnSoundDeviceAdded(l, true);
+        registerOnSoundDeviceRemoved(l, true);
+        registerOnSoundDeviceUnplugged(l, true);
+        registerOnSoundDeviceNewDefaultInput(l, true);
+        registerOnSoundDeviceNewDefaultOutput(l, true);
+        registerOnSoundDeviceNewDefaultInputComDevice(l, true);
+        registerOnSoundDeviceNewDefaultOutputComDevice(l, true);
     }
-    
+    /** @deprecated use registerOn* methods instead */
+    @Deprecated
+    public void removeClientListener(ClientListener l) {
+        registerOnInternalError(l, false);
+        registerOnVoiceActivation(l, false);
+        registerOnHotKeyToggle(l, false);
+        registerOnHotKeyTest(l, false);
+        registerOnFileTransfer(l, false);
+        registerOnDesktopWindowTransfer(l, false);
+        registerOnStreamMediaFile(l, false);
+        registerOnLocalMediaFile(l, false);
+        registerOnAudioInput(l, false);
+        registerOnSoundDeviceAdded(l, false);
+        registerOnSoundDeviceRemoved(l, false);
+        registerOnSoundDeviceUnplugged(l, false);
+        registerOnSoundDeviceNewDefaultInput(l, false);
+        registerOnSoundDeviceNewDefaultOutput(l, false);
+        registerOnSoundDeviceNewDefaultInputComDevice(l, false);
+        registerOnSoundDeviceNewDefaultOutputComDevice(l, false);
+    }
+    public void registerOnInternalError(ClientEventListener.OnInternalErrorListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_INTERNAL_ERROR, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__CLIENTERRORMSG);
+                    l.onInternalError(pMsg.clienterrormsg);
+                }
+            });
+    }
+    public void registerOnVoiceActivation(ClientEventListener.OnVoiceActivationListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_VOICE_ACTIVATION, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__TTBOOL);
+                    l.onVoiceActivation(pMsg.bActive);
+                }
+            });
+    }
+    public void registerOnHotKeyToggle(ClientEventListener.OnHotKeyToggleListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_HOTKEY, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__TTBOOL);
+                    int nHotKeyID = pMsg.nSource;
+                    boolean bActive = pMsg.bActive;
+                    l.onHotKeyToggle(nHotKeyID, bActive);
+                }
+            });
+    }
+    public void registerOnHotKeyTest(ClientEventListener.OnHotKeyTestListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_HOTKEY_TEST, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__TTBOOL);
+                    int nVkCode = pMsg.nSource;
+                    boolean bActive = pMsg.bActive;
+                    l.onHotKeyTest(nVkCode, bActive);
+                }
+            });
+    }
+    public void registerOnFileTransfer(ClientEventListener.OnFileTransferListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_FILETRANSFER, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__FILETRANSFER);
+                    l.onFileTransfer(pMsg.filetransfer);
+                }
+            });
+    }
+    public void registerOnDesktopWindowTransfer(ClientEventListener.OnDesktopWindowTransferListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_DESKTOPWINDOW_TRANSFER, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert (pMsg.ttType == TTType.__INT32);
+                    int nSessionID = pMsg.nSource;
+                    int nBytesRemain = pMsg.nBytesRemain;
+                    l.onDesktopWindowTransfer(nSessionID, nBytesRemain);
+                }
+            });
+    }
+    public void registerOnStreamMediaFile(ClientEventListener.OnStreamMediaFileListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_STREAM_MEDIAFILE, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert(pMsg.ttType == TTType.__MEDIAFILEINFO);
+                    l.onStreamMediaFile(pMsg.mediafileinfo);
+                }
+            });
+    }
+    public void registerOnLocalMediaFile(ClientEventListener.OnLocalMediaFileListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_LOCAL_MEDIAFILE, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert(pMsg.ttType == TTType.__MEDIAFILEINFO);
+                    l.onLocalMediaFile(pMsg.mediafileinfo);
+                }
+            });
+    }
+    public void registerOnAudioInput(ClientEventListener.OnAudioInputListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_AUDIOINPUT, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert(pMsg.ttType == TTType.__AUDIOINPUTPROGRESS);
+
+                    l.onAudioInput(pMsg.audioinputprogress, pMsg.nSource);
+                }
+            });
+    }
+    public void registerOnSoundDeviceAdded(ClientEventListener.OnSoundDeviceAddedListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_SOUNDDEVICE_ADDED, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert(pMsg.ttType == TTType.__SOUNDDEVICE);
+                    l.onSoundDeviceAdded(pMsg.sounddevice);
+                }
+            });
+    }
+    public void registerOnSoundDeviceRemoved(ClientEventListener.OnSoundDeviceRemovedListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_SOUNDDEVICE_REMOVED, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert(pMsg.ttType == TTType.__SOUNDDEVICE);
+                    l.onSoundDeviceRemoved(pMsg.sounddevice);
+                }
+            });
+    }
+    public void registerOnSoundDeviceUnplugged(ClientEventListener.OnSoundDeviceUnpluggedListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_SOUNDDEVICE_UNPLUGGED, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert(pMsg.ttType == TTType.__SOUNDDEVICE);
+                    l.onSoundDeviceUnplugged(pMsg.sounddevice);
+                }
+            });
+    }
+    public void registerOnSoundDeviceNewDefaultInput(ClientEventListener.OnSoundDeviceNewDefaultInputListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_SOUNDDEVICE_NEW_DEFAULT_INPUT, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert(pMsg.ttType == TTType.__SOUNDDEVICE);
+                    l.onSoundDeviceNewDefaultInput(pMsg.sounddevice);
+                }
+            });
+    }
+    public void registerOnSoundDeviceNewDefaultOutput(ClientEventListener.OnSoundDeviceNewDefaultOutputListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_SOUNDDEVICE_NEW_DEFAULT_OUTPUT, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert(pMsg.ttType == TTType.__SOUNDDEVICE);
+                    l.onSoundDeviceNewDefaultOutput(pMsg.sounddevice);
+                }
+            });
+    }
+    public void registerOnSoundDeviceNewDefaultInputComDevice(ClientEventListener.OnSoundDeviceNewDefaultInputComDeviceListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_SOUNDDEVICE_NEW_DEFAULT_INPUT_COMDEVICE, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert(pMsg.ttType == TTType.__SOUNDDEVICE);
+                    l.onSoundDeviceNewDefaultInputComDevice(pMsg.sounddevice);
+                }
+            });
+    }
+    public void registerOnSoundDeviceNewDefaultOutputComDevice(ClientEventListener.OnSoundDeviceNewDefaultOutputComDeviceListener l, boolean enable) {
+        register(ClientEvent.CLIENTEVENT_SOUNDDEVICE_NEW_DEFAULT_OUTPUT_COMDEVICE, l, enable, new ProcessTTMessage(l) {
+                @Override
+                void processTTMessage(TTMessage pMsg) {
+                    assert(pMsg.ttType == TTType.__SOUNDDEVICE);
+                    l.onSoundDeviceNewDefaultOutputComDevice(pMsg.sounddevice);
+                }
+            });
+    }
+
     public boolean processEvent(TeamTalkBase ttclient, int timeoutMsecs) {
 
         TTMessage pMsg = new TTMessage();
         if(!ttclient.getMessage(pMsg, timeoutMsecs))
             return false;
-        
-        switch(pMsg.nClientEvent) {
-            case ClientEvent.CLIENTEVENT_CON_SUCCESS : {
-                for(ConnectionListener l : conListener)
-                    l.onConnectSuccess();
-                break;
-            }
-            case ClientEvent.CLIENTEVENT_CON_CRYPT_ERROR : {
-                for(ConnectionListener l : conListener)
-                    l.onEncryptionError(pMsg.nSource, pMsg.clienterrormsg);
-                break;
-            }
-            case ClientEvent.CLIENTEVENT_CON_FAILED : {
-                for(ConnectionListener l : conListener)
-                    l.onConnectFailed();
-                break;
-            }
-            case ClientEvent.CLIENTEVENT_CON_LOST : {
-                for(ConnectionListener l : conListener)
-                    l.onConnectionLost();
-                break;
-            }
-            case ClientEvent.CLIENTEVENT_CON_MAX_PAYLOAD_UPDATED : {
-                for(ConnectionListener l : conListener)
-                    l.onMaxPayloadUpdate(pMsg.nPayloadSize);
-                break;
-            }
-            case ClientEvent.CLIENTEVENT_CMD_PROCESSING : {
-                for(CommandListener l : cmdListener)
-                    l.onCmdProcessing(pMsg.nSource, !pMsg.bActive);
-                break;
-            }
-            case ClientEvent.CLIENTEVENT_CMD_ERROR : {
-                assert (pMsg.ttType == TTType.__CLIENTERRORMSG);
-                for(CommandListener l : cmdListener)
-                    l.onCmdError(pMsg.nSource, pMsg.clienterrormsg);
-                break;
-            }
-            case ClientEvent.CLIENTEVENT_CMD_SUCCESS : {
-                for(CommandListener l : cmdListener)
-                    l.onCmdSuccess(pMsg.nSource);
-                break;
-            }
-            case ClientEvent.CLIENTEVENT_CMD_MYSELF_LOGGEDIN : {
-                assert (pMsg.ttType == TTType.__USERACCOUNT);
-                for(CommandListener l : cmdListener)
-                    l.onCmdMyselfLoggedIn(pMsg.nSource, pMsg.useraccount);
-                break;
-            }
-            case ClientEvent.CLIENTEVENT_CMD_MYSELF_LOGGEDOUT : {
-                for(CommandListener l : cmdListener)
-                    l.onCmdMyselfLoggedOut();
-                break;
-            }
-            case ClientEvent.CLIENTEVENT_CMD_MYSELF_KICKED : {
-                for(CommandListener l : cmdListener)
-                    if(pMsg.ttType == TTType.__NONE)
-                        l.onCmdMyselfKickedFromChannel();
-                    else if(pMsg.ttType == TTType.__USER)
-                        l.onCmdMyselfKickedFromChannel(pMsg.user);
-                break;
-            }
-            case ClientEvent.CLIENTEVENT_CMD_USER_LOGGEDIN : {
-                assert (pMsg.ttType == TTType.__USER);
-                User user = pMsg.user;
 
-                for(CommandListener l : cmdListener)
-                    l.onCmdUserLoggedIn(user);
+        for (ProcessTTMessage l : get(pMsg.nClientEvent))
+            l.processTTMessage(pMsg);
 
-                break;
-            }
-            case ClientEvent.CLIENTEVENT_CMD_USER_LOGGEDOUT : {
-                assert (pMsg.ttType == TTType.__USER);
-                User user = pMsg.user;
-
-                for(CommandListener l : cmdListener)
-                    l.onCmdUserLoggedOut(user);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_CMD_USER_UPDATE : {
-                assert (pMsg.ttType == TTType.__USER);
-                User user = pMsg.user;
-
-                for(CommandListener l : cmdListener)
-                    l.onCmdUserUpdate(user);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_CMD_USER_JOINED : {
-                assert (pMsg.ttType == TTType.__USER);
-                User user = pMsg.user;
-
-                for(CommandListener l : cmdListener)
-                    l.onCmdUserJoinedChannel(user);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_CMD_USER_LEFT : {
-                assert (pMsg.ttType == TTType.__USER);
-                User user = pMsg.user;
-
-                for(CommandListener l : cmdListener)
-                    l.onCmdUserLeftChannel(pMsg.nSource, user);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_CMD_USER_TEXTMSG : {
-                assert (pMsg.ttType == TTType.__TEXTMESSAGE);
-                TextMessage msg = pMsg.textmessage;
-
-                for(CommandListener l : cmdListener)
-                    l.onCmdUserTextMessage(msg);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_CMD_CHANNEL_NEW : {
-                assert (pMsg.ttType == TTType.__CHANNEL);
-                Channel newchan = pMsg.channel;
-
-                for(CommandListener l : cmdListener)
-                    l.onCmdChannelNew(newchan);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_CMD_CHANNEL_UPDATE : {
-                assert (pMsg.ttType == TTType.__CHANNEL);
-                Channel chan = pMsg.channel;
-
-                for(CommandListener l : cmdListener)
-                    l.onCmdChannelUpdate(chan);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_CMD_CHANNEL_REMOVE : {
-                assert (pMsg.ttType == TTType.__CHANNEL);
-                Channel chan = pMsg.channel;
-
-                for(CommandListener l : cmdListener)
-                    l.onCmdChannelRemove(chan);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_CMD_SERVER_UPDATE : {
-                assert (pMsg.ttType == TTType.__SERVERPROPERTIES);
-                ServerProperties srvprop = pMsg.serverproperties;
-
-                for(CommandListener l : cmdListener)
-                    l.onCmdServerUpdate(srvprop);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_CMD_FILE_NEW : {
-                assert (pMsg.ttType == TTType.__REMOTEFILE);
-
-                RemoteFile file = pMsg.remotefile;
-
-                for(CommandListener l : cmdListener)
-                    l.onCmdFileNew(file);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_CMD_FILE_REMOVE : {
-                assert (pMsg.ttType == TTType.__REMOTEFILE);
-
-                RemoteFile file = pMsg.remotefile;
-
-                for(CommandListener l : cmdListener)
-                    l.onCmdFileRemove(file);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_CMD_USERACCOUNT : {
-                assert (pMsg.ttType == TTType.__USERACCOUNT);
-
-                UserAccount useraccount = pMsg.useraccount;
-
-                for(CommandListener l : cmdListener)
-                    l.onCmdUserAccount(useraccount);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_CMD_USERACCOUNT_NEW : {
-                assert (pMsg.ttType == TTType.__USERACCOUNT);
-
-                UserAccount useraccount = pMsg.useraccount;
-
-                for(CommandListener l : cmdListener)
-                    l.onCmdUserAccountNew(useraccount);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_CMD_USERACCOUNT_REMOVE : {
-                assert (pMsg.ttType == TTType.__USERACCOUNT);
-
-                UserAccount useraccount = pMsg.useraccount;
-
-                for(CommandListener l : cmdListener)
-                    l.onCmdUserAccountRemove(useraccount);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_CMD_BANNEDUSER : {
-                assert (pMsg.ttType == TTType.__BANNEDUSER);
-
-                BannedUser banneduser  = pMsg.banneduser;
-
-                for(CommandListener l : cmdListener)
-                    l.onCmdBannedUser(banneduser);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_USER_STATECHANGE : {
-                assert (pMsg.ttType == TTType.__USER);
-                User user = pMsg.user;
-
-                for(UserListener l : userListener)
-                    l.onUserStateChange(user);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_USER_VIDEOCAPTURE : {
-                assert (pMsg.ttType == TTType.__INT32);
-
-                int nUserID = pMsg.nSource;
-                int nStreamID = pMsg.nStreamID;
-                for(UserListener l : userListener)
-                    l.onUserVideoCapture(nUserID, nStreamID);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_USER_MEDIAFILE_VIDEO : {
-                assert (pMsg.ttType == TTType.__INT32);
-
-                int nUserID = pMsg.nSource;
-                int nStreamID = pMsg.nStreamID;
-                for(UserListener l : userListener)
-                    l.onUserMediaFileVideo(nUserID, nStreamID);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_USER_DESKTOPWINDOW : {
-                assert (pMsg.ttType == TTType.__INT32);
-
-                int nUserID = pMsg.nSource;
-                int nStreamID = pMsg.nStreamID;
-                for(UserListener l : userListener)
-                    l.onUserDesktopWindow(nUserID, nStreamID);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_USER_DESKTOPCURSOR : {
-                assert (pMsg.ttType == TTType.__DESKTOPINPUT);
-
-                int nUserID = pMsg.nSource;
-                DesktopInput desktopinput = pMsg.desktopinput;
-
-                for(UserListener l : userListener)
-                    l.onUserDesktopCursor(nUserID, desktopinput);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_USER_DESKTOPINPUT : {
-                assert (pMsg.ttType == TTType.__DESKTOPINPUT);
-
-                int nUserID = pMsg.nSource;
-                DesktopInput desktopinput = pMsg.desktopinput;
-
-                for(UserListener l : userListener)
-                    l.onUserDesktopInput(nUserID, desktopinput);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_USER_RECORD_MEDIAFILE : {
-                assert (pMsg.ttType == TTType.__NONE);
-
-                int nUserID = pMsg.nSource;
-                MediaFileInfo mediafileinfo = pMsg.mediafileinfo;
-                for(UserListener l : userListener)
-                    l.onUserRecordMediaFile(nUserID, mediafileinfo);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_USER_AUDIOBLOCK : {
-                assert (pMsg.ttType == TTType.__STREAMTYPE);
-                
-                int nUserID = pMsg.nSource;
-                for(UserListener l : userListener)
-                    l.onUserAudioBlock(nUserID, pMsg.nStreamType);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_INTERNAL_ERROR : {
-                assert (pMsg.ttType == TTType.__CLIENTERRORMSG);
-
-                ClientErrorMsg clienterrormsg = pMsg.clienterrormsg;
-
-                for(ClientListener l : clientListener)
-                    l.onInternalError(clienterrormsg);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_VOICE_ACTIVATION : {
-                assert (pMsg.ttType == TTType.__TTBOOL);
-
-                boolean bActive = pMsg.bActive;
-
-                for(ClientListener l : clientListener)
-                    l.onVoiceActivation(bActive);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_HOTKEY : {
-                assert (pMsg.ttType == TTType.__TTBOOL);
-
-                int nHotKeyID = pMsg.nSource;
-                boolean bActive = pMsg.bActive;
-
-                for(ClientListener l : clientListener)
-                    l.onHotKeyToggle(nHotKeyID, bActive);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_HOTKEY_TEST : {
-                assert (pMsg.ttType == TTType.__TTBOOL);
-
-                int nVkCode = pMsg.nSource;
-                boolean bActive = pMsg.bActive;
-
-                for(ClientListener l : clientListener)
-                    l.onHotKeyTest(nVkCode, bActive);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_FILETRANSFER : {
-                assert (pMsg.ttType == TTType.__FILETRANSFER);
-
-                FileTransfer filetransfer = pMsg.filetransfer;
-                for(ClientListener l : clientListener)
-                    l.onFileTransfer(filetransfer);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_DESKTOPWINDOW_TRANSFER : {
-                assert (pMsg.ttType == TTType.__INT32);
-
-                int nSessionID = pMsg.nSource;
-                int nBytesRemain = pMsg.nBytesRemain;
-
-                for(ClientListener l : clientListener)
-                    l.onDesktopWindowTransfer(nSessionID, nBytesRemain);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_STREAM_MEDIAFILE : {
-                assert(pMsg.ttType == TTType.__MEDIAFILEINFO);
-                
-                MediaFileInfo mediafileinfo = pMsg.mediafileinfo;
-                for(ClientListener l : clientListener)
-                    l.onStreamMediaFile(mediafileinfo);
-            }
-            break;
-            case ClientEvent.CLIENTEVENT_LOCAL_MEDIAFILE : {
-                assert(pMsg.ttType == TTType.__MEDIAFILEINFO);
-                
-                MediaFileInfo mediafileinfo = pMsg.mediafileinfo;
-                for(ClientListener l : clientListener)
-                    l.onLocalMediaFile(mediafileinfo);
-            }
-            break;
-        case ClientEvent.CLIENTEVENT_AUDIOINPUT : {
-            assert(pMsg.ttType == TTType.__AUDIOINPUTPROGRESS);
-
-            AudioInputProgress aip = pMsg.audioinputprogress;
-            for (ClientListener l : clientListener)
-                l.onAudioInput(aip, pMsg.nSource);
-            break;
-        }
-        case ClientEvent.CLIENTEVENT_SOUNDDEVICE_ADDED : {
-            assert(pMsg.ttType == TTType.__SOUNDDEVICE);
-
-            for (ClientListener l : clientListener)
-                l.onSoundDeviceAdded(pMsg.sounddevice);
-            break;
-        }
-        case ClientEvent.CLIENTEVENT_SOUNDDEVICE_REMOVED : {
-            assert(pMsg.ttType == TTType.__SOUNDDEVICE);
-
-            for (ClientListener l : clientListener)
-                l.onSoundDeviceRemoved(pMsg.sounddevice);
-            break;
-        }
-        case ClientEvent.CLIENTEVENT_SOUNDDEVICE_UNPLUGGED : {
-            assert(pMsg.ttType == TTType.__SOUNDDEVICE);
-
-            for (ClientListener l : clientListener)
-                l.onSoundDeviceUnplugged(pMsg.sounddevice);
-            break;
-        }
-        case ClientEvent.CLIENTEVENT_SOUNDDEVICE_NEW_DEFAULT_INPUT : {
-            assert(pMsg.ttType == TTType.__SOUNDDEVICE);
-
-            for (ClientListener l : clientListener)
-                l.onSoundDeviceNewDefaultInput(pMsg.sounddevice);
-            break;
-        }
-        case ClientEvent.CLIENTEVENT_SOUNDDEVICE_NEW_DEFAULT_OUTPUT : {
-            assert(pMsg.ttType == TTType.__SOUNDDEVICE);
-
-            for (ClientListener l : clientListener)
-                l.onSoundDeviceNewDefaultOutput(pMsg.sounddevice);
-            break;
-        }
-        case ClientEvent.CLIENTEVENT_SOUNDDEVICE_NEW_DEFAULT_INPUT_COMDEVICE : {
-            assert(pMsg.ttType == TTType.__SOUNDDEVICE);
-
-            for (ClientListener l : clientListener)
-                l.onSoundDeviceNewDefaultInputComDevice(pMsg.sounddevice);
-            break;
-        }
-        case ClientEvent.CLIENTEVENT_SOUNDDEVICE_NEW_DEFAULT_OUTPUT_COMDEVICE : {
-            assert(pMsg.ttType == TTType.__SOUNDDEVICE);
-
-            for (ClientListener l : clientListener)
-                l.onSoundDeviceNewDefaultOutputComDevice(pMsg.sounddevice);
-            break;
-        }
-        case ClientEvent.CLIENTEVENT_USER_FIRSTVOICESTREAMPACKET : {
-            assert(pMsg.ttType == TTType.__USER);
-
-            User user = pMsg.user;
-            for (UserListener l : userListener)
-                l.onUserFirstVoiceStreamPacket(user, pMsg.nSource);
-            break;
-        }
-        }
-        
         return true;
     }
 }

--- a/Library/TeamTalkJNI/src/dk/bearware/events/UserListener.java
+++ b/Library/TeamTalkJNI/src/dk/bearware/events/UserListener.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005-2018, BearWare.dk
- * 
+ *
  * Contact Information:
  *
  * Bjoern D. Rasmussen
@@ -23,19 +23,13 @@
 
 package dk.bearware.events;
 
-import dk.bearware.DesktopInput;
-import dk.bearware.MediaFileInfo;
-import dk.bearware.User;
-
-public interface UserListener {
-
-    public void onUserStateChange(User user);
-    public void onUserVideoCapture(int nUserID, int nStreamID);
-    public void onUserMediaFileVideo(int nUserID, int nStreamID);
-    public void onUserDesktopWindow(int nUserID, int nStreamID);
-    public void onUserDesktopCursor(int nUserID, DesktopInput desktopinput);
-    public void onUserDesktopInput(int nUserID, DesktopInput desktopinput);
-    public void onUserRecordMediaFile(int nUserID, MediaFileInfo mediafileinfo);
-    public void onUserAudioBlock(int nUserID, int nStreamType);
-    public void onUserFirstVoiceStreamPacket(User user, int nStreamID);
-}
+public interface UserListener
+    extends ClientEventListener.OnUserStateChangeListener
+    , ClientEventListener.OnUserVideoCaptureListener
+    , ClientEventListener.OnUserMediaFileVideoListener
+    , ClientEventListener.OnUserDesktopWindowListener
+    , ClientEventListener.OnUserDesktopCursorListener
+    , ClientEventListener.OnUserDesktopInputListener
+    , ClientEventListener.OnUserRecordMediaFileListener
+    , ClientEventListener.OnUserAudioBlockListener
+    , ClientEventListener.OnUserFirstVoiceStreamPacketListener {}


### PR DESCRIPTION
Previously a class would have to implement all methods of interfaces UserListener, ClientListener, CommandsListener and ConnectionListener. With this change it's possible to register only a subset of events.