### PR TITLE
fixed join channel option

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -4,6 +4,7 @@
 
 Version 5.16, unreleased
 Default Qt Client
+- Fixed join channel / leave channel option
 - Option to show server's message of the day in a welcome dialog box
 - Don't display server name when disconnected from server where not authentified
 - Option to show channel topic in channel list

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -6147,15 +6147,20 @@ void MainWindow::slotUpdateUI()
     {
     }
 
-    if(user_chanid == mychannel)
+    if(chanid>0 && user_chanid>0 && mychannel>0 && user_chanid == mychannel)
     {
         ui.actionJoinChannel->setText(tr("&Leave Channel"));
         ui.actionJoinChannel->setShortcut(tr("CTRL+L"));
     }
-    else
+    else if(chanid>0 && user_chanid != mychannel)
     {
         ui.actionJoinChannel->setText(tr("&Join Channel"));
         ui.actionJoinChannel->setShortcut(tr("CTRL+J"));
+    }
+    else
+    {
+        ui.actionJoinChannel->setText(tr("Join/Leave &Channel"));
+        ui.actionJoinChannel->setShortcut(tr("CTRL+C"));
     }
 
     ui.actionJoinChannel->setEnabled(chanid>0);

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -6147,7 +6147,7 @@ void MainWindow::slotUpdateUI()
     {
     }
 
-    if(chanid>0 && user_chanid>0 && mychannel>0 && user_chanid == mychannel)
+    if(chanid>0 && user_chanid == mychannel)
     {
         ui.actionJoinChannel->setText(tr("&Leave Channel"));
         ui.actionJoinChannel->setShortcut(tr("CTRL+L"));


### PR DESCRIPTION
now when focused on a user and not a channel, or when not connected and accessing the channel menu from the alt menu, the label of join channel option will no longer be announced "Leave Channel", it'll be announced "Join/Leave Channel" instead.