### PR TITLE
Fix TTS crash in Settings when not connected

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/TTSWrapper.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/TTSWrapper.java
@@ -35,7 +35,7 @@ import java.util.List;
 
 public class TTSWrapper {
     private static final String TAG = "bearware";
-    private static TextToSpeech tts;
+    private TextToSpeech tts;
     public static final String defaultEngineName = "com.google.android.tts"; // should be got from getDefaultEngine method.
     private Context mContext;
     public Boolean useAnnouncements;
@@ -77,7 +77,7 @@ public class TTSWrapper {
         }
     }
 
-    public static List<EngineInfo> getEngines() {
+    public List<EngineInfo> getEngines() {
         List<EngineInfo> spEngines = tts.getEngines();
         return spEngines;
     }

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/PreferencesActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/PreferencesActivity.java
@@ -400,8 +400,10 @@ public class PreferencesActivity extends PreferenceActivity implements TeamTalkC
             super.onCreate(savedInstanceState);
             addPreferencesFromResource(R.xml.pref_tts);
 
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity().getBaseContext());
+            TTSWrapper tts = new TTSWrapper(getActivity().getBaseContext(), prefs.getString("pref_speech_engine", TTSWrapper.defaultEngineName));
+            List<EngineInfo> engines = tts.getEngines();
             ListPreference enginePrefs = (ListPreference) findPreference("pref_speech_engine");
-            List<EngineInfo> engines = TTSWrapper.getEngines();
             ArrayList<String> entries = new ArrayList<>();
             ArrayList<String> values = new ArrayList<>();
             for (EngineInfo info : engines) {


### PR DESCRIPTION
TTSWrapper.getEngines() is a static method and 'tts' is null if TTSWrapper has never been instantiated.

MainWindow instantiates TTSWrapper but Settings does not.

This fixes #1895