### PR TITLE
Time out Timer for voice and media files

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -11,6 +11,7 @@ Default Qt Client
 - Initial support for inclusive writing in some status and events
 - Selected communication sound device is now default in Windows
 - Removed public servers from server list
+- Ability to specify max duration of voice and media file streams (time out timer) in "Channel" dialog
 - Changed to Qt 6.6 beta1 on macOS
 Accessible Windows Client
 - Classic client is no longer available in Windows installer
@@ -28,6 +29,7 @@ Server
 - TeamTalk Pro server supports verifying client certificate
 - Fixed bug where it was possible to move a user, who was not logged in, into a channel
 - Fixed crash issue when banned user has invalid time
+- Support for time out timer on voice/media file streams
 
 Version 5.13.1, 2023/05/22
 Server

--- a/Client/qtTeamTalk/channel.ui
+++ b/Client/qtTeamTalk/channel.ui
@@ -22,7 +22,7 @@
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_5">
        <item>
-        <widget class="QGroupBox" name="groupBox">
+        <widget class="QGroupBox" name="chaninfoGroupBox">
          <property name="title">
           <string>Channel Information</string>
          </property>
@@ -143,7 +143,7 @@
           <item row="6" column="0">
            <widget class="QLabel" name="diskquotaLabel">
             <property name="text">
-             <string>Disk quota (KBytes)</string>
+             <string>Disk quota</string>
             </property>
             <property name="buddy">
              <cstring>diskquotaSpinBox</cstring>
@@ -158,6 +158,9 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="suffix">
+             <string> KBytes</string>
+            </property>
             <property name="maximum">
              <number>999999999</number>
             </property>
@@ -167,7 +170,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox_4">
+        <widget class="QGroupBox" name="chantypeGroupBox">
          <property name="title">
           <string>Channel type</string>
          </property>
@@ -243,7 +246,7 @@
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
-        <widget class="QGroupBox" name="groupBox_2">
+        <widget class="QGroupBox" name="audiocodecGroupBox">
          <property name="title">
           <string>Audio Codec</string>
          </property>
@@ -381,6 +384,9 @@
                <layout class="QHBoxLayout" name="horizontalLayout_3">
                 <item>
                  <widget class="QSpinBox" name="spx_txdelaySpinBox">
+                  <property name="suffix">
+                   <string> msec</string>
+                  </property>
                   <property name="minimum">
                    <number>20</number>
                   </property>
@@ -392,13 +398,6 @@
                   </property>
                   <property name="value">
                    <number>40</number>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="label_16">
-                  <property name="text">
-                   <string>msec</string>
                   </property>
                  </widget>
                 </item>
@@ -509,6 +508,9 @@
                <layout class="QHBoxLayout" name="horizontalLayout_9">
                 <item>
                  <widget class="QSpinBox" name="spxvbr_maxbpsSpinBox">
+                  <property name="suffix">
+                   <string> bps</string>
+                  </property>
                   <property name="minimum">
                    <number>0</number>
                   </property>
@@ -524,11 +526,17 @@
                  </widget>
                 </item>
                 <item>
-                 <widget class="QLabel" name="label_17">
-                  <property name="text">
-                   <string>bps</string>
+                 <spacer name="horizontalSpacer_2">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
                   </property>
-                 </widget>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
                 </item>
                </layout>
               </item>
@@ -556,6 +564,9 @@
                <layout class="QHBoxLayout" name="horizontalLayout_24">
                 <item>
                  <widget class="QSpinBox" name="spxvbr_txdelaySpinBox">
+                  <property name="suffix">
+                   <string> msec</string>
+                  </property>
                   <property name="minimum">
                    <number>20</number>
                   </property>
@@ -571,11 +582,17 @@
                  </widget>
                 </item>
                 <item>
-                 <widget class="QLabel" name="label_24">
-                  <property name="text">
-                   <string>msec</string>
+                 <spacer name="horizontalSpacer_3">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
                   </property>
-                 </widget>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
                 </item>
                </layout>
               </item>
@@ -693,12 +710,9 @@
               <item row="3" column="1">
                <layout class="QHBoxLayout" name="horizontalLayout_29">
                 <item>
-                 <widget class="QSpinBox" name="opus_bpsSpinBox"/>
-                </item>
-                <item>
-                 <widget class="QLabel" name="label_42">
-                  <property name="text">
-                   <string>Kbps</string>
+                 <widget class="QSpinBox" name="opus_bpsSpinBox">
+                  <property name="suffix">
+                   <string> Kbps</string>
                   </property>
                  </widget>
                 </item>
@@ -747,12 +761,9 @@
               <item row="5" column="1">
                <layout class="QHBoxLayout" name="horizontalLayout_28">
                 <item>
