### PR TITLE
Android client. Fixed some functions which will be explaned in the discription

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -14,6 +14,9 @@ Default Qt Client
 - Fixed sort by size on file list
 - OPUS codec updated to v1.5.1
 Android Client
+- admins can now upload files to the channels they have not joined
+- Navigating back now also closes root channel tree like other channels raather than disconnecting from the server
+- It is now possible to move users to root channel too
 - Intercept options for admins
 - Navigating back returns to Channels-tab prior to disconnecting
 - User menu action to grant/revoke channel operator

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -1417,11 +1417,9 @@ private EditText newmsg;
             ttclient.getMyUserAccount(myuseraccount);
 
             boolean moveRight = (myuseraccount.uUserRights & UserRight.USERRIGHT_MOVE_USERS) !=0;
-            boolean isRemovable = (ttclient != null) && (selectedChannel.nChannelID != ttclient.getMyChannelID());
             PopupMenu channelActions = new PopupMenu(this, v);
             channelActions.setOnMenuItemClickListener(this);
             channelActions.inflate(R.menu.channel_actions);
-            channelActions.getMenu().findItem(R.id.action_remove).setEnabled(isRemovable).setVisible(isRemovable);
             channelActions.getMenu().findItem(R.id.action_move).setEnabled(moveRight).setVisible(moveRight);
             channelActions.show();
             return true;

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -288,12 +288,16 @@ extends AppCompatActivity
 
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
+        UserAccount myuseraccount = new UserAccount();
+        ttclient.getMyUserAccount(myuseraccount);
+
+        boolean uploadRight = (myuseraccount.uUserRights & UserRight.USERRIGHT_UPLOAD_FILES) !=0;
         boolean isEditable = curchannel != null;
         boolean isJoinable = (ttclient != null) && (curchannel != null) && (ttclient.getMyChannelID() != curchannel.nChannelID) && (curchannel.nMaxUsers > 0);
         boolean isMyChannel = (ttclient != null) && (curchannel != null) && (ttclient.getMyChannelID() == curchannel.nChannelID);
         menu.findItem(R.id.action_edit).setEnabled(isEditable).setVisible(isEditable);
         menu.findItem(R.id.action_join).setEnabled(isJoinable).setVisible(isJoinable);
-        menu.findItem(R.id.action_upload).setEnabled(isMyChannel).setVisible(isMyChannel);
+        menu.findItem(R.id.action_upload).setEnabled(uploadRight).setVisible(uploadRight);
         menu.findItem(R.id.action_stream).setEnabled(isMyChannel).setVisible(isMyChannel);
         return super.onPrepareOptionsMenu(menu);
     }
@@ -350,12 +354,12 @@ extends AppCompatActivity
                 int currentPage = mViewPager.getCurrentItem();
                 Channel parentChannel = ((currentPage == SectionsPagerAdapter.CHANNELS_PAGE)
                                          && (curchannel != null)
-                                         && (curchannel.nChannelID != ttclient.getRootChannelID())) ?
+                                         ) ?
                     ttservice.getChannels().get(curchannel.nParentID) :
                     null;
                 if (currentPage != SectionsPagerAdapter.CHANNELS_PAGE) {
                     mViewPager.setCurrentItem(SectionsPagerAdapter.CHANNELS_PAGE);
-                } else if ((parentChannel != null) && (parentChannel.nChannelID > 0)) {
+                } else if ((curchannel != null)) {
                     setCurrentChannel(parentChannel);
                     channelsAdapter.notifyDataSetChanged();
                 }
@@ -1409,15 +1413,18 @@ private EditText newmsg;
         }
         if (item instanceof Channel) {
             selectedChannel = (Channel) item;
-            if ((curchannel != null) && (curchannel.nParentID != selectedChannel.nChannelID)) {
-                boolean isRemovable = (ttclient != null) && (selectedChannel.nChannelID != ttclient.getMyChannelID());
-                PopupMenu channelActions = new PopupMenu(this, v);
-                channelActions.setOnMenuItemClickListener(this);
-                channelActions.inflate(R.menu.channel_actions);
-                channelActions.getMenu().findItem(R.id.action_remove).setEnabled(isRemovable).setVisible(isRemovable);
-                channelActions.show();
-                return true;
-            }
+            UserAccount myuseraccount = new UserAccount();
+            ttclient.getMyUserAccount(myuseraccount);
+
+            boolean moveRight = (myuseraccount.uUserRights & UserRight.USERRIGHT_MOVE_USERS) !=0;
+            boolean isRemovable = (ttclient != null) && (selectedChannel.nChannelID != ttclient.getMyChannelID());
+            PopupMenu channelActions = new PopupMenu(this, v);
+            channelActions.setOnMenuItemClickListener(this);
+            channelActions.inflate(R.menu.channel_actions);
+            channelActions.getMenu().findItem(R.id.action_remove).setEnabled(isRemovable).setVisible(isRemovable);
+            channelActions.getMenu().findItem(R.id.action_move).setEnabled(moveRight).setVisible(moveRight);
+            channelActions.show();
+            return true;
         }
         return false;
     }


### PR DESCRIPTION
fixed the navigate up button's problem, which now allowes you to interact with the root channel properly like other subchannels also, like windows client.
since android users now have access to the root channel, Fixed a bug that was preventing long presses on the root channel, Which means they can long press on the root channel and move users to the root channel as they can do with other channels
Also, as another direct result and some other related code fixes i've made, It is now possible only for admins to upload files to the channels they have not joined, inclooding the root channel, This had happened because in the teamtalk5's erules, i've read that only administrator accounts can upload files to the channels they have not joined. Note that default accounts cannot do that, The server disallowes that and they will get an error message if they try to do that.