### PR TITLE
add missing TT types To enum

### DIFF
--- a/Library/TeamTalkLib/bin/dll/TeamTalk.cpp
+++ b/Library/TeamTalkLib/bin/dll/TeamTalk.cpp
@@ -3439,6 +3439,12 @@ TEAMTALKDLL_API INT32 TT_DBG_SIZEOF(IN TTType nType)
         return sizeof(WebRTCAudioPreprocessor);
     case __ENCRYPTIONCONTEXT:
         return sizeof(EncryptionContext);
+    case __SOUNDDEVICEEFFECTS:
+        return sizeof(SoundDeviceEffects);
+    case __DESKTOPWINDOW:
+        return sizeof(DesktopWindow);
+    case __ABUSEPREVENTION:
+        return sizeof(AbusePrevention);
     }
     return 0;
 }

--- a/Library/TeamTalk_DLL/TeamTalk.h
+++ b/Library/TeamTalk_DLL/TeamTalk.h
@@ -3962,6 +3962,9 @@ extern "C" {
         __JITTERCONFIG            = 41,
         __WEBRTCAUDIOPREPROCESSOR = 42,
         __ENCRYPTIONCONTEXT       = 43,
+        __SOUNDDEVICEEFFECTS       = 44,
+        __DESKTOPWINDOW       = 45,
+        __ABUSEPREVENTION       = 46,
     } TTType;
 
     /**


### PR DESCRIPTION
Added missing TT types to corresponding enum and cases in DBG_SIZEOF because without this size comparisons of these structs will fail