### PR TITLE
bVerifyClientOnce or nVerifyDepth >= 0 will force certificate verification

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
@@ -615,6 +615,9 @@ public class TeamTalkService extends Service
             if (!this.ttserver.clientcertkey.isEmpty())
                 context.szPrivateKeyFile = clientkeyfile.getAbsolutePath();
             context.bVerifyPeer = ttserver.verifypeer;
+            if (!context.bVerifyPeer) {
+                context.nVerifyDepth = -1;
+            }
             return ttclient.setEncryptionContext(context);
         } catch (IOException e) {
             return false;

--- a/Library/TeamTalkJNI/src/dk/bearware/EncryptionContext.java
+++ b/Library/TeamTalkJNI/src/dk/bearware/EncryptionContext.java
@@ -30,7 +30,7 @@ public class EncryptionContext {
     public String szCAFile = "";
     public String szCADir = "";
     public boolean bVerifyPeer = false;
-    public boolean bVerifyClientOnce = true;
+    public boolean bVerifyClientOnce = false;
     public int nVerifyDepth = 0;
 
     public EncryptionContext() {


### PR DESCRIPTION
Align default value of bVerifyClientOnce to false (like C++) and set nVerifyDepth = -1 when no peer verification should take place.