-                 <widget class="QSpinBox" name="opus_txdelaySpinBox"/>
-                </item>
-                <item>
-                 <widget class="QLabel" name="label_41">
-                  <property name="text">
-                   <string>msec</string>
+                 <widget class="QSpinBox" name="opus_txdelaySpinBox">
+                  <property name="suffix">
+                   <string> msec</string>
                   </property>
                  </widget>
                 </item>
@@ -799,7 +810,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox_3">
+        <widget class="QGroupBox" name="audiocfgGroupBox">
          <property name="title">
           <string>Audio Configuration</string>
          </property>
@@ -850,6 +861,55 @@
              </widget>
             </item>
            </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="streamGroupBox">
+         <property name="title">
+          <string>Stream Timeout Timer</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout_2">
+          <item row="0" column="0">
+           <widget class="QLabel" name="voiceTotLabel">
+            <property name="text">
+             <string>Voice stream max duration</string>
+            </property>
+            <property name="buddy">
+             <cstring>voiceTotDoubleSpinBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="mfTotLabel">
+            <property name="text">
+             <string>Media file stream max duration</string>
+            </property>
+            <property name="buddy">
+             <cstring>mfTotDoubleSpinBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="voiceTotDoubleSpinBox">
+            <property name="suffix">
+             <string> seconds</string>
+            </property>
+            <property name="decimals">
+             <number>1</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QDoubleSpinBox" name="mfTotDoubleSpinBox">
+            <property name="suffix">
+             <string> seconds</string>
+            </property>
+            <property name="decimals">
+             <number>1</number>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/Client/qtTeamTalk/channel.ui
+++ b/Client/qtTeamTalk/channel.ui
@@ -28,7 +28,7 @@
          </property>
          <layout class="QFormLayout" name="formLayout">
           <item row="0" column="0">
-           <widget class="QLabel" name="label_7">
+           <widget class="QLabel" name="chanpathLabelFixed">
             <property name="text">
              <string>Channel path</string>
             </property>
@@ -45,7 +45,7 @@
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="label">
+           <widget class="QLabel" name="nameLabel">
             <property name="text">
              <string>Channel name</string>
             </property>
@@ -58,7 +58,7 @@
            <widget class="QLineEdit" name="nameEdit"/>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="label_2">
+           <widget class="QLabel" name="topicLabel">
             <property name="text">
              <string>Topic</string>
             </property>
@@ -75,7 +75,7 @@
            </widget>
           </item>
           <item row="3" column="0">
-           <widget class="QLabel" name="label_3">
+           <widget class="QLabel" name="passwordLabel">
             <property name="text">
              <string>Password</string>
             </property>
@@ -95,7 +95,7 @@
            </widget>
           </item>
           <item row="4" column="0">
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="oppasswordLabel">
             <property name="text">
              <string>Operator password</string>
             </property>
@@ -115,7 +115,7 @@
            </widget>
           </item>
           <item row="5" column="0">
-           <widget class="QLabel" name="label_12">
+           <widget class="QLabel" name="maxusersLabel">
             <property name="text">
              <string>Max users</string>
             </property>
@@ -141,7 +141,7 @@
            </widget>
           </item>
           <item row="6" column="0">
-           <widget class="QLabel" name="label_13">
+           <widget class="QLabel" name="diskquotaLabel">
             <property name="text">
              <string>Disk quota (KBytes)</string>
             </property>

