### PR TITLE
Only use QLabel in User info dialog

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -16,6 +16,8 @@ Default Qt Client
 - Redesign "Sound Events" tab in Preferences
 - Ability to replace existing file on upload
 - Menu to insert MOTD variables in "Server Properties" dialog
+- Replace readonly edit fields by statis label in "User info" dialog
+- Only show available info in "User info" dialog
 Android Client
 - users who have the "User can make other users channel operator" right will no longer be asked for the operator password for granting/revoking channel operator
 iOS Client

--- a/Client/qtTeamTalk/userinfo.ui
+++ b/Client/qtTeamTalk/userinfo.ui
@@ -15,230 +15,127 @@
   </property>
   <layout class="QFormLayout" name="formLayout">
    <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>User ID</string>
-     </property>
-     <property name="buddy">
-      <cstring>userid</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="userid">
+    <widget class="QLabel" name="idLabel">
      <property name="text">
       <string/>
      </property>
-     <property name="readOnly">
-      <bool>true</bool>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
      </property>
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Nickname</string>
-     </property>
-     <property name="buddy">
-      <cstring>nickname</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="nickname">
+    <widget class="QLabel" name="nicknameLabel">
      <property name="text">
       <string/>
      </property>
-     <property name="readOnly">
-      <bool>true</bool>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
      </property>
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Username</string>
-     </property>
-     <property name="buddy">
-      <cstring>username</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="username">
+    <widget class="QLabel" name="usernameLabel">
      <property name="text">
       <string/>
      </property>
-     <property name="readOnly">
-      <bool>true</bool>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
      </property>
     </widget>
    </item>
    <item row="3" column="0">
-    <widget class="QLabel" name="label_11">
+    <widget class="QLabel" name="clientLabel">
      <property name="text">
-      <string>Client name</string>
+      <string/>
      </property>
-     <property name="buddy">
-      <cstring>clientname</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QLineEdit" name="clientname">
-     <property name="readOnly">
-      <bool>true</bool>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
      </property>
     </widget>
    </item>
    <item row="4" column="0">
-    <widget class="QLabel" name="label_7">
-     <property name="text">
-      <string>Status mode</string>
-     </property>
-     <property name="buddy">
-      <cstring>statusmode</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QLineEdit" name="statusmode">
+    <widget class="QLabel" name="statusLabel">
      <property name="text">
       <string/>
      </property>
-     <property name="readOnly">
-      <bool>true</bool>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
      </property>
     </widget>
    </item>
    <item row="5" column="0">
-    <widget class="QLabel" name="label_9">
-     <property name="text">
-      <string>Status message</string>
-     </property>
-     <property name="buddy">
-      <cstring>statusmsg</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QLineEdit" name="statusmsg">
+    <widget class="QLabel" name="statusmsgLabel">
      <property name="text">
       <string/>
      </property>
-     <property name="readOnly">
-      <bool>true</bool>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
      </property>
     </widget>
    </item>
    <item row="6" column="0">
-    <widget class="QLabel" name="label_15">
+    <widget class="QLabel" name="usertypeLabel">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
      <property name="text">
-      <string>User type</string>
-     </property>
-     <property name="buddy">
-      <cstring>usertype</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="QLineEdit" name="usertype">
-     <property name="text">
       <string/>
      </property>
-     <property name="readOnly">
-      <bool>true</bool>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
      </property>
     </widget>
    </item>
    <item row="7" column="0">
-    <widget class="QLabel" name="label_8">
-     <property name="text">
-      <string>IP-address</string>
-     </property>
-     <property name="buddy">
-      <cstring>ipaddr</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <widget class="QLineEdit" name="ipaddr">
+    <widget class="QLabel" name="ipLabel">
      <property name="text">
       <string/>
      </property>
-     <property name="readOnly">
-      <bool>true</bool>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
      </property>
     </widget>
    </item>
    <item row="8" column="0">
