### PR TITLE
Alternative way for #2352

### DIFF
--- a/Client/qtTeamTalk/serverlistdlg.cpp
+++ b/Client/qtTeamTalk/serverlistdlg.cpp
@@ -449,7 +449,7 @@ void ServerListDlg::slotImportTTFile()
 
 void ServerListDlg::slotConnect()
 {
-    HostEntry host, latestHost;
+    HostEntryEx host, latestHost;
     if (getServerEntry(0, latestHost, true) || ui.hostListWidget->count() == 0)
     {
         if (!getSelectedHost(host))
@@ -535,10 +535,10 @@ void ServerListDlg::deleteSelectedServer()
 
 void ServerListDlg::editSelectedServer()
 {
-    HostEntry host;
+    HostEntryEx host;
     if (!getSelectedHost(host))
         return;
-    ServerDlg dlg((m_model->getServers()[m_proxyModel->mapToSource(ui.serverTableView->currentIndex()).row()].srvtype == SERVERTYPE_LOCAL?ServerDlg::SERVER_UPDATE:ServerDlg::SERVER_READONLY), host, this);
+    ServerDlg dlg((host.srvtype == SERVERTYPE_LOCAL ? ServerDlg::SERVER_UPDATE : ServerDlg::SERVER_READONLY), host, this);
     if (dlg.exec() == QDialog::Accepted)
     {
         HostEntry updatedHost = dlg.GetHostEntry();
@@ -562,7 +562,7 @@ void ServerListDlg::editSelectedServer()
 
 void ServerListDlg::duplicateSelectedServer()
 {
-    HostEntry host;
+    HostEntryEx host;
     if (!getSelectedHost(host))
         return;
 
@@ -802,7 +802,7 @@ void ServerListDlg::publishServerRequest(QNetworkReply* reply)
     }
 }
 
-bool ServerListDlg::getSelectedHost(HostEntry& host)
+bool ServerListDlg::getSelectedHost(HostEntryEx& host)
 {
     if (ui.hostListWidget->hasFocus())
     {

--- a/Client/qtTeamTalk/serverlistdlg.h
+++ b/Client/qtTeamTalk/serverlistdlg.h
@@ -124,7 +124,7 @@ private:
     void showExportMenu(); // Nouvelle méthode
     void publishServer();
     void publishServerRequest(QNetworkReply* reply);
-    bool getSelectedHost(HostEntry& host);
+    bool getSelectedHost(HostEntryEx& host);
 
     void slotTreeContextMenu(const QPoint&);
     void slotLatestHostsContextMenu(const QPoint&);


### PR DESCRIPTION
When calling getSelectedHost() we get a HostEntryEx from the models and the HostEntryEx defaults to SERVERTYPE_LOCAL when a latest host is selected.