### PR TITLE
Android client: navigate up button behaviour fix

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -342,12 +342,15 @@ extends AppCompatActivity
                 break;
             }
             case android.R.id.home : {
-                Channel parentChannel = ((mViewPager.getCurrentItem() == SectionsPagerAdapter.CHANNELS_PAGE)
+                int currentPage = mViewPager.getCurrentItem();
+                Channel parentChannel = ((currentPage == SectionsPagerAdapter.CHANNELS_PAGE)
                                          && (curchannel != null)
                                          && (curchannel.nChannelID != ttclient.getRootChannelID())) ?
                     ttservice.getChannels().get(curchannel.nParentID) :
                     null;
-                if ((parentChannel != null) && (parentChannel.nChannelID > 0)) {
+                if (currentPage != SectionsPagerAdapter.CHANNELS_PAGE) {
+                    mViewPager.setCurrentItem(SectionsPagerAdapter.CHANNELS_PAGE);
+                } else if ((parentChannel != null) && (parentChannel.nChannelID > 0)) {
                     setCurrentChannel(parentChannel);
                     channelsAdapter.notifyDataSetChanged();
                 }


### PR DESCRIPTION
At first this button should switch to the channels tab. Anyway, it
definitely should not kick user out of the server if some other tab is
selected.