### PR TITLE
Do not allow user to move user who is not logged in

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -21,6 +21,7 @@ iOS Client
 - Support for verifying authenticity of encrypted TeamTalk servers using certificates
 Server
 - TeamTalk Pro server supports verifying client certificate
+- Fixed bug where it was possible to move a user, who was not logged in, into a channel
 
 Version 5.13.1, 2023/05/22
 Server

--- a/Library/TeamTalkJNI/test/dk/bearware/TeamTalkServerTestCase.java
+++ b/Library/TeamTalkJNI/test/dk/bearware/TeamTalkServerTestCase.java
@@ -676,6 +676,38 @@ public class TeamTalkServerTestCase extends TeamTalkTestCaseBase {
     }
 
     @Test
+    public void testMoveUserNoLogin() {
+        UserAccount useraccount = new UserAccount();
+
+        final String USERNAME = "tt_test", PASSWORD = "tt_test", NICKNAME = "jUnit - " + getTestMethodName();
+
+        useraccount.szUsername = USERNAME;
+        useraccount.szPassword = PASSWORD;
+        useraccount.uUserType = UserType.USERTYPE_DEFAULT;
+        useraccount.szNote = "An example user account with limited user-rights";
+        useraccount.uUserRights = UserRight.USERRIGHT_VIEW_ALL_USERS |
+            UserRight.USERRIGHT_MULTI_LOGIN |
+            UserRight.USERRIGHT_CREATE_TEMPORARY_CHANNEL |
+            UserRight.USERRIGHT_MOVE_USERS;
+
+        useraccounts.add(useraccount);
+
+        TeamTalkSrv server = newServerInstance();
+        TeamTalkBase client1 = newClientInstance();
+        TeamTalkBase client2 = newClientInstance();
+
+        ServerInterleave interleave = new RunServer(server);
+
+        connect(server, client1);
+        login(server, client1, NICKNAME, USERNAME, PASSWORD);
+        joinRoot(server, client1);
+
+        connect(server, client2);
+        int cmdid = client1.doMoveUser(client2.getMyUserID(), client1.getMyChannelID());
+        assertTrue("move user", waitCmdError(client1, cmdid, DEF_WAIT, interleave));
+    }
+
+    @Test
     public void testChannelUpdates() {
 
         final String USERNAME = "tt_test", PASSWORD = "tt_test", NICKNAME = "jUnit - " + getTestMethodName();
@@ -1403,7 +1435,7 @@ public class TeamTalkServerTestCase extends TeamTalkTestCaseBase {
 
         TeamTalkSrv server = newServerInstance("", "", srvcontext);
         ServerInterleave interleave = new RunServer(server);
-        
+
         final TeamTalkBase client = newClientInstance();
 
         EncryptionContext context = new EncryptionContext();
@@ -1443,9 +1475,9 @@ public class TeamTalkServerTestCase extends TeamTalkTestCaseBase {
 
         TeamTalkSrv server = newServerInstance("", "", srvcontext);
         ServerInterleave interleave = new RunServer(server);
-        
+
         final TeamTalkBase client = newClientInstance();
-        
+
         EncryptionContext context = new EncryptionContext();
         context.szCAFile = CRYPTO_CA2_FILE;
         context.bVerifyPeer = true;
@@ -1485,7 +1517,7 @@ public class TeamTalkServerTestCase extends TeamTalkTestCaseBase {
 
         TeamTalkSrv server = newServerInstance("", "", srvcontext);
         ServerInterleave interleave = new RunServer(server);
-        
+
         final TeamTalkBase client = newClientInstance();
 
         EncryptionContext context = new EncryptionContext();
@@ -1529,9 +1561,9 @@ public class TeamTalkServerTestCase extends TeamTalkTestCaseBase {
 
         TeamTalkSrv server = newServerInstance("", "", srvcontext);
         ServerInterleave interleave = new RunServer(server);
-        
+
         final TeamTalkBase client = newClientInstance();
-        
+
         EncryptionContext context = new EncryptionContext();
         context.szCertificateFile = CRYPTO_CLIENT_CERT_EXPIRED_FILE;
         context.szPrivateKeyFile = CRYPTO_CLIENT_KEY_FILE;

--- a/Library/TeamTalkLib/teamtalk/server/ServerNode.h
+++ b/Library/TeamTalkLib/teamtalk/server/ServerNode.h
@@ -128,7 +128,7 @@ namespace teamtalk {
         ACE_thread_t m_reactorlock_thr_id;
 
         int GetNewUserID();
-        serveruser_t GetUser(int userid, const ServerUser* caller);
+        serveruser_t GetUser(int userid, const ServerUser* caller, bool authenticated = true);
 
         ACE_Time_Value GetUptime() const;
         serverchannel_t& GetRootChannel();


### PR DESCRIPTION
If a user has USERRIGHT_MOVE_USERS then it was possible to move a user who had no yet logged in.