### PR TITLE
moved the move user option to the channels menu which is its proper place

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -11,6 +11,7 @@ Default Qt Client
 - "Check for Update" in "Help" menu
 - Ability to join Last Joined Channel for each server individually
 - Use Qt checkable flag in user rights list to allow screenreader to see if an item is checked
+- Moved "Move User" option from users menu to channels menu, to allow the option usage as wel, raather than only shortcut usage
 Android Client
 -
 iOS Client

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -6210,7 +6210,6 @@ void MainWindow::slotUpdateUI()
     ui.actionIncreaseMediaFileVolume->setEnabled(userid>0 && user.nVolumeMediaFile < SOUND_VOLUME_MAX);
     ui.actionLowerMediaFileVolume->setEnabled(userid>0 && user.nVolumeMediaFile > SOUND_VOLUME_MIN);
     ui.actionStoreForMove->setEnabled(userid>0 && (userrights & USERRIGHT_MOVE_USERS));
-    ui.actionMoveUser->setEnabled(m_moveusers.size() && (userrights & USERRIGHT_MOVE_USERS));
     ui.actionMoveUsersDialog->setEnabled(userrights & USERRIGHT_MOVE_USERS);
     ui.actionRelayVoiceStream->setEnabled(userid > 0 && !voiceactivated && !voicetx);
     ui.actionRelayVoiceStream->setChecked(userid > 0 && userid == m_relayvoice_userid);
@@ -6254,6 +6253,7 @@ void MainWindow::slotUpdateUI()
     ui.actionUploadFile->setEnabled(m_myuseraccount.uUserRights & USERRIGHT_UPLOAD_FILES);
     ui.actionDownloadFile->setEnabled(m_myuseraccount.uUserRights & USERRIGHT_DOWNLOAD_FILES);
     ui.actionDeleteFile->setEnabled(filescount>0);
+    ui.actionMoveUser->setEnabled(m_moveusers.size() && (userrights & USERRIGHT_MOVE_USERS));
 
     //Users-menu items dependent on Channel
     bool modchan = (userrights & USERRIGHT_MODIFY_CHANNELS) == USERRIGHT_MODIFY_CHANNELS;

--- a/Client/qtTeamTalk/mainwindow.ui
+++ b/Client/qtTeamTalk/mainwindow.ui
@@ -1210,7 +1210,6 @@
      <addaction name="actionLowerMediaFileVolume"/>
      <addaction name="separator"/>
      <addaction name="actionStoreForMove"/>
-     <addaction name="actionMoveUser"/>
      <addaction name="actionMoveUsersDialog"/>
      <addaction name="separator"/>
      <addaction name="separator"/>
@@ -1297,6 +1296,7 @@
     <addaction name="actionUploadFile"/>
     <addaction name="actionDownloadFile"/>
     <addaction name="actionDeleteFile"/>
+    <addaction name="actionMoveUser"/>
    </widget>
    <widget class="QMenu" name="menuServer">
     <property name="title">
@@ -1607,6 +1607,14 @@
     <string>Shift+Del</string>
    </property>
   </action>
+  <action name="actionMoveUser">
+   <property name="text">
+    <string>&amp;Move User(s)</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Alt+V</string>
+   </property>
+  </action>
   <action name="actionBannedUsers">
    <property name="text">
     <string>&amp;Banned Users</string>
@@ -1896,14 +1904,6 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Alt+X</string>
-   </property>
-  </action>
-  <action name="actionMoveUser">
-   <property name="text">
-    <string>&amp;Move User(s)</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+Alt+V</string>
    </property>
   </action>
   <action name="actionMoveUsersDialog">


### PR DESCRIPTION
some users and also me have reported that we can only use ctrl+alt+v shortcut to do the move action, but we can't use the option which this shortcut is assighned for it, because this option is not in its proper place. For the more, this option was in the users menu, but we needed to focus on a channel when we wanted to press ctrl+alt+v, so now that this option has been moved to channels menu, we can press enter on it and complete the move action