### PR TITLE
A couple of fixes for requesting permissions in the Android client

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/Permissions.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/Permissions.java
@@ -80,11 +80,13 @@ public enum Permissions {
     }
 
     public boolean request(@NonNull Activity activity) {
+        return request(activity, false);
+    }
+
+    public boolean request(@NonNull Activity activity, boolean noWarn) {
         boolean state = isGranted(activity.getBaseContext());
         if (!state) {
-            if (ActivityCompat.shouldShowRequestPermissionRationale(activity, id)) {
-                Toast.makeText(activity.getBaseContext(), msgResId, Toast.LENGTH_LONG).show();
-            } else {
+            if (!ActivityCompat.shouldShowRequestPermissionRationale(activity, id)) {
                 boolean busy = false;
                 for (Permissions p : values())
                     if (p.pending) {
@@ -96,6 +98,8 @@ public enum Permissions {
                 } else {
                     emitRequest(activity);
                 }
+            } else if (!noWarn) {
+                Toast.makeText(activity.getBaseContext(), msgResId, Toast.LENGTH_LONG).show();
             }
         }
         return state;
@@ -108,7 +112,7 @@ public enum Permissions {
 
     @Nullable
     public static Permissions onRequestResult(@NonNull Activity activity, int requestCode, @NonNull int[] grantResults) {
-        Permissions permission = ((requestCode > 0) && (requestCode <= values().length)) ? values()[requestCode - 1] : null;
+        Permissions permission = fromRequestCode(requestCode);
         boolean granted = (grantResults.length > 0) && (grantResults[0] == PackageManager.PERMISSION_GRANTED);
         if (permission != null) {
             permission.pending = false;
@@ -124,6 +128,11 @@ public enum Permissions {
             next.emitRequest(activity);
         }
         return permission;
+    }
+
+    @Nullable
+    public static Permissions fromRequestCode(int requestCode) {
+        return ((requestCode > 0) && (requestCode <= values().length)) ? values()[requestCode - 1] : null;
     }
 
 }

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -763,12 +763,10 @@ extends AppCompatActivity
     }
 
     private boolean requestMediaPermissions() {
-        boolean images = Permissions.READ_MEDIA_IMAGES.request(this);
-        boolean video = Permissions.READ_MEDIA_VIDEO.request(this);
-        boolean audio = Permissions.READ_MEDIA_AUDIO.request(this);
-        return areMediaPermissionsComplete() ?
-            (images || video || audio) :
-            false;
+        Permissions.READ_MEDIA_IMAGES.request(this, true);
+        Permissions.READ_MEDIA_VIDEO.request(this, true);
+        Permissions.READ_MEDIA_AUDIO.request(this, true);
+        return areMediaPermissionsComplete();
     }
 
     private boolean areMediaPermissionsComplete() {
@@ -1929,8 +1927,13 @@ private EditText newmsg;
                                            @NonNull String[] permissions, @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         Permissions granted = Permissions.onRequestResult(this, requestCode, grantResults);
-        if (granted == null)
-            return;
+        if (granted == null) {
+            granted = Permissions.fromRequestCode(requestCode);
+            if ((granted != Permissions.READ_MEDIA_IMAGES) &&
+                (granted != Permissions.READ_MEDIA_VIDEO) &&
+                (granted != Permissions.READ_MEDIA_AUDIO))
+                return;
+        }
         switch (granted) {
             case READ_EXTERNAL_STORAGE:
             case READ_MEDIA_IMAGES:


### PR DESCRIPTION
1) Implemented requests queue to prevent responses mess-up and some
dialogs loss.

2) When all media files (images, video and audio) access is not
granted in modern Android, other files (text or pdf documents for
instance) still can be read. Thus, files upload facility remains actual
in this case.