### PR TITLE
Restore 'Hear myself' upon new connection

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -13,6 +13,7 @@ Default Qt Client
 - Removed public servers from server list
 - Ability to specify max duration of voice and media file streams (time out timer) in "Channel" dialog
 - Changed to Qt 6.6 beta1 on macOS
+- State of "Hear myself" restore at startup
 Accessible Windows Client
 - Classic client is no longer available in Windows installer
 Android Client

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -3006,6 +3006,8 @@ void MainWindow::processMyselfJoined(int channelid)
         updateAudioStorage(false, AUDIOSTORAGE_SINGLEFILE);
         updateAudioStorage(true, AUDIOSTORAGE_SINGLEFILE);
     }
+
+    slotMeHearMyself(ttSettings->value(SETTINGS_CONNECTION_HEAR_MYSELF, SETTINGS_CONNECTION_HEAR_MYSELF_DEFAULT).toBool());
 }
 
 void MainWindow::processMyselfLeft(int /*channelid*/)
@@ -4533,6 +4535,8 @@ void MainWindow::slotMeHearMyself(bool checked/*=false*/)
             m_commands[cmdid] = CMD_COMPLETE_UNSUBSCRIBE;
         }
     }
+    if (QObject::sender() == ui.actionHearMyself)
+        ttSettings->setValue(SETTINGS_CONNECTION_HEAR_MYSELF, ui.actionHearMyself->isChecked());
 }
 
 void MainWindow::slotMeEnableVoiceActivation(bool checked)

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -3007,7 +3007,8 @@ void MainWindow::processMyselfJoined(int channelid)
         updateAudioStorage(true, AUDIOSTORAGE_SINGLEFILE);
     }
 
-    slotMeHearMyself(ttSettings->value(SETTINGS_CONNECTION_HEAR_MYSELF, SETTINGS_CONNECTION_HEAR_MYSELF_DEFAULT).toBool());
+    if (ttSettings->value(SETTINGS_CONNECTION_HEAR_MYSELF, SETTINGS_CONNECTION_HEAR_MYSELF_DEFAULT).toBool())
+        subscribeCommon(true, SUBSCRIBE_VOICE, TT_GetMyUserID(ttInst));
 }
 
 void MainWindow::processMyselfLeft(int /*channelid*/)
@@ -4521,22 +4522,8 @@ void MainWindow::slotMeEnablePushToTalk(bool checked)
 
 void MainWindow::slotMeHearMyself(bool checked/*=false*/)
 {
-    User user;
-    if (ui.channelsWidget->getUser(TT_GetMyUserID(ttInst), user))
-    {
-        if (checked)
-        {
-            int cmdid = TT_DoSubscribe(ttInst, TT_GetMyUserID(ttInst), SUBSCRIBE_VOICE);
-            m_commands[cmdid] = CMD_COMPLETE_SUBSCRIBE;
-        }
-        else
-        {
-            int cmdid = TT_DoUnsubscribe(ttInst, TT_GetMyUserID(ttInst), SUBSCRIBE_VOICE);
-            m_commands[cmdid] = CMD_COMPLETE_UNSUBSCRIBE;
-        }
-    }
-    if (QObject::sender() == ui.actionHearMyself)
-        ttSettings->setValue(SETTINGS_CONNECTION_HEAR_MYSELF, ui.actionHearMyself->isChecked());
+    subscribeCommon(checked, SUBSCRIBE_VOICE, TT_GetMyUserID(ttInst));
+    ttSettings->setValue(SETTINGS_CONNECTION_HEAR_MYSELF, checked);
 }
 
 void MainWindow::slotMeEnableVoiceActivation(bool checked)

--- a/Client/qtTeamTalk/settings.h
+++ b/Client/qtTeamTalk/settings.h
@@ -186,6 +186,8 @@
 #define SETTINGS_CONNECTION_SUBSCRIBE_MEDIAFILE_DEFAULT true
 #define SETTINGS_CONNECTION_TCPPORT                 "connection/localtcpport"
 #define SETTINGS_CONNECTION_UDPPORT                 "connection/localudpport"
+#define SETTINGS_CONNECTION_HEAR_MYSELF                            "connection/hear-myself"
+#define SETTINGS_CONNECTION_HEAR_MYSELF_DEFAULT                            false
 
 #define SOUNDDEVICEID_DEFAULT  -2
 


### PR DESCRIPTION
@CoBC I've simplified it a bit by just using subscribeCommon() which is already there. Also as I've mentioned earlier I'm not a big fan of [QObject::sender()](https://doc.qt.io/qt-6/qobject.html#sender).