### PR TITLE
Remove unused config keys from config file at first version startup

### DIFF
--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -670,8 +670,11 @@ void MainWindow::loadSettings()
 
         ttSettings->setValue(SETTINGS_SOUNDEVENT_ACTIVEEVENTS, activeEvents);
 
-        // Server name TTS option removed in 5.4 format
+        // TTS options removed in 5.4 format
         ttSettings->remove("texttospeech/announce-server-name");
+#if defined(Q_OS_DARWIN)
+        ttSettings->remove("texttospeech/speak-lists");
+#endif
         ttSettings->setValue(SETTINGS_GENERAL_VERSION, SETTINGS_VERSION);
     }
 

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -669,6 +669,9 @@ void MainWindow::loadSettings()
         }
 
         ttSettings->setValue(SETTINGS_SOUNDEVENT_ACTIVEEVENTS, activeEvents);
+
+        // Server name TTS option removed in 5.4 format
+        ttSettings->remove("texttospeech/announce-server-name");
         ttSettings->setValue(SETTINGS_GENERAL_VERSION, SETTINGS_VERSION);
     }
 


### PR DESCRIPTION
Some TTS config keys are no longer use and can be remove from config file