### PR TITLE
fixes all client lojic checks

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -4,6 +4,7 @@
 
 Version 5.16, unreleased
 Default Qt Client
+- fixed some client lojic checks, such as you had access to server's banned users when you were an operator of a channel
 - Option to show server's message of the day in a welcome dialog box
 - Fixed "Gender" property not being saved in .tt files
 Android Client

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -6103,8 +6103,9 @@ void MainWindow::slotUpdateUI()
     ui.actionMuteMediaFile->setEnabled(userid>0);
     ui.actionVolume->setEnabled(userid>0);
     ui.actionOp->setEnabled(userid>0);
-    ui.actionKickFromChannel->setEnabled(userid>0);
+    ui.actionKickFromChannel->setEnabled(userid>0 && (me_op || userrights & USERRIGHT_KICK_USERS));
     ui.actionKickFromServer->setEnabled(userid>0 && (userrights & USERRIGHT_KICK_USERS));
+    ui.actionKickAndBanFromChannel->setEnabled(userid>0 && (me_op || userrights & USERRIGHT_BAN_USERS));
     ui.actionKickBan->setEnabled(userid>0 && (userrights & USERRIGHT_BAN_USERS));
     ui.actionDesktopAccessAllow->setEnabled(userid>0);
 
@@ -6117,12 +6118,12 @@ void MainWindow::slotUpdateUI()
     ui.actionDesktopInput->setEnabled(userid>0);
     ui.actionMediaFile->setEnabled(userid>0);
     //intercept only works for admins
-    ui.actionInterceptUserMessages->setEnabled(userid>0);
-    ui.actionInterceptChannelMessages->setEnabled(userid>0);
-    ui.actionInterceptVoice->setEnabled(userid>0);
-    ui.actionInterceptVideo->setEnabled(userid>0);
-    ui.actionInterceptDesktop->setEnabled(userid>0);
-    ui.actionInterceptMediaFile->setEnabled(userid>0);
+    ui.actionInterceptUserMessages->setEnabled(userid>0 && me_admin);
+    ui.actionInterceptChannelMessages->setEnabled(userid>0 && me_admin);
+    ui.actionInterceptVoice->setEnabled(userid>0 && me_admin);
+    ui.actionInterceptVideo->setEnabled(userid>0 && me_admin);
+    ui.actionInterceptDesktop->setEnabled(userid>0 && me_admin);
+    ui.actionInterceptMediaFile->setEnabled(userid>0 && me_admin);
 
     ui.actionIncreaseVoiceVolume->setEnabled(userid>0 && user.nVolumeVoice < SOUND_VOLUME_MAX);
     ui.actionLowerVoiceVolume->setEnabled(userid>0 && user.nVolumeVoice > SOUND_VOLUME_MIN);
@@ -6163,7 +6164,7 @@ void MainWindow::slotUpdateUI()
     ui.actionGenerateTTURL->setEnabled(chanid > 0);
     ui.actionSpeakChannelInfo->setEnabled(tts);
     ui.actionSpeakChannelStat->setEnabled(tts);
-    ui.actionBannedUsersInChannel->setEnabled(chanid>0);
+    ui.actionBannedUsersInChannel->setEnabled(chanid>0 && (me_op || userrights & USERRIGHT_BAN_USERS));
     ui.actionCreateChannel->setEnabled(chanid>0 || mychannel>0);
     ui.actionUpdateChannel->setEnabled(chanid>0);
     ui.actionDeleteChannel->setEnabled(chanid>0);
@@ -6200,12 +6201,12 @@ void MainWindow::slotUpdateUI()
 
     //Server-menu items
     ui.actionUserAccounts->setEnabled(auth);
-    ui.actionBannedUsers->setEnabled(me_op || (userrights & USERRIGHT_BAN_USERS));
+    ui.actionBannedUsers->setEnabled(userrights & USERRIGHT_BAN_USERS);
     ui.actionOnlineUsers->setEnabled(auth);
-    ui.actionBroadcastMessage->setEnabled(auth && (userrights & USERRIGHT_TEXTMESSAGE_BROADCAST));
+    ui.actionBroadcastMessage->setEnabled(userrights & USERRIGHT_TEXTMESSAGE_BROADCAST);
     ui.actionServerProperties->setEnabled(auth);
-    ui.actionSaveConfiguration->setEnabled(auth && me_admin);
-    ui.actionServerStatistics->setEnabled(auth && me_admin);
+    ui.actionSaveConfiguration->setEnabled(me_admin);
+    ui.actionServerStatistics->setEnabled(me_admin);
 
     ui.uploadButton->setEnabled(m_myuseraccount.uUserRights & USERRIGHT_UPLOAD_FILES);
     ui.downloadButton->setEnabled(m_myuseraccount.uUserRights & USERRIGHT_DOWNLOAD_FILES);


### PR DESCRIPTION
in the qt client, i found some incorrect lojic checks for options, which some of them cause some Strange problems. For example, one of them were caused by this line we had in the server options section
ui.actionBannedUsers->setEnabled(me_op || (userrights & USERRIGHT_BAN_USERS));
as you can look and reproduce, with this line, even if a teamtalk user doesn't have the "user can ban users from server" right, if that user simply becomes channel operator in any channel either temporary or permenantly, that user would be able to klick "banned users" option in the server submenu, which has now been fixed. However, i think i can guess why this code mistake had happened. You were supposed to use this condition for the "banned users from channel" option, but it was rongly aplyed to the "banned users from server" option, which also now has been fixed, i have moved everything to their proper places.