### PR TITLE
Use prettyProductName instead of productType on login

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -45,6 +45,7 @@ Default Qt Client
 - Locale date time in "Banned Users" dialog
 - Windows installer translatable
 - Windows and macOS updated to Qt v6.8.0-beta2
+- OS version displays in user info
 Android Client
 - Toggle channel operator does not show password dialog if user has user-right to change channel operator
 iOS Client

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -2120,7 +2120,7 @@ void MainWindow::login()
     QString nick = ttSettings->value(SETTINGS_GENERAL_NICKNAME, SETTINGS_GENERAL_NICKNAME_DEFAULT).toString();
     if(m_host.nickname.size())
         nick = m_host.nickname;
-    QString client = QString("%1 (%2)").arg(APPNAME_SHORT).arg(QSysInfo::productType());
+    QString client = QString("%1 (%2)").arg(APPNAME_SHORT).arg(QSysInfo::prettyProductName());
     int cmdid = TT_DoLoginEx(ttInst, _W(nick), _W(m_host.username),
                              _W(m_host.password), _W(client));
     if (cmdid>0)


### PR DESCRIPTION
I thought it can be useful to have OS version available to debug sometimes