### PR TITLE
Use Qt checkable flags in user rights model

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -9,6 +9,7 @@ Default Qt Client
 - "Move Users" dialog
 - Locale file size now also use in "file transfer" dialog
 - "Check for Update" in "Help" menu
+- Use Qt checkable flag in user rights list to allow screenreader to see if an item is checked
 Android Client
 -
 iOS Client

--- a/Client/qtTeamTalk/useraccountsmodel.cpp
+++ b/Client/qtTeamTalk/useraccountsmodel.cpp
@@ -260,6 +260,7 @@ QVariant UserRightsModel::data(const QModelIndex & index, int role /*= Qt::Displ
         }
 
         break;
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     case Qt::AccessibleTextRole :
         switch (m_userrights[index.row()])
         {
@@ -269,6 +270,7 @@ QVariant UserRightsModel::data(const QModelIndex & index, int role /*= Qt::Displ
         default :
             return QString("%1: %2").arg(data(index, Qt::DisplayRole).toString()).arg((m_activeUserRights & m_userrights[index.row()])? tr("Enabled") : tr("Disabled"));
         }
+#endif
     case Qt::CheckStateRole :
         switch (m_userrights[index.row()])
         {
@@ -280,6 +282,11 @@ QVariant UserRightsModel::data(const QModelIndex & index, int role /*= Qt::Displ
         }
     }
     return QVariant();
+}
+
+Qt::ItemFlags UserRightsModel::flags(const QModelIndex &index) const
+{
+    return Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsUserCheckable |  Qt::ItemIsEditable;
 }
 
 QModelIndex UserRightsModel::index(int row, int column, const QModelIndex & /*parent = QModelIndex()*/) const

--- a/Client/qtTeamTalk/useraccountsmodel.h
+++ b/Client/qtTeamTalk/useraccountsmodel.h
@@ -62,6 +62,7 @@ public:
     UserRightsModel(QObject* parent);
     int columnCount(const QModelIndex & parent = QModelIndex()) const;
     QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
     QModelIndex index(int row, int column, const QModelIndex & parent = QModelIndex()) const;
     QModelIndex parent(const QModelIndex & index) const;
     int rowCount(const QModelIndex & parent = QModelIndex()) const;


### PR DESCRIPTION
This allows screenreaders to see if an item is checked without accessible text role in Qt6