### PR TITLE
Android 11 and beyond requires MANAGE_EXTERNAL_STORAGE to access files

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -20,6 +20,7 @@ Android Client
 - Fixed a bug of not showing contents of other tabs rather than current when going to another activity or locking/unlocking screen
 - It is now possible to use accessibility stream to play text-to-speech messages
 - Removed public servers from server list
+- Fixed import/export of TT files
 iOS Client
 - Support for verifying authenticity of encrypted TeamTalk servers using certificates
 - Removed public servers from server list

--- a/Client/TeamTalkAndroid/src/main/AndroidManifest.xml
+++ b/Client/TeamTalkAndroid/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"></uses-permission>
     <uses-permission android:name="android.hardware.sensor.proximity"></uses-permission>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
Should be fixed #973