### PR TITLE
[Docs]: Fix typo in advanced TeamTalk5 documentation.

### DIFF
--- a/Documentation/TeamTalk/advanced.md
+++ b/Documentation/TeamTalk/advanced.md
@@ -1,7 +1,7 @@
 # Advanced Topics {#advanced}
 
 The TeamTalk client supports a couple of command-line arguments and
-additionals configuration options which are explain in the following
+additional configuration options which are explain in the following
 sections:
 
 - [Command-line arguments](@ref cmdline)


### PR DESCRIPTION
This PR simply fixes a typo I found in the advanced documentation.