### PR TITLE
Minor Update for iTeamTalk English Translation

### DIFF
--- a/Client/iTeamTalk/iTeamTalk/en.lproj/Localizable.strings
+++ b/Client/iTeamTalk/iTeamTalk/en.lproj/Localizable.strings
@@ -381,7 +381,7 @@
 "No Voice Activation" = "No Voice Activation";
 
 /* default nickname */
-"Noname" = "Noname";
+"Noname" = "NoName";
 
 /* serverlist */
 "Official server" = "Official server";

--- a/Client/iTeamTalk/iTeamTalk/en.lproj/Localizable.strings
+++ b/Client/iTeamTalk/iTeamTalk/en.lproj/Localizable.strings
@@ -295,7 +295,7 @@
 "Log message" = "Log message";
 
 /* log entry */
-"Logged on to server" = "Logged on to server";
+"Logged on to server" = "Logged in to server";
 
 /* preferences */
 "Male" = "Male";

--- a/Client/iTeamTalk/iTeamTalk/en.lproj/Localizable.strings
+++ b/Client/iTeamTalk/iTeamTalk/en.lproj/Localizable.strings
@@ -247,7 +247,7 @@
 "has left the channel" = "has left the channel";
 
 /* TTS EVENT */
-"has logged on" = "has logged on";
+"has logged on" = "has logged in";
 
 /* TTS EVENT */
 "has logged out" = "has logged out";

--- a/Client/iTeamTalk/iTeamTalk/en.lproj/Localizable.strings
+++ b/Client/iTeamTalk/iTeamTalk/en.lproj/Localizable.strings
@@ -436,10 +436,10 @@
 "Play sound when transmit ready in \"No Interruptions\" channel" = "Play sound when transmit ready in \"No Interruptions\" channel";
 
 /* preferences */
-"Play sound when user logs off to the server" = "Play sound when user logs off to the server";
+"Play sound when user logs off to the server" = "Play sound when user logs out from the server";
 
 /* preferences */
-"Play sound when user logs on to the server" = "Play sound when user logs on to the server";
+"Play sound when user logs on to the server" = "Play sound when user logs in to the server";
 
 /* preferences */
 "Play sound when voice activation is triggered" = "Play sound when voice activation is triggered";


### PR DESCRIPTION
I make this change is because other client like QTTeamTalk and TeamTalk5Droid use the word "logged in" instead of "logged on". Feel free to reject this pull request if you think no need to change.