### PR TITLE
Fix empty access-token for BearWare.dk WebLogin

### DIFF
--- a/Library/TeamTalkLib/bin/ttsrv/ServerGuard.cpp
+++ b/Library/TeamTalkLib/bin/ttsrv/ServerGuard.cpp
@@ -583,7 +583,7 @@ void ServerGuard::WebLoginBearWare(ServerNode* servernode, ACE_UINT32 userid, Us
     {
         GUARD_OBJ_NAME(g, servernode, servernode->lock());
 
-        auto user = servernode->GetUser(userid, nullptr);
+        auto user = servernode->GetUser(userid, nullptr, false);
         if (user.get())
         {
             authtoken = UnicodeToUtf8(user->GetAccessToken()).c_str();
@@ -693,7 +693,7 @@ ErrorMsg ServerGuard::WebLoginPostAuthenticate(UserAccount& useraccount)
 void ServerGuard::WebLoginComplete(ServerNode* servernode, ACE_UINT32 userid,
                                    const UserAccount& useraccount, const ErrorMsg& err)
 {
-    serveruser_t user = servernode->GetUser(userid, nullptr);
+    serveruser_t user = servernode->GetUser(userid, nullptr, false);
     if(!user)
         return;
 

--- a/Library/TeamTalkLib/teamtalk/server/ServerNode.cpp
+++ b/Library/TeamTalkLib/teamtalk/server/ServerNode.cpp
@@ -641,7 +641,7 @@ int ServerNode::TimerEvent(ACE_UINT32 timer_event_id, long userdata)
     {
         timer_userdata tm_data;
         tm_data.userdata = userdata;
-        serveruser_t src_user = GetUser(tm_data.src_userid, nullptr);
+        serveruser_t src_user = GetUser(tm_data.src_userid, nullptr, false);
         if(src_user)
             src_user->ProcessCommandQueue(true);
 


### PR DESCRIPTION
After introduced of 'authenticated' ServerNode::GetUser() (git hash ba0d2770ce) it is not possible do BearWare.dk WebLogin.