### PR TITLE
Prevent TextMessageAdapter from modifying during list view update

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -23,6 +23,7 @@ Android Client
 - Subscriptions for intercepting users
 - OPUS codec updated to v1.5.1
 - Fixed crash issue when entering Text-To-Speech settings
+- Fixed crash issue when updating text messages
 iOS Client
 - OPUS codec updated to v1.5.1
 Server

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/TextMessageAdapter.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/TextMessageAdapter.java
@@ -41,7 +41,8 @@ import android.widget.TextView;
 
 public class TextMessageAdapter extends BaseAdapter {
 
-    private Vector<MyTextMessage> messages;
+    private Vector<MyTextMessage> messages, // reference to TeamTalkService's messages (modified by other thread)
+            messagesUpdateView; // copy of 'this.message' after update
     
     private final LayoutInflater inflater;
     private final AccessibilityAssistant accessibilityAssistant;
@@ -91,16 +92,20 @@ public class TextMessageAdapter extends BaseAdapter {
     }
     
     public void setTextMessages(Vector<MyTextMessage> msgs) {
-        messages = msgs;
+        this.messages = msgs;
+        copyToMessagesView();
+    }
+
+    private void copyToMessagesView() {
+        this.messagesUpdateView = (Vector<MyTextMessage>)this.messages.clone();
     }
     
     Vector<MyTextMessage> getMessages() {
-        
         if(show_logs)
-            return messages;
+            return this.messagesUpdateView;
         
         Vector<MyTextMessage> result = new Vector<>();
-        for(MyTextMessage m : messages) {
+        for(MyTextMessage m : this.messagesUpdateView) {
             switch(m.nMsgType) {
                 case MyTextMessage.MSGTYPE_LOG_ERROR :
                 case MyTextMessage.MSGTYPE_LOG_INFO :
@@ -228,5 +233,11 @@ public class TextMessageAdapter extends BaseAdapter {
         convertView.setAccessibilityDelegate(accessibilityAssistant);
         
         return convertView;
+    }
+
+    @Override
+    public void notifyDataSetChanged() {
+        copyToMessagesView();
+        super.notifyDataSetChanged();
     }
 }


### PR DESCRIPTION
This should fix #2229:

java.lang.IllegalStateException: The content of the adapter has changed but ListView did not receive a notification. Make sure the content of your adapter is not modified from a background thread, but only from the UI thread. Make sure your adapter calls notifyDataSetChanged() when its content changes. [in ListView(2131230864, class android.widget.ListView) with Adapter(class dk.bearware.data.TextMessageAdapter)]