### PR TITLE
Replace some texts by emojis in channel list

### DIFF
--- a/Client/qtTeamTalk/channelstree.cpp
+++ b/Client/qtTeamTalk/channelstree.cpp
@@ -1206,10 +1206,10 @@ void ChannelsTree::updateUserItem(QTreeWidgetItem* item)
         if((user.uUserState & USERSTATE_VOICE) || (user.nUserID == TT_GetMyUserID(ttInst) && isMyselfTalking() == TRUE && userCanVoiceTx(TT_GetMyUserID(ttInst), chan) == TRUE))
             itemtext += " 🎤";
         if (user.nStatusMode & STATUSMODE_STREAM_MEDIAFILE)
-            itemtext += ", " + tr("Streaming media file");
+            itemtext += ", 💿";
 
         if (user.nStatusMode & STATUSMODE_VIDEOTX)
-            itemtext += ", " + tr("Webcam");
+            itemtext += ", 🎥";
     }
 
     if(_Q(user.szStatusMsg).size())


### PR DESCRIPTION
If someone has any idea for channel operator and administrator, maybe we can also replace "channel operator" and "administrator" by emojis. This make channel item shorter