### PR TITLE
Change foreground type to include FOREGROUND_SERVICE_TYPE_MICROPHONE

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -29,6 +29,10 @@ Server
 - Support for banning IP-address as subnet, e.g. 192.168.0.0/24 or 2a02:09b0:402b:eed8::/63
 - Owner of ban is stored
 
+Version 5.14.2, unreleased
+Android Client
+- Fixed crash issue on Android 14 upon establishing connection to server
+
 Version 5.14.1, 2023/10/21
 Android Client
 - Fixed importing of tt files on newer android versions

--- a/Client/TeamTalkAndroid/build.gradle
+++ b/Client/TeamTalkAndroid/build.gradle
@@ -31,8 +31,8 @@ android {
         applicationId "dk.bearware.gui"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 125
-        versionName '5.14.1'
+        versionCode 126
+        versionName '5.14.2'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/Client/TeamTalkAndroid/src/main/AndroidManifest.xml
+++ b/Client/TeamTalkAndroid/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30"></uses-permission>
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"></uses-permission>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"></uses-permission>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"></uses-permission>
     <uses-permission android:name="android.hardware.sensor.proximity"></uses-permission>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
@@ -92,6 +93,7 @@
 
         <service
             android:name="dk.bearware.backend.TeamTalkService"
+            android:foregroundServiceType="microphone"
             android:enabled="true"
             android:exported="true"
             android:stopWithTask="true" />

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
@@ -33,6 +33,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.ServiceInfo;
 import android.media.AudioManager;
 import android.os.AsyncTask;
 import android.os.Binder;
@@ -374,7 +375,7 @@ public class TeamTalkService extends Service
     @SuppressLint("NewApi")
     private void displayNotification(boolean enabled) {
         if (enabled) {
-            final int UI_WIDGET_ID = 1;
+            final int UI_WIDGET_ID = android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE | ServiceInfo.FLAG_STOP_WITH_TASK;
             if (widget == null) {
                 Intent ui = new Intent(this, MainActivity.class);
                 ui.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);


### PR DESCRIPTION
Android 14 with targetSdkVersion=34 and
android.content.pm.ServiceInfo.FLAG_STOP_WITH_TASK causes the following exception:

android.app.MissingForegroundServiceTypeException: Starting FGS without a type  callerApp=ProcessRecord{91b6812 15893:dk.bearware.gui/u0a192} targetSDK=34 ...
	at android.app.Service.startForeground(Service.java:775)
	at dk.bearware.backend.TeamTalkService.displayNotification(TeamTalkService.java:402)