### PR TITLE
Simplify several dialogs

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -28,6 +28,8 @@ Default Qt Client
 - Ability to search by IP or username in "Banned Users" dialog
 - Ban time displays in local format
 - Locale file size now also use in "file transfer" dialog
+- Unic dialog to enter username and password on login error and channel share
+- Ability to show password on login error, channel password, channel operator password, and channel share
 - Reset label of files list when disconnected from server
 - Limit text size in channels tree ignored for screen readers
 - Windows and macOS updated to Qt v6.7.1

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -5240,6 +5240,7 @@ void MainWindow::slotChannelsJoinChannel(bool /*checked=false*/)
 
     if (chan.nChannelID != TT_GetMyChannelID(ttInst) && ((dbClickAct & ACTION_JOIN) == ACTION_JOIN || QObject::sender() == ui.actionJoinChannel))
     {
+        m_last_channel = chan;
         QString password = m_channel_passwd[chan.nChannelID];
         if(chan.bPassword)
         {

--- a/Client/qtTeamTalk/utilui.cpp
+++ b/Client/qtTeamTalk/utilui.cpp
@@ -24,6 +24,12 @@
 #include <QDir>
 #include <QDateTime>
 #include <QLocale>
+#include <QLabel>
+#include <QLineEdit>
+#include <QCheckBox>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
 #if QT_VERSION < QT_VERSION_CHECK(6,0,0)
 #include <QDesktopWidget>
 #include <QApplication>
@@ -417,4 +423,104 @@ QString UtilUI::getStatusBarMessage(const QString& paramKey, const QHash<QString
 QString UtilUI::getRawStatusBarMessage(const QString& paramKey)
 {
     return ttSettings->value(paramKey, getDefaultValue(paramKey)).toString();
+}
+
+LoginInfoDialog::LoginInfoDialog(const QString &title, const QString &desc, const QString &initialUsername, const QString &initialPassword, QWidget *parent)
+    : QDialog(parent)
+{
+    setWindowTitle(title);
+    setAccessibleDescription(desc);
+
+    QLabel *descLabel = new QLabel(desc);
+    QLabel *userLabel = new QLabel(tr("Username:"));
+    userEdit = new QLineEdit;
+    userEdit->setText(initialUsername);
+    userLabel->setBuddy(userEdit);
+
+    QLabel *passLabel = new QLabel(tr("Password:"));
+    passEdit = new QLineEdit;
+    passEdit->setEchoMode(QLineEdit::Password);
+    passEdit->setText(initialPassword);
+    passLabel->setBuddy(passEdit);
+
+    QCheckBox *showPasswordCheckBox = new QCheckBox(tr("Show password"));
+    connect(showPasswordCheckBox, &QCheckBox::toggled, [=](bool checked) {
+        passEdit->setEchoMode(checked ? QLineEdit::Normal : QLineEdit::Password);
+    });
+
+    QPushButton *okButton = new QPushButton(tr("&OK"));
+    QPushButton *cancelButton = new QPushButton(tr("&Cancel"));
+
+    connect(okButton, &QPushButton::clicked, this, &QDialog::accept);
+    connect(cancelButton, &QPushButton::clicked, this, &QDialog::reject);
+
+    QVBoxLayout *mainLayout = new QVBoxLayout;
+    mainLayout->addWidget(descLabel);
+    mainLayout->addWidget(userLabel);
+    mainLayout->addWidget(userEdit);
+    mainLayout->addWidget(passLabel);
+    mainLayout->addWidget(passEdit);
+    mainLayout->addWidget(showPasswordCheckBox);
+
+    QHBoxLayout *buttonLayout = new QHBoxLayout;
+    buttonLayout->addWidget(okButton);
+    buttonLayout->addWidget(cancelButton);
+
+    mainLayout->addLayout(buttonLayout);
+
+    setLayout(mainLayout);
+}
+
+QString LoginInfoDialog::getUsername() const
+{
+    return userEdit->text();
+}
+
+QString LoginInfoDialog::getPassword() const
+{
+    return passEdit->text();
+}
+
+PasswordDialog::PasswordDialog(const QString &title, const QString &desc, const QString &initialPassword, QWidget *parent)
+    : QDialog(parent)
+{
+    setWindowTitle(title);
+    setAccessibleDescription(desc);
+
+    QLabel *descLabel = new QLabel(desc);
+    QLabel *passLabel = new QLabel(tr("Password"));
+    passEdit = new QLineEdit;
+    passEdit->setEchoMode(QLineEdit::Password);
+    passEdit->setText(initialPassword);
+    passLabel->setBuddy(passEdit);
+
+    QCheckBox *showPasswordCheckBox = new QCheckBox(tr("Show password"));
+    connect(showPasswordCheckBox, &QCheckBox::toggled, [=](bool checked) {
+        passEdit->setEchoMode(checked ? QLineEdit::Normal : QLineEdit::Password);
+    });
+
+    QPushButton *okButton = new QPushButton(tr("&OK"));
+    QPushButton *cancelButton = new QPushButton(tr("&Cancel"));
+
+    connect(okButton, &QPushButton::clicked, this, &QDialog::accept);
+    connect(cancelButton, &QPushButton::clicked, this, &QDialog::reject);
+
+    QVBoxLayout *mainLayout = new QVBoxLayout;
+    mainLayout->addWidget(descLabel);
+    mainLayout->addWidget(passLabel);
+    mainLayout->addWidget(passEdit);
+    mainLayout->addWidget(showPasswordCheckBox);
+
+    QHBoxLayout *buttonLayout = new QHBoxLayout;
+    buttonLayout->addWidget(okButton);
+    buttonLayout->addWidget(cancelButton);
+
+    mainLayout->addLayout(buttonLayout);
+
+    setLayout(mainLayout);
+}
+
+QString PasswordDialog::getPassword() const
+{
+    return passEdit->text();
 }

--- a/Client/qtTeamTalk/utilui.cpp
+++ b/Client/qtTeamTalk/utilui.cpp
@@ -339,7 +339,7 @@ QStringList extractLanguages()
 {
     QStringList languages;
     QDir dir(TRANSLATE_FOLDER, "*.qm", QDir::Name, QDir::Files);
-    for (auto lang : dir.entryList())
+    for (const auto& lang : dir.entryList())
         languages.append(lang.left(lang.size()-3));
     return languages;
 }
@@ -444,7 +444,7 @@ LoginInfoDialog::LoginInfoDialog(const QString &title, const QString &desc, cons
     passLabel->setBuddy(passEdit);
 
     QCheckBox *showPasswordCheckBox = new QCheckBox(tr("Show password"));
-    connect(showPasswordCheckBox, &QCheckBox::toggled, [=](bool checked) {
+    connect(showPasswordCheckBox, &QCheckBox::toggled, this, [=](bool checked) {
         passEdit->setEchoMode(checked ? QLineEdit::Normal : QLineEdit::Password);
     });
 
@@ -495,7 +495,7 @@ PasswordDialog::PasswordDialog(const QString &title, const QString &desc, const 
     passLabel->setBuddy(passEdit);
 
     QCheckBox *showPasswordCheckBox = new QCheckBox(tr("Show password"));
-    connect(showPasswordCheckBox, &QCheckBox::toggled, [=](bool checked) {
+    connect(showPasswordCheckBox, &QCheckBox::toggled, this, [=](bool checked) {
         passEdit->setEchoMode(checked ? QLineEdit::Normal : QLineEdit::Password);
     });
 

--- a/Client/qtTeamTalk/utilui.h
+++ b/Client/qtTeamTalk/utilui.h
@@ -176,4 +176,31 @@ public:
     static QString getRawStatusBarMessage(const QString& paramKey);
 };
 
+class LoginInfoDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit LoginInfoDialog(const QString &title, const QString &desc, const QString &initialUsername, const QString &initialPassword, QWidget *parent = nullptr);
+
+    QString getUsername() const;
+    QString getPassword() const;
+
+private:
+    QLineEdit *userEdit;
+    QLineEdit *passEdit;
+};
+
+class PasswordDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit PasswordDialog(const QString &title, const QString &desc, const QString &initialPassword, QWidget *parent = nullptr);
+
+    QString getPassword() const;
+
+private:
+    QLineEdit *passEdit;
+};
 #endif


### PR DESCRIPTION
- Only use one dialog to enter username and password on login error and channel share
- Add ability to show password on login error, channel share, channel password and channel operator password