### PR TITLE
Fix keyPressEvent on "Banned users" dialog

### DIFF
--- a/Client/qtTeamTalk/bannedusersdlg.cpp
+++ b/Client/qtTeamTalk/bannedusersdlg.cpp
@@ -291,7 +291,7 @@ void BannedUsersDlg::cmdProcessing(int cmdid, bool active)
 
 void BannedUsersDlg::keyPressEvent(QKeyEvent* e)
 {
-    if (ui.banEdit->hasFocus()  && (e->key() == Qt::Key_Enter || e->key() == Qt::Key_Return))
+    if (e->key() == Qt::Key_Enter || e->key() == Qt::Key_Return)
     {
         if (ui.banEdit->hasFocus())
         {


### PR DESCRIPTION
Ensure enter key behaviour is set to desired action in all widget