--- a/Client/qtTeamTalk/channeldlg.cpp
+++ b/Client/qtTeamTalk/channeldlg.cpp
@@ -70,6 +70,8 @@ ChannelDlg::ChannelDlg(ChannelDlgType type, const Channel& chan, QWidget * paren
         ui.hiddenchannelBox->hide();
     if (!versionSameOrLater(_Q(prop.szServerProtocolVersion), "5.10"))
         ui.singletxButton->hide();
+    if (!versionSameOrLater(_Q(prop.szServerProtocolVersion), "5.12"))
+        ui.streamGroupBox->hide();
 
     ui.audiocodecBox->addItem(tr("No Audio"), NO_CODEC);
 
@@ -199,6 +201,10 @@ ChannelDlg::ChannelDlg(ChannelDlgType type, const Channel& chan, QWidget * paren
 
         ui.agcBox->setEnabled(false);
         ui.gainlevelSlider->setEnabled(false);
+
+        ui.voiceTotDoubleSpinBox->setEnabled(false);
+        ui.mfTotDoubleSpinBox->setEnabled(false);
+
         ui.buttonBox->setStandardButtons(QDialogButtonBox::Close);
         ui.buttonBox->button(QDialogButtonBox::Close)->setText(tr("&Close"));
         ui.joinchanBox->setEnabled(false);
@@ -253,6 +259,9 @@ ChannelDlg::ChannelDlg(ChannelDlgType type, const Channel& chan, QWidget * paren
     ui.agcBox->setChecked(m_channel.audiocfg.bEnableAGC);
     ui.gainlevelSlider->setEnabled(m_channel.audiocfg.bEnableAGC);
     ui.gainlevelSlider->setValue(m_channel.audiocfg.nGainLevel / 1000);
+    // Stream Timeout
+    ui.voiceTotDoubleSpinBox->setValue(m_channel.nTimeOutTimerVoiceMSec / 1000.);
+    ui.mfTotDoubleSpinBox->setValue(m_channel.nTimeOutTimerMediaFileMSec / 1000.);
 
     slotUpdateSliderLabels();
     slotUpdateChannelPath(_Q(m_channel.szName));
@@ -351,6 +360,9 @@ Channel ChannelDlg::GetChannel() const
     {
         newchannel.audiocfg.nGainLevel = ui.gainlevelSlider->value()*1000;
     }
+
+    newchannel.nTimeOutTimerVoiceMSec = ui.voiceTotDoubleSpinBox->value() * 1000;
+    newchannel.nTimeOutTimerMediaFileMSec = ui.mfTotDoubleSpinBox->value() * 1000;
 
     return newchannel;
 }

--- a/Client/qtTeamTalk/channeldlg.cpp
+++ b/Client/qtTeamTalk/channeldlg.cpp
@@ -418,7 +418,7 @@ void ChannelDlg::slotUpdateChannelPath(const QString& str)
         ui.chanpathLabel->setText(_Q(path) + str);
     else
         ui.chanpathLabel->setText(QString());
-    ui.chanpathLabel->setAccessibleName(QString("%1 %2").arg(ui.label_7->text()).arg(ui.chanpathLabel->text()));
+    ui.chanpathLabel->setAccessibleName(QString("%1 %2").arg(ui.chanpathLabelFixed->text()).arg(ui.chanpathLabel->text()));
 
     QPushButton* btn = ui.buttonBox->button(QDialogButtonBox::Ok);
     if(btn)

--- a/Library/TeamTalk.NET/TeamTalk.cs
+++ b/Library/TeamTalk.NET/TeamTalk.cs
@@ -2689,6 +2689,16 @@ namespace BearWare
          * @c transmitUsersQueue. Default value is 500 msec. */
         public int nTransmitUsersQueueDelayMSec;        
 
+        /** @brief Time out timer for voice stream.
+         * The maximum time in miliseconds a user can transmit voice
+         * without changing stream ID. @see StreamType.STREAMTYPE_VOICE */
+        public int nTimeOutTimerVoiceMSec;
+
+        /** @brief Time out timer for media file stream.
+         * The maximum time in miliseconds a user can transmit a
+         * media file. @see StreamType.STREAMTYPE_MEDIAFILE_AUDIO */
+        public int nTimeOutTimerMediaFileMSec;
+        
         /** @brief Helper function for adding a user and
          * #BearWare.StreamType to @c transmitUsers */
         public void AddTransmitUser(int nUserID, StreamType uStreamType)

--- a/Library/TeamTalkJNI/jni/ttconvert-jni.cpp
+++ b/Library/TeamTalkJNI/jni/ttconvert-jni.cpp
@@ -252,6 +252,8 @@ void setChannel(JNIEnv* env, Channel& chan, jobject lpChannel, JConvert conv) {
     jfieldID fid_txusers = env->GetFieldID(cls_chan, "transmitUsers", "[[I");
     jfieldID fid_queueusers = env->GetFieldID(cls_chan, "transmitUsersQueue", "[I");
     jfieldID fid_switchdelay = env->GetFieldID(cls_chan, "nTransmitUsersQueueDelayMSec", "I");
+    jfieldID fid_totvoice = env->GetFieldID(cls_chan, "nTimeOutTimerVoiceMSec", "I");
+    jfieldID fid_totmf = env->GetFieldID(cls_chan, "nTimeOutTimerMediaFileMSec", "I");
 
     assert(fid_parentid);
     assert(fid_chanid);
@@ -269,6 +271,8 @@ void setChannel(JNIEnv* env, Channel& chan, jobject lpChannel, JConvert conv) {
     assert(fid_txusers);
     assert(fid_queueusers);
     assert(fid_switchdelay);
+    assert(fid_totvoice);
+    assert(fid_totmf);
 
     if(conv == N2J)
     {
@@ -308,6 +312,8 @@ void setChannel(JNIEnv* env, Channel& chan, jobject lpChannel, JConvert conv) {
         env->SetIntArrayRegion(intArr, 0, TT_TRANSMITQUEUE_MAX, TO_JINT_ARRAY(chan.transmitUsersQueue, tmp, TT_TRANSMITQUEUE_MAX));
         env->SetObjectField(lpChannel, fid_queueusers, intArr);
         env->SetIntField(lpChannel, fid_switchdelay, chan.nTransmitUsersQueueDelayMSec);
+        env->SetIntField(lpChannel, fid_totvoice, chan.nTimeOutTimerVoiceMSec);
+        env->SetIntField(lpChannel, fid_totmf, chan.nTimeOutTimerMediaFileMSec);
     }
     else
     {
@@ -335,6 +341,8 @@ void setChannel(JNIEnv* env, Channel& chan, jobject lpChannel, JConvert conv) {
         env->GetIntArrayRegion(intArr, 0, TT_TRANSMITQUEUE_MAX, tmp);
         TO_INT32_ARRAY(tmp, chan.transmitUsersQueue, TT_TRANSMITQUEUE_MAX);
         chan.nTransmitUsersQueueDelayMSec = env->GetIntField(lpChannel, fid_switchdelay);
+        chan.nTimeOutTimerVoiceMSec = env->GetIntField(lpChannel, fid_totvoice);
+        chan.nTimeOutTimerMediaFileMSec = env->GetIntField(lpChannel, fid_totmf);
     }
 
     setAudioCodec(env, chan.audiocodec, env->GetObjectField(lpChannel, fid_codec), conv);

--- a/Library/TeamTalkJNI/src/dk/bearware/Channel.java
+++ b/Library/TeamTalkJNI/src/dk/bearware/Channel.java
@@ -40,6 +40,8 @@ public class Channel {
     public int[][] transmitUsers = new int[Constants.TT_TRANSMITUSERS_MAX][2];
     public int[] transmitUsersQueue = new int[Constants.TT_TRANSMITQUEUE_MAX];
     public int nTransmitUsersQueueDelayMSec = 0;
+    public int nTimeOutTimerVoiceMSec = 0;
+    public int nTimeOutTimerMediaFileMSec = 0;
 
     public Channel() {
     }

--- a/Library/TeamTalkJNI/test/dk/bearware/TeamTalkTestCase.java
+++ b/Library/TeamTalkJNI/test/dk/bearware/TeamTalkTestCase.java
@@ -2807,6 +2807,7 @@ public abstract class TeamTalkTestCase extends TeamTalkTestCaseBase {
         Channel chan = buildDefaultChannel(ttclient1, "Opus");
         assertEquals("opus default", chan.audiocodec.nCodec, Codec.OPUS_CODEC);
         chan.uChannelType |= ChannelType.CHANNEL_SOLO_TRANSMIT;
+        chan.nTransmitUsersQueueDelayMSec = 500;
 
         assertTrue("join", waitCmdSuccess(ttclient1, ttclient1.doJoinChannel(chan), DEF_WAIT));
 
@@ -2837,7 +2838,7 @@ public abstract class TeamTalkTestCase extends TeamTalkTestCaseBase {
                 switch (msg.nClientEvent) {
                 case ClientEvent.CLIENTEVENT_CMD_CHANNEL_UPDATE :
                     assertTrue("Channel tx queue set", ttclient.getChannel(ttclient.getMyChannelID(), chan));
-                    assertEquals("myself in queue", ttclient.getMyUserID(), chan.transmitUsersQueue[0]);
+                    assertEquals("myself in queue #"+ ttclient.getMyUserID(), ttclient.getMyUserID(), chan.transmitUsersQueue[0]);
                     chanUpEvent = true;
                     break;
                 case ClientEvent.CLIENTEVENT_USER_STATECHANGE :
@@ -2955,6 +2956,7 @@ public abstract class TeamTalkTestCase extends TeamTalkTestCaseBase {
         Channel chan = buildDefaultChannel(ttclient1, "Opus");
         assertEquals("opus default", chan.audiocodec.nCodec, Codec.OPUS_CODEC);
         chan.uChannelType |= ChannelType.CHANNEL_SOLO_TRANSMIT;
+        chan.nTransmitUsersQueueDelayMSec = 500;
         assertTrue("join", waitCmdSuccess(ttclient1, ttclient1.doJoinChannel(chan), DEF_WAIT));
 
         TeamTalkBase ttclient2 = newClientInstance();

--- a/Library/TeamTalkLib/bin/dll/Convert.cpp
+++ b/Library/TeamTalkLib/bin/dll/Convert.cpp
@@ -1176,6 +1176,8 @@ bool Convert(const teamtalk::ChannelProp& chanprop, Channel& result)
     }
 
     result.nTransmitUsersQueueDelayMSec = chanprop.transmitswitchdelay;
+    result.nTimeOutTimerVoiceMSec = chanprop.totvoice;
+    result.nTimeOutTimerMediaFileMSec = chanprop.totmediafile;
 
     return true;
 }
@@ -1219,6 +1221,8 @@ bool Convert(const Channel& channel, teamtalk::ChannelProp& chanprop)
     }
 
     chanprop.transmitswitchdelay = channel.nTransmitUsersQueueDelayMSec;
+    chanprop.totvoice = channel.nTimeOutTimerVoiceMSec;
+    chanprop.totmediafile = channel.nTimeOutTimerMediaFileMSec;
 
     return true;
 }

--- a/Library/TeamTalkLib/bin/ttsrv/ServerXML.cpp
+++ b/Library/TeamTalkLib/bin/ttsrv/ServerXML.cpp
@@ -841,6 +841,10 @@ namespace teamtalk{
                 PutInteger(audcfgElement, "gain-level", chan.audiocfg.gain_level);
                 ReplaceElement(xmlChan, audcfgElement);
 
+                PutInteger(xmlChan, "transmit-delay-msec", chan.transmitswitchdelay);
+                PutInteger(xmlChan, "tot-voice-msec", chan.totvoice);
+                PutInteger(xmlChan, "tot-mediafile-msec", chan.totmediafile);
+
                 TiXmlElement txusersElement("transmit-users");
                 PutBoolean(txusersElement, "channelmsg-tx-all",
                            chan.transmitusers[STREAMTYPE_CHANNELMSG].find(TRANSMITUSERS_FREEFORALL) != chan.transmitusers[STREAMTYPE_CHANNELMSG].end());
@@ -954,6 +958,9 @@ namespace teamtalk{
                 GetInteger(*child, "max-users", newchan.maxusers);
                 GetInteger(*child, "channel-type", (int&)newchan.chantype);
                 GetInteger(*child, "userdata", newchan.userdata);
+                GetInteger(*child, "transmit-delay-msec", newchan.transmitswitchdelay);
+                GetInteger(*child, "tot-voice-msec", newchan.totvoice);
+                GetInteger(*child, "tot-mediafile-msec", newchan.totmediafile);
 
                 //get codec
 

--- a/Library/TeamTalkLib/teamtalk/Channel.h
+++ b/Library/TeamTalkLib/teamtalk/Channel.h
@@ -116,6 +116,10 @@ namespace teamtalk {
         const AudioConfig& GetAudioConfig() const { return m_audiocfg; }
         void SetUserData(int userdata) { m_userdata = userdata; }
         int GetUserData() const { return m_userdata; }
+        void SetTimeOutTimerVoice(const ACE_Time_Value& tm) { m_tot_voice = tm; }
+        ACE_Time_Value GetTimeOutTimerVoice() const { return m_tot_voice; }
+        void SetTimeOutTimerMediaFile(const ACE_Time_Value& tm) { m_tot_mediafile = tm; }
+        ACE_Time_Value GetTimeOutTimerMediaFile() const { return m_tot_mediafile; }
         ACE_TString GetChannelPath() const
         {
             ACE_TString pwc = GetName() + ACE_TString(CHANNEL_SEPARATOR);
@@ -450,6 +454,11 @@ namespace teamtalk {
             m_transmitqueue = users;
         }
 
+        const std::vector<int>& GetTransmitQueue() const
+        {
+            return m_transmitqueue;
+        }
+
         void SetTransmitSwitchDelay(const ACE_Time_Value& tm)
         {
             m_transmitswitch_delay = tm;
@@ -458,11 +467,6 @@ namespace teamtalk {
         const ACE_Time_Value& GetTransmitSwitchDelay() const
         {
             return m_transmitswitch_delay;
-        }
-
-        const std::vector<int>& GetTransmitQueue() const
-        {
-            return m_transmitqueue;
         }
 
         ChannelProp GetChannelProp() const
@@ -488,7 +492,8 @@ namespace teamtalk {
             GetFiles(prop.files, false);
             prop.transmitusers = m_transmitusers;
             prop.transmitswitchdelay = int(GetTransmitSwitchDelay().msec());
-
+            prop.totvoice = int(GetTimeOutTimerVoice().msec());
+            prop.totmediafile = int(GetTimeOutTimerMediaFile().msec());
             prop.transmitqueue = m_transmitqueue;
             prop.bans = m_bans;
             return prop;
@@ -529,6 +534,7 @@ namespace teamtalk {
         AudioCodec m_audiocodec;
         AudioConfig m_audiocfg;
         ChannelTypes m_chantype;
+        ACE_Time_Value m_tot_voice, m_tot_mediafile;
         //classroom transmission
         transmitusers_t m_transmitusers;
         //solo transmission

--- a/Library/TeamTalkLib/teamtalk/Commands.h
+++ b/Library/TeamTalkLib/teamtalk/Commands.h
@@ -32,7 +32,7 @@
 #include <ace/SString.h>
 #include "Common.h"
 
-#define TEAMTALK_PROTOCOL_VERSION ACE_TEXT("5.11")
+#define TEAMTALK_PROTOCOL_VERSION ACE_TEXT("5.12")
 
 /* parameter names */
 #define TT_USERID ACE_TEXT("userid")
@@ -137,6 +137,8 @@
 #define TT_TRANSMITSWITCHDELAY ACE_TEXT("switchdelay") // v5.10
 #define TT_LOGEVENTS ACE_TEXT("logevents") // v5.10
 #define TT_TEXTMSG_MORE ACE_TEXT("more") // v5.10
+#define TT_TOTVOICE ACE_TEXT("voicetot") // v5.12
+#define TT_TOTMEDIAFILE ACE_TEXT("mediafiletot") // v5.12
 
 //    Client ---> Server
 //    -------------------------

--- a/Library/TeamTalkLib/teamtalk/Common.h
+++ b/Library/TeamTalkLib/teamtalk/Common.h
@@ -641,6 +641,7 @@ namespace teamtalk {
         transmitusers_t transmitusers;
         std::vector<int> transmitqueue;
         int transmitswitchdelay = 0;
+        int totvoice = 0, totmediafile = 0;
         bannedusers_t bans;
         std::set<int> GetTransmitUsers(StreamType st) const
         {

--- a/Library/TeamTalkLib/teamtalk/client/ClientNode.cpp
+++ b/Library/TeamTalkLib/teamtalk/client/ClientNode.cpp
@@ -4453,6 +4453,8 @@ int ClientNode::DoJoinChannel(const ChannelProp& chanprop, bool forceexisting)
         AppendProperty(TT_CHANMSGUSERS, chanprop.GetTransmitUsers(STREAMTYPE_CHANNELMSG), command);
         if ((chanprop.chantype & CHANNEL_SOLO_TRANSMIT) && chanprop.transmitswitchdelay > 0)
             AppendProperty(TT_TRANSMITSWITCHDELAY, chanprop.transmitswitchdelay, command);
+        AppendProperty(TT_TOTVOICE, chanprop.totvoice, command);
+        AppendProperty(TT_TOTMEDIAFILE, chanprop.totmediafile, command);
     }
     else //already exists
     {
@@ -4660,6 +4662,8 @@ int ClientNode::DoMakeChannel(const ChannelProp& chanprop)
     AppendProperty(TT_CHANMSGUSERS, chanprop.GetTransmitUsers(STREAMTYPE_CHANNELMSG), command);
     if ((chanprop.chantype & CHANNEL_SOLO_TRANSMIT) && chanprop.transmitswitchdelay > 0)
         AppendProperty(TT_TRANSMITSWITCHDELAY, chanprop.transmitswitchdelay, command);
+    AppendProperty(TT_TOTVOICE, chanprop.totvoice, command);
+    AppendProperty(TT_TOTMEDIAFILE, chanprop.totmediafile, command);
     AppendProperty(TT_CMDID, GEN_NEXT_ID(m_cmdid_counter), command);
     command += EOL;
 
@@ -4692,6 +4696,8 @@ int ClientNode::DoUpdateChannel(const ChannelProp& chanprop)
     AppendProperty(TT_CHANMSGUSERS, chanprop.GetTransmitUsers(STREAMTYPE_CHANNELMSG), command);
     if (chanprop.chantype & CHANNEL_SOLO_TRANSMIT)
         AppendProperty(TT_TRANSMITSWITCHDELAY, chanprop.transmitswitchdelay, command);
+    AppendProperty(TT_TOTVOICE, chanprop.totvoice, command);
+    AppendProperty(TT_TOTMEDIAFILE, chanprop.totmediafile, command);
 
     AppendProperty(TT_CMDID, GEN_NEXT_ID(m_cmdid_counter), command);
     command += EOL;
@@ -5585,6 +5591,10 @@ void ClientNode::HandleAddChannel(const mstrings_t& properties)
     newchan->SetChannelTextMsgUsers(chanprop.transmitusers[STREAMTYPE_CHANNELMSG]);
     GetProperty(properties, TT_TRANSMITSWITCHDELAY, chanprop.transmitswitchdelay);
     newchan->SetTransmitSwitchDelay(ToTimeValue(chanprop.transmitswitchdelay));
+    GetProperty(properties, TT_TOTVOICE, chanprop.totvoice);
+    newchan->SetTimeOutTimerVoice(ToTimeValue(chanprop.totvoice));
+    GetProperty(properties, TT_TOTMEDIAFILE, chanprop.totmediafile);
+    newchan->SetTimeOutTimerMediaFile(ToTimeValue(chanprop.totmediafile));
 
 #if defined(ENABLE_ENCRYPTION)
     ACE_TString crypt_key;
@@ -5656,7 +5666,10 @@ void ClientNode::HandleUpdateChannel(const mstrings_t& properties)
     chan->SetChannelTextMsgUsers(chanprop.transmitusers[STREAMTYPE_CHANNELMSG]);
     GetProperty(properties, TT_TRANSMITSWITCHDELAY, chanprop.transmitswitchdelay);
     chan->SetTransmitSwitchDelay(ToTimeValue(chanprop.transmitswitchdelay));
-    chan->SetTransmitSwitchDelay(ToTimeValue(chanprop.transmitswitchdelay));
+    GetProperty(properties, TT_TOTVOICE, chanprop.totvoice);
+    chan->SetTimeOutTimerVoice(ToTimeValue(chanprop.totvoice));
+    GetProperty(properties, TT_TOTMEDIAFILE, chanprop.totmediafile);
+    chan->SetTimeOutTimerMediaFile(ToTimeValue(chanprop.totmediafile));
 
 #if defined(ENABLE_ENCRYPTION)
     ACE_TString crypt_key;

--- a/Library/TeamTalkLib/teamtalk/server/ServerChannel.h
+++ b/Library/TeamTalkLib/teamtalk/server/ServerChannel.h
@@ -36,6 +36,7 @@ namespace teamtalk {
         typedef Channel<ServerChannel, ServerUser> PARENT;
         ServerChannel(int channelid);
         ServerChannel(channel_t& parent, int channelid, const ACE_TString& name);
+        ~ServerChannel();
         // Used for channels with CHANNEL_SOLO_TRANSMIT. 'modified' is only set if 'true'
         bool CanTransmit(int userid, StreamType txtype, int streamid, bool* modified);
         void RemoveUser(int userid);
@@ -55,6 +56,8 @@ namespace teamtalk {
         void Init();
         // userid -> last transmit time
         std::map<int, ACE_Time_Value> m_lastUserPacket;
+        // userid (streamkey) -> stream-id started
+        std::map<int, ACE_Time_Value> m_streamstart;
         // userid -> stream id
         std::map<int, int> m_blockStreams, m_activeStreams;
         ACE_TString m_usernameOwner;

--- a/Library/TeamTalkLib/teamtalk/server/ServerNode.cpp
+++ b/Library/TeamTalkLib/teamtalk/server/ServerNode.cpp
@@ -3665,6 +3665,11 @@ ErrorMsg ServerNode::MakeChannel(const ChannelProp& chanprop,
     chan->SetDesktopUsers(chanprop.GetTransmitUsers(STREAMTYPE_DESKTOP));
     chan->SetMediaFileUsers(chanprop.GetTransmitUsers(STREAMTYPE_MEDIAFILE));
     chan->SetChannelTextMsgUsers(chanprop.GetTransmitUsers(STREAMTYPE_CHANNELMSG));
+    chan->SetTransmitQueue(chanprop.transmitqueue);
+    if (chanprop.transmitswitchdelay > 0) // inherit default from ServerChannel
+        chan->SetTransmitSwitchDelay(ToTimeValue(chanprop.transmitswitchdelay));
+    chan->SetTimeOutTimerVoice(ToTimeValue(chanprop.totvoice));
+    chan->SetTimeOutTimerMediaFile(ToTimeValue(chanprop.totmediafile));
     if (user)
         chan->SetOwner(*user);
 
@@ -3764,6 +3769,8 @@ ErrorMsg ServerNode::UpdateChannel(const ChannelProp& chanprop,
     chan->SetChannelTextMsgUsers(chanprop.GetTransmitUsers(STREAMTYPE_CHANNELMSG));
     chan->SetTransmitQueue(chanprop.transmitqueue);
     chan->SetTransmitSwitchDelay(ToTimeValue(chanprop.transmitswitchdelay));
+    chan->SetTimeOutTimerVoice(ToTimeValue(chanprop.totvoice));
+    chan->SetTimeOutTimerMediaFile(ToTimeValue(chanprop.totmediafile));
 
     UpdateChannel(chan, user);
 

--- a/Library/TeamTalkLib/teamtalk/server/ServerUser.cpp
+++ b/Library/TeamTalkLib/teamtalk/server/ServerUser.cpp
@@ -641,6 +641,8 @@ ErrorMsg ServerUser::HandleJoinChannel(const mstrings_t& properties)
     GetProperty(properties, TT_CHANMSGUSERS, chanprop.transmitusers[STREAMTYPE_CHANNELMSG]);
     GetProperty(properties, TT_PASSWORD, chanprop.passwd);
     GetProperty(properties, TT_TRANSMITSWITCHDELAY, chanprop.transmitswitchdelay);
+    GetProperty(properties, TT_TOTVOICE, chanprop.totvoice);
+    GetProperty(properties, TT_TOTMEDIAFILE, chanprop.totmediafile);
 
     if(chanprop.name.find(CHANNEL_SEPARATOR) != ACE_TString::npos)
     {
@@ -718,6 +720,8 @@ ErrorMsg ServerUser::HandleMakeChannel(const mstrings_t& properties)
     GetProperty(properties, TT_MEDIAFILEUSERS, chanprop.transmitusers[STREAMTYPE_MEDIAFILE]);
     GetProperty(properties, TT_CHANMSGUSERS, chanprop.transmitusers[STREAMTYPE_CHANNELMSG]);
     GetProperty(properties, TT_TRANSMITSWITCHDELAY, chanprop.transmitswitchdelay);
+    GetProperty(properties, TT_TOTVOICE, chanprop.totvoice);
+    GetProperty(properties, TT_TOTMEDIAFILE, chanprop.totmediafile);
 
     if(chanprop.name.find(CHANNEL_SEPARATOR) != ACE_TString::npos)
     {
@@ -761,6 +765,8 @@ ErrorMsg ServerUser::HandleUpdateChannel(const mstrings_t& properties)
         chanprop.transmitusers[STREAMTYPE_CHANNELMSG].clear();
     GetProperty(properties, TT_CHANMSGUSERS, chanprop.transmitusers[STREAMTYPE_CHANNELMSG]);
     GetProperty(properties, TT_TRANSMITSWITCHDELAY, chanprop.transmitswitchdelay);
+    GetProperty(properties, TT_TOTVOICE, chanprop.totvoice);
+    GetProperty(properties, TT_TOTMEDIAFILE, chanprop.totmediafile);
 
     if(GetUserRights() & USERRIGHT_MODIFY_CHANNELS)
     {
@@ -1504,6 +1510,9 @@ void ServerUser::DoAddChannel(const ServerChannel& channel, bool encrypted)
         AppendProperty(TT_CHANMSGUSERS, channel.GetChannelTextMsgUsers(), command);
     if (channel.GetChannelType() & CHANNEL_SOLO_TRANSMIT)
         AppendProperty(TT_TRANSMITSWITCHDELAY, channel.GetTransmitSwitchDelay().msec(), command);
+
+    AppendProperty(TT_TOTVOICE, channel.GetTimeOutTimerVoice().msec(), command);
+    AppendProperty(TT_TOTMEDIAFILE, channel.GetTimeOutTimerMediaFile().msec(), command);
     command += ACE_TString(EOL);
 
     TransmitCommand(command);
@@ -1567,6 +1576,9 @@ void ServerUser::DoUpdateChannel(const ServerChannel& channel, bool encrypted)
         AppendProperty(TT_TRANSMITQUEUE, channel.GetTransmitQueue(), command);
         AppendProperty(TT_TRANSMITSWITCHDELAY, channel.GetTransmitSwitchDelay().msec(), command);
     }
+    AppendProperty(TT_TOTVOICE, channel.GetTimeOutTimerVoice().msec(), command);
+    AppendProperty(TT_TOTMEDIAFILE, channel.GetTimeOutTimerMediaFile().msec(), command);
+
     command += ACE_TString(EOL);
 
     TransmitCommand(command);

--- a/Library/TeamTalkPy/TeamTalk5.py
+++ b/Library/TeamTalkPy/TeamTalk5.py
@@ -769,6 +769,8 @@ class Channel(Structure):
     ("transmitUsers", (INT32*2)*TT_TRANSMITUSERS_MAX),
     ("transmitUsersQueue", INT32*TT_TRANSMITQUEUE_MAX),
     ("nTransmitUsersQueueDelayMSec", INT32),
+    ("nTimeOutTimerVoiceMSec", INT32),
+    ("nTimeOutTimerMediaFileMSec", INT32),
     ]
     def __init__(self):
         assert(DBG_SIZEOF(TTType.CHANNEL) == ctypes.sizeof(Channel))

--- a/Library/TeamTalk_DLL/TeamTalk.h
+++ b/Library/TeamTalk_DLL/TeamTalk.h
@@ -2575,6 +2575,14 @@ extern "C" {
          * specifies the delay before switching to next user in 
          * @c transmitUsersQueue. Default value is 500 msec. */
         INT32 nTransmitUsersQueueDelayMSec;
+        /** @brief Time out timer for voice stream.
+         * The maximum time in miliseconds a user can transmit voice
+         * without changing stream ID. @see STREAMTYPE_VOICE */
+        INT32 nTimeOutTimerVoiceMSec;
+        /** @brief Time out timer for media file stream.
+         * The maximum time in miliseconds a user can transmit a
+         * media file. @see STREAMTYPE_MEDIAFILE_AUDIO */
+        INT32 nTimeOutTimerMediaFileMSec;
     } Channel;
 
 


### PR DESCRIPTION
This fixes #22.

A voice or media file stream can be limited to last a maximum duration after which they are blocked. User will have to toggle PTT to transmit again for voice stream. Media file stream will have to be restarted.