### PR TITLE
removed server read only mode

### DIFF
--- a/Client/qtTeamTalk/serverdlg.cpp
+++ b/Client/qtTeamTalk/serverdlg.cpp
@@ -70,26 +70,6 @@ ServerDlg::ServerDlg(ServerDlgType type, const HostEntry& host, QWidget *parent)
         this->setAccessibleDescription(tr("Edit Server %1").arg(host.name));
     }
     break;
-    case SERVER_READONLY :
-        setWindowTitle(tr("View Server Information"));
-        this->setAccessibleDescription(tr("View %1 Information").arg(host.name));
-        ui->nameEdit->setReadOnly(true);
-        ui->hostaddrEdit->setReadOnly(true);
-        ui->tcpportSpinbox->setReadOnly(true);
-        ui->udpportSpinbox->setReadOnly(true);
-        ui->cryptChkBox->setEnabled(false);
-        ui->encsetupBtn->setEnabled(false);
-        ui->bdkLogChkBox->setEnabled(false);
-        ui->usernameEdit->setReadOnly(true);
-        ui->passwordEdit->setReadOnly(true);
-        ui->nicknameEdit->setReadOnly(true);
-        ui->lastChanChkBox->setEnabled(false);
-        ui->channelEdit->setReadOnly(true);
-        ui->chanpasswdEdit->setReadOnly(true);
-        ui->connectSrvBox->setEnabled(false);
-        ui->buttonBox->setStandardButtons(QDialogButtonBox::Close);
-        ui->buttonBox->button(QDialogButtonBox::Close)->setText(tr("&Close"));
-        break;
     }
 
     ui->nameEdit->setText(m_hostentry.name);

--- a/Client/qtTeamTalk/serverlistdlg.cpp
+++ b/Client/qtTeamTalk/serverlistdlg.cpp
@@ -538,7 +538,7 @@ void ServerListDlg::editSelectedServer()
     HostEntry host;
     if (!getSelectedHost(host))
         return;
-    ServerDlg dlg((m_model->getServers()[m_proxyModel->mapToSource(ui.serverTableView->currentIndex()).row()].srvtype == SERVERTYPE_LOCAL?ServerDlg::SERVER_UPDATE:ServerDlg::SERVER_READONLY), host, this);
+    ServerDlg dlg(ServerDlg::SERVER_UPDATE, host, this);
     if (dlg.exec() == QDialog::Accepted)
     {
         HostEntry updatedHost = dlg.GetHostEntry();


### PR DESCRIPTION
* fixes https://github.com/BearWare/TeamTalk5/issues/2351 as standard
* code cleanup
* the ability to edit hole information of an unofficial and an official server, and press the save button to save it to your local server list for your later use
* the ability to specify nickname for the server while saving it in to your local server list https://github.com/BearWare/TeamTalk5/discussions/2276 like the old host manager that didn't have this limit
* built the app with these changes and tested everything