### PR TITLE
Fix CMake 3.5 deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.1)
+# Relative paths are not supported pre-2.8.1, target_link_libraries seems to require 3.0.2
+cmake_minimum_required(VERSION 3.5)
+
 project (TeamTalk5SDK)
 
 # To build TeamTalk libraries, clients and servers including all their

--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
-
 project (TeamTalkClients)
 
 if (MSVC)

--- a/Client/TeamTalkClassic/CMakeLists.txt
+++ b/Client/TeamTalkClassic/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
 project (TeamTalk5Classic)
 
 include(CMakeDependentOption)

--- a/Client/qtTeamTalk/CMakeLists.txt
+++ b/Client/qtTeamTalk/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
-
 if (CMAKE_VERSION VERSION_LESS "3.7.0")
   set(CMAKE_INCLUDE_CURRENT_DIR ON)
 endif()

--- a/Client/qtTeamTalk/qt/CMakeLists.txt
+++ b/Client/qtTeamTalk/qt/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
-
 project(Qt)
 
 include(ExternalProject)

--- a/Client/ttserverlog/CMakeLists.txt
+++ b/Client/ttserverlog/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
 project (ttserverlog)
 
 include_directories (../../Library/TeamTalk_DLL)

--- a/Library/TeamTalkJNI/CMakeLists.txt
+++ b/Library/TeamTalkJNI/CMakeLists.txt
@@ -1,5 +1,3 @@
-# Relative paths are not supported pre-2.8.1, target_link_libraries seems to require 3.0.2
-cmake_minimum_required(VERSION 3.1)
 project (TeamTalk5JNI)
 
 function(set_output_dir target dir)

--- a/Library/TeamTalkLib/CMakeLists.txt
+++ b/Library/TeamTalkLib/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
 project (TeamTalk5Lib)
 
 include (FeatureSummary)

--- a/Library/TeamTalkLib/build/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
-
 project(Toolchain)
 
 include(ExternalProject)

--- a/Library/TeamTalkLib/build/ace/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/ace/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
-
 project(ACE)
 
 include(ExternalProject)

--- a/Library/TeamTalkLib/build/catch2/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/catch2/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
-
 project(Catch2)
 
 include(ExternalProject)

--- a/Library/TeamTalkLib/build/ffmpeg/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/ffmpeg/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
-
 project(OpenSSL)
 
 include(ExternalProject)

--- a/Library/TeamTalkLib/build/libvpx/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/libvpx/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
-
 project(LibVPX)
 
 include(ExternalProject)

--- a/Library/TeamTalkLib/build/ogg/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/ogg/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
-
 project(Ogg)
 
 include(ExternalProject)

--- a/Library/TeamTalkLib/build/openssl/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/openssl/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
-
 project(OpenSSL)
 
 include(ExternalProject)

--- a/Library/TeamTalkLib/build/opus/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/opus/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
-
 project(OPUS)
 
 include(ExternalProject)

--- a/Library/TeamTalkLib/build/opustools/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/opustools/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
-
 project(OPUSTools)
 
 include(ExternalProject)

--- a/Library/TeamTalkLib/build/portaudio/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/portaudio/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
-
 project(PortAudio)
 
 include(ExternalProject)

--- a/Library/TeamTalkLib/build/speex/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/speex/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
-
 project(Speex)
 
 include(ExternalProject)

--- a/Library/TeamTalkLib/build/speexdsp/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/speexdsp/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
-
 project(SpeexDSP)
 
 include(ExternalProject)

--- a/Library/TeamTalkLib/build/tinyxml/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/tinyxml/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
-
 project(TinyXML)
 
 include(ExternalProject)

--- a/Library/TeamTalkLib/build/webrtc/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/webrtc/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
-
 project(WebRTC)
 
 include(ExternalProject)

--- a/Library/TeamTalkLib/build/zlib/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/zlib/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
-
 project(ZLib)
 
 include(ExternalProject)

--- a/Server/TeamTalkServer/CMakeLists.txt
+++ b/Server/TeamTalkServer/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
 project (TeamTalk5ProServer)
 
 include_directories (../../Library/TeamTalk_DLL)


### PR DESCRIPTION
All supported platforms have CMake >= 3.1 anyway.