### PR TITLE
Exclude VS2019Release32 from Windows workflow

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,6 +30,8 @@ jobs:
             qtarch: win64_msvc2019_64
             msystem: MINGW64
             portablearch: win64
+        exlude:
+          - name: VS2019Release32
 
     runs-on: ${{ matrix.vmimage }}
     name: ${{ matrix.name }}


### PR DESCRIPTION
Qt deploy cannot find OpenSSL libraries libcrypto.dll and libssl.dll