-    <widget class="QLabel" name="label_13">
-     <property name="text">
-      <string>Voice packet loss</string>
-     </property>
-     <property name="buddy">
-      <cstring>voicepacketloss</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
-    <widget class="QLineEdit" name="voicepacketloss">
+    <widget class="QLabel" name="vplLabel">
      <property name="text">
       <string/>
      </property>
-     <property name="readOnly">
-      <bool>true</bool>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
      </property>
     </widget>
    </item>
    <item row="9" column="0">
-    <widget class="QLabel" name="label_6">
-     <property name="text">
-      <string>Video frame loss</string>
-     </property>
-     <property name="buddy">
-      <cstring>vidpacketloss</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1">
-    <widget class="QLineEdit" name="vidpacketloss">
+    <widget class="QLabel" name="vflLabel">
      <property name="text">
       <string/>
      </property>
-     <property name="readOnly">
-      <bool>true</bool>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
      </property>
     </widget>
    </item>
    <item row="10" column="0">
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="afplLabel">
      <property name="text">
-      <string>Audio file packets loss</string>
+      <string/>
      </property>
-     <property name="buddy">
-      <cstring>mediaaudpacketloss</cstring>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
      </property>
     </widget>
-   </item>
-   <item row="10" column="1">
-    <widget class="QLineEdit" name="mediaaudpacketloss"/>
    </item>
    <item row="11" column="0">
-    <widget class="QLabel" name="label_10">
+    <widget class="QLabel" name="vfflLabel">
      <property name="text">
-      <string>Video file frame loss</string>
+      <string/>
      </property>
-     <property name="buddy">
-      <cstring>mediavidpacketloss</cstring>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
      </property>
     </widget>
-   </item>
-   <item row="11" column="1">
-    <widget class="QLineEdit" name="mediavidpacketloss"/>
    </item>
   </layout>
  </widget>

--- a/Client/qtTeamTalk/userinfodlg.cpp
+++ b/Client/qtTeamTalk/userinfodlg.cpp
@@ -48,11 +48,13 @@ void UserInfoDlg::updateUser()
 
     this->setAccessibleDescription(tr("Information of %1").arg(_Q(user.szNickname)));
 
-    if(ui.userid->text() != QString::number(user.nUserID))
-        ui.userid->setText(QString::number(user.nUserID));
+    QString idLabelText = QString(tr("User ID") + ": %1").arg(QString::number(user.nUserID));
+    if(ui.idLabel->text() != idLabelText)
+        ui.idLabel->setText(idLabelText);
 
-    if(ui.nickname->text() != _Q(user.szNickname))
-        ui.nickname->setText(_Q(user.szNickname));
+    QString nickLabelText = QString(tr("Nickname") + ": %1").arg(_Q(user.szNickname));
+    if(ui.nicknameLabel->text() != nickLabelText)
+        ui.nicknameLabel->setText(nickLabelText);
 
     QString status;
     switch(user.nStatusMode & STATUSMODE_MODE)
@@ -66,17 +68,27 @@ void UserInfoDlg::updateUser()
     default :
         status = tr("Unknown"); break;
     }
-    
-    if(ui.statusmode->text() != status)
-        ui.statusmode->setText(status);
+    QString statusLabelText = QString(tr("Status mode") + ": %1").arg(status);    
+    if(ui.statusLabel->text() != statusLabelText)
+        ui.statusLabel->setText(statusLabelText);
 
-    if(ui.statusmsg->text() != _Q(user.szStatusMsg))
-        ui.statusmsg->setText(_Q(user.szStatusMsg));
-    if(ui.username->text() != _Q(user.szUsername))
-        ui.username->setText(_Q(user.szUsername));
+    if (_Q(user.szStatusMsg).size() > 0)
+    {
+        QString statusmsgLabelText = QString(tr("Status message") + ": %1").arg(_Q(user.szStatusMsg));
+        if(ui.statusmsgLabel->text() != statusmsgLabelText)
+            ui.statusmsgLabel->setText(statusmsgLabelText);
+        ui.statusmsgLabel->show();
+    }
+    else
+        ui.statusmsgLabel->hide();
 
