### PR TITLE
Update TeamTalk5.py

### DIFF
--- a/Library/TeamTalkPy/TeamTalk5.py
+++ b/Library/TeamTalkPy/TeamTalk5.py
@@ -1157,7 +1157,7 @@ _StopStreamingMediaFileToChannel = function_factory(dll.TT_StopStreamingMediaFil
 _InitLocalPlayback = function_factory(dll.TT_InitLocalPlayback, [INT32, [_TTInstance, TTCHAR_P, POINTER(MediaFilePlayback)]])
 _UpdateLocalPlayback = function_factory(dll.TT_UpdateLocalPlayback, [BOOL, [_TTInstance, INT32, POINTER(MediaFilePlayback)]])
 _StopLocalPlayback = function_factory(dll.TT_StopLocalPlayback, [BOOL, [_TTInstance, INT32]])
-_GetMediaFileInfo = function_factory(dll.TT_GetMediaFileInfo, [BOOL, [_TTInstance, TTCHAR_P, POINTER(MediaFileInfo)]])
+_GetMediaFileInfo = function_factory(dll.TT_GetMediaFileInfo, [BOOL, [TTCHAR_P, POINTER(MediaFileInfo)]])
 _SetEncryptionContext = function_factory(dll.TT_SetEncryptionContext, [BOOL, [_TTInstance, POINTER(EncryptionContext)]])
 _Connect = function_factory(dll.TT_Connect, [BOOL, [_TTInstance, TTCHAR_P, INT32, INT32, INT32, INT32, BOOL]])
 _ConnectSysID = function_factory(dll.TT_ConnectSysID, [BOOL, [_TTInstance, TTCHAR_P, INT32, INT32, INT32, INT32, BOOL, TTCHAR_P]])
@@ -1652,6 +1652,10 @@ class TeamTalk(object):
     def releaseUserAudioBlock(self, lpAudioBlock: POINTER(AudioBlock)) -> bool:
         return _ReleaseUserAudioBlock(self._tt, lpAudioBlock)
 
+    def getMediaFileInfo(szMediaFilePath) -> MediaFileInfo:
+        mfi = MediaFileInfo()
+        _GetMediaFileInfo(szMediaFilePath, mfi)
+        return mfi
 
     # event handling
 


### PR DESCRIPTION
Hello. This is my first contribution at GH. So please excuse me if I'm doing something wrong. As a result of my tests, I noticed that TeamTalk counts non-ASCII characters as extra characters when sending a message larger than 512 characters containing UTF-8 characters, that is, it sends the message incomplete. So I rolled up my sleeves and updated the buildTextMessage function so that it counts non-ASCII characters as extra characters when splitting a message.