### PR TITLE
people who have the user can make others channel operator right will no longer be asked to enter the operator password in auder to grant/revoke channel operator

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -6,7 +6,7 @@ Version 5.17, unreleased
 Default Qt Client
 - "Connect to a Server" dialog simplied with multiple sub dialogs
 Android Client
--
+- users who have the "User can make other users channel operator" right will no longer be asked for the operator password for granting/revoking channel operator
 iOS Client
 -
 Server

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -1434,6 +1434,8 @@ private EditText newmsg;
 
     @Override
     public boolean onMenuItemClick(MenuItem item) {
+        UserAccount myuseraccount = new UserAccount();
+        ttclient.getMyUserAccount(myuseraccount);
         AlertDialog.Builder alert = new AlertDialog.Builder(this);
         switch (item.getItemId()) {
         case R.id.action_banchan:
@@ -1474,6 +1476,10 @@ private EditText newmsg;
             alert.show();
             break;
             case R.id.action_makeop:
+                if ((myuseraccount.uUserRights & UserRight.USERRIGHT_OPERATOR_ENABLE) != UserRight.USERRIGHT_NONE) {
+                    ttclient.doChannelOp(selectedUser.nUserID, selectedUser.nChannelID, ttclient.isChannelOperator(selectedUser.nUserID, selectedUser.nChannelID)? false: true);
+                    break;
+                }
                 alert.setTitle(ttclient.isChannelOperator(selectedUser.nUserID , selectedUser.nChannelID) ? R.string.action_revoke_operator : R.string.action_make_operator);
                 alert.setMessage(R.string.text_operator_password);
                 final EditText input = new EditText(this);


### PR DESCRIPTION
In teamtalk classic, when you have the user can make other users channel operator right enabled, you don't need to enter the password in auder to grant/revoke operator, because you have the access to it even if you don't know the operator password, and even if you enter the password incorrectly or don't enter anything, it would work for you, so just used the function in android client as wel.