-    if(ui.clientname->text() != _Q(user.szClientName)+" "+getVersion(user))
-        ui.clientname->setText(_Q(user.szClientName)+" "+getVersion(user));
+    QString usernameLabelText = QString(tr("Username") + ": %1").arg(_Q(user.szUsername));
+    if(ui.usernameLabel->text() != usernameLabelText)
+        ui.usernameLabel->setText(usernameLabelText);
+
+    QString clientLabelText = QString(tr("Client") + ": %1 %2").arg(_Q(user.szClientName)).arg(getVersion(user));
+    if(ui.clientLabel->text() != clientLabelText)
+        ui.clientLabel->setText(clientLabelText);
 
     switch(user.uUserType)
     {
@@ -87,19 +99,26 @@ void UserInfoDlg::updateUser()
     default:
         status = tr("Unknown"); break;
     }
+    QString usertypeLabelText = QString(tr("User type") + ": %1").arg(status);
+    if(ui.usertypeLabel->text() != usertypeLabelText)
+        ui.usertypeLabel->setText(usertypeLabelText);
 
-    if(ui.usertype->text() != status)
-        ui.usertype->setText(status);
-
-    if(ui.ipaddr->text() != _Q(user.szIPAddress))
-        ui.ipaddr->setText(_Q(user.szIPAddress));
+    if (TT_GetMyUserType(ttInst) & USERTYPE_ADMIN || TT_GetMyUserID(ttInst) == user.nUserID)
+    {
+        QString ipLabelText = QString(tr("IP-address") + ": %1").arg(_Q(user.szIPAddress));
+        if(ui.ipLabel->text() != ipLabelText)
+            ui.ipLabel->setText(ipLabelText);
+        ui.ipLabel->show();
+    }
+    else
+        ui.ipLabel->hide();
 
     UserStatistics stats;
     if(!TT_GetUserStatistics(ttInst, m_userid, &stats))
         return;
 
-    ui.voicepacketloss->setText(QString("%1/%2").arg(stats.nVoicePacketsLost).arg(stats.nVoicePacketsRecv+stats.nVoicePacketsLost));
-    ui.vidpacketloss->setText(QString("%1/%2").arg(stats.nVideoCaptureFramesLost).arg(stats.nVideoCaptureFramesRecv+stats.nVideoCaptureFramesLost));
-    ui.mediaaudpacketloss->setText(QString("%1/%2").arg(stats.nMediaFileAudioPacketsLost).arg(stats.nMediaFileAudioPacketsRecv+stats.nMediaFileAudioPacketsLost));
-    ui.mediavidpacketloss->setText(QString("%1/%2").arg(stats.nMediaFileVideoFramesLost).arg(stats.nMediaFileVideoFramesRecv+stats.nMediaFileVideoFramesLost));
+    ui.vplLabel->setText(QString(tr("Voice packet loss") + ": %1/%2").arg(stats.nVoicePacketsLost).arg(stats.nVoicePacketsRecv+stats.nVoicePacketsLost));
+    ui.vflLabel->setText(QString(tr("Video frame loss") + ": %1/%2").arg(stats.nVideoCaptureFramesLost).arg(stats.nVideoCaptureFramesRecv+stats.nVideoCaptureFramesLost));
+    ui.afplLabel->setText(QString(tr("Audio file packets loss") + ": %1/%2").arg(stats.nMediaFileAudioPacketsLost).arg(stats.nMediaFileAudioPacketsRecv+stats.nMediaFileAudioPacketsLost));
+    ui.vfflLabel->setText(QString(tr("Video file frame loss") + ": %1/%2").arg(stats.nMediaFileVideoFramesLost).arg(stats.nMediaFileVideoFramesRecv+stats.nMediaFileVideoFramesLost));
 }


### PR DESCRIPTION
Maybe usage of readonly QLineEdit was wanted, but I didn't see the real advantage of it.
So, I just replaced it by static QLabel