### PR TITLE
Change 'connection lost' to server's user timeout times 2

### DIFF
--- a/Library/TeamTalkLib/bin/dll/Convert.cpp
+++ b/Library/TeamTalkLib/bin/dll/Convert.cpp
@@ -1699,7 +1699,7 @@ void Convert(const teamtalk::ClientStats& stats, ClientStatistics& result)
 
 void Convert(const ClientKeepAlive& ka, teamtalk::ClientKeepAlive& result)
 {
-    result.connection_lost.msec(ka.nConnectionLostMSec);
+    result.connection_lost_timeout.msec(ka.nConnectionLostMSec);
     result.tcp_keepalive_interval.msec(ka.nTcpKeepAliveIntervalMSec);
     result.udp_keepalive_interval.msec(ka.nUdpKeepAliveIntervalMSec);
     result.udp_keepalive_rtx.msec(ka.nUdpKeepAliveRTXMSec);
@@ -1709,7 +1709,7 @@ void Convert(const ClientKeepAlive& ka, teamtalk::ClientKeepAlive& result)
 
 void Convert(const teamtalk::ClientKeepAlive& ka, ClientKeepAlive& result)
 {
-    result.nConnectionLostMSec = ka.connection_lost.msec();
+    result.nConnectionLostMSec = ka.connection_lost_timeout.msec();
     result.nTcpKeepAliveIntervalMSec = ka.tcp_keepalive_interval.msec();
     result.nUdpKeepAliveIntervalMSec = ka.udp_keepalive_interval.msec();
     result.nUdpKeepAliveRTXMSec = ka.udp_keepalive_rtx.msec();

--- a/Library/TeamTalkLib/teamtalk/client/ClientNode.h
+++ b/Library/TeamTalkLib/teamtalk/client/ClientNode.h
@@ -139,8 +139,8 @@ namespace teamtalk {
 
     struct ClientKeepAlive
     {
-        // no reply for three minutes, consider server dead
-        ACE_Time_Value connection_lost = ACE_Time_Value(180, 0);
+        // no reply from server after this then report connection lost
+        ACE_Time_Value connection_lost_timeout = ACE_Time_Value(180, 0);
         // Defaults to 1/2 of server's user-timeout
         ACE_Time_Value tcp_keepalive_interval;
         // Delay between UDP keepalive packets


### PR DESCRIPTION
Previously it has hardcoded to 180 seconds.

This fixes #1970 
