### PR TITLE
Fix crash issue if std::gmtime() returns nullptr in DoShowBan

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -27,6 +27,7 @@ iOS Client
 Server
 - TeamTalk Pro server supports verifying client certificate
 - Fixed bug where it was possible to move a user, who was not logged in, into a channel
+- Fixed crash issue when banned user has invalid time
 
 Version 5.13.1, 2023/05/22
 Server

--- a/Library/TeamTalkLib/teamtalk/Commands.cpp
+++ b/Library/TeamTalkLib/teamtalk/Commands.cpp
@@ -725,7 +725,7 @@ namespace teamtalk {
     {
         time_t local_tm = tv.sec();
         struct tm* gmt = std::gmtime(&local_tm);
-        ACE_INT64 utc_tm = std::mktime(gmt);
+        ACE_INT64 utc_tm = gmt ? std::mktime(gmt) : tv.sec();
         AppendProperty(prop, utc_tm, dest_str);
     }
 


### PR DESCRIPTION
Stack trace:
 0  0x00005555556f6948 in teamtalk::ServerUser::DoShowBan(teamtalk::BannedUser const&) ()
 1  0x00005555556c3fb6 in teamtalk::ServerNode::UserListServerBans(int, int, int, int) ()
 2  0x00005555556f3d79 in teamtalk::ServerUser::HandleListServerBans(std::map<ACE_String_Base<char>, ACE_String_Base<char>, std::less<ACE_String_Base<char> >, std::allocator<std::pair<ACE_String_Base<char> const, ACE_String_Base<char> > > > const&)
    ()
 3  0x00005555557024d3 in teamtalk::ServerUser::HandleCommand(ACE_String_Base<char> const&, std::map<ACE_String_Base<char>, ACE_String_Base<char>, std::less<ACE_String_Base<char> >, std::allocator<std::pair<ACE_String_Base<char> const, ACE_String_Base<char> > > > const&) ()
 4  0x00005555557071d2 in teamtalk::ServerUser::ProcessCommand(ACE_String_Base<char> const&, bool) ()
 5  0x000055555570781c in teamtalk::ServerUser::ProcessCommandQueue(bool) ()
 6  0x00005555556cda7f in teamtalk::ServerNode::OnReceive(int, char const*, int) ()
 7  0x00005555556ec758 in StreamHandler<ACE_SOCK_Stream>::handle_input(int) ()
 8  0x000055555574cdbc in ACE_Select_Reactor_T<ACE_Reactor_Token_T<ACE_Token> >::notify_handle(int, unsigned long, ACE_Handle_Set&, ACE_Event_Handler*, int (ACE_Event_Handler::*)(int)) ()
 9  0x000055555574b40b in ACE_Select_Reactor_T<ACE_Reactor_Token_T<ACE_Token> >::dispatch_io_set(int, int&, int, ACE_Handle_Set&, ACE_Handle_Set&, int (ACE_Event_Handler::*)(int)) ()
 10 0x0000555555749086 in ACE_Select_Reactor_T<ACE_Reactor_Token_T<ACE_Token> >::dispatch_io_handlers(ACE_Select_Reactor_Handle_Set&, int&, int&) ()
 11 0x000055555574ca2c in ACE_Select_Reactor_T<ACE_Reactor_Token_T<ACE_Token> >::dispatch(int, ACE_Select_Reactor_Handle_Set&) ()
 12 0x0000555555751181 in ACE_Select_Reactor_T<ACE_Reactor_Token_T<ACE_Token> >::handle_events(ACE_Time_Value*) ()
 13 0x0000555555745be7 in RunEventLoop(ACE_Reactor*, ACE_Reactor*, ACE_String_Base<char> const&) ()
 14 0x00005555557485c0 in RunServer() ()
 15 0x000055555566d163 in main ()