### PR TITLE
Fix all stream types being enabled when all should be disabled

### DIFF
--- a/Client/qtTeamTalk/channelstree.cpp
+++ b/Client/qtTeamTalk/channelstree.cpp
@@ -250,6 +250,7 @@ void ChannelsTree::getTransmitUsers(int channelid,
         Q_ASSERT(child);
         if(child->type() != USER_TYPE)
             continue;
+        transmitUsers[child->data(COLUMN_ITEM, Qt::UserRole).toInt()] = STREAMTYPE_NONE;
         if ((bool)child->checkState(COLUMN_CHANMSG))
             transmitUsers[child->data(COLUMN_ITEM, Qt::UserRole).toInt()] |= STREAMTYPE_CHANNELMSG;
         if ((bool)child->checkState(COLUMN_VOICE))


### PR DESCRIPTION
This only occurs when using mouse as input.

This fixes #1663.