### PR TITLE
Correctly ask for language selection at first start

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -11,6 +11,7 @@ Default Qt Client
 - Ability to restore all custom TTS and status bar events to default values
 - Fixed gender changed from female to male when migrating to 5.17 release
 - Fixed sound events disabled when migrating to 5.17 release
+- Fixed language not set at first start
 Android Client
 -
 iOS Client

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -628,7 +628,7 @@ void MainWindow::loadSettings()
     migrateSettings();
 
     // Ask to set language at first start
-    if (!ttSettings->contains(SETTINGS_DISPLAY_LANGUAGE))
+    if (ttSettings->value(SETTINGS_GENERAL_FIRSTSTART, SETTINGS_GENERAL_FIRSTSTART_DEFAULT).toBool())
     {
         QLocale locale = QLocale::system();
         QString languageCode = locale.name();

--- a/Client/qtTeamTalk/preferencesdlg.cpp
+++ b/Client/qtTeamTalk/preferencesdlg.cpp
@@ -497,6 +497,11 @@ void PreferencesDlg::initDisplayTab()
     }
     QString lang = ttSettings->value(SETTINGS_DISPLAY_LANGUAGE, SETTINGS_DISPLAY_LANGUAGE_DEFAULT).toString();
     int index = ui.languageBox->findData(lang);
+    if (index < 0)
+    {
+        QString langPrefix = lang.section('_', 0, 0);
+        index = ui.languageBox->findData(langPrefix);
+    }
     if (index >= 0)
         ui.languageBox->setCurrentIndex(index);
 

--- a/Client/qtTeamTalk/settings.h
+++ b/Client/qtTeamTalk/settings.h
@@ -31,10 +31,8 @@
 #define SETTINGS_VERSION                            "5.5"
 #define SETTINGS_GENERAL_VERSION                    "general_/version"
 #define SETTINGS_GENERAL_VERSION_DEFAULT            SETTINGS_VERSION
-#if defined(ENABLE_TOLK) || defined(Q_OS_LINUX)
 #define SETTINGS_GENERAL_FIRSTSTART                 "general_/first-start"
 #define SETTINGS_GENERAL_FIRSTSTART_DEFAULT         true
-#endif
 
 #define SETTINGS_GENERAL_NICKNAME                   "general_/nickname"
 #define SETTINGS_GENERAL_NICKNAME_DEFAULT           ""

--- a/Client/qtTeamTalk/utilui.cpp
+++ b/Client/qtTeamTalk/utilui.cpp
@@ -110,35 +110,38 @@ void migrateSettings()
 #endif
 
         // Language files was renamed in 5.4 format
-        QString lc_code;
-        QString lang = ttSettings->value(SETTINGS_DISPLAY_LANGUAGE, SETTINGS_DISPLAY_LANGUAGE_DEFAULT).toString();
-        if (lang == "Bulgarian") lc_code = "bg";
-        else if (lang == "Chinese_Simplified") lc_code = "zh_CN";
-        else if (lang == "Chinese_Traditional") lc_code = "zh_TW";
-        else if (lang == "Croatian") lc_code = "hr";
-        else if (lang == "Czech") lc_code = "cs";
-        else if (lang == "Danish") lc_code = "da";
-        else if (lang == "Dutch") lc_code = "nl";
-        else if (lang == "English") lc_code = "en";
-        else if (lang == "French") lc_code = "fr";
-        else if (lang == "German") lc_code = "de";
-        else if (lang == "Hebrew") lc_code = "he";
-        else if (lang == "Hungarian") lc_code = "hu";
-        else if (lang == "Indonesian") lc_code = "id";
-        else if (lang == "Italian") lc_code = "it";
-        else if (lang == "Korean") lc_code = "ko";
-        else if (lang == "Persian") lc_code = "fa";
-        else if (lang == "Polish") lc_code = "pl";
-        else if (lang == "Portuguese_BR") lc_code = "pt_BR";
-        else if (lang == "Portuguese_EU") lc_code = "pt_PT";
-        else if (lang == "Russian") lc_code = "ru";
-        else if (lang == "Slovak") lc_code = "sk";
-        else if (lang == "Slovenian") lc_code = "sl";
-        else if (lang == "Spanish") lc_code = "es";
-        else if (lang == "Thai") lc_code = "th";
-        else if (lang == "Turkish") lc_code = "tr";
-        else if (lang == "Vietnamese") lc_code = "vi";
-        ttSettings->setValue(SETTINGS_DISPLAY_LANGUAGE, lc_code);
+        if (ttSettings->contains(SETTINGS_DISPLAY_LANGUAGE))
+        {
+            QString lc_code;
+            QString lang = ttSettings->value(SETTINGS_DISPLAY_LANGUAGE, SETTINGS_DISPLAY_LANGUAGE_DEFAULT).toString();
+            if (lang == "Bulgarian") lc_code = "bg";
+            else if (lang == "Chinese_Simplified") lc_code = "zh_CN";
+            else if (lang == "Chinese_Traditional") lc_code = "zh_TW";
+            else if (lang == "Croatian") lc_code = "hr";
+            else if (lang == "Czech") lc_code = "cs";
+            else if (lang == "Danish") lc_code = "da";
+            else if (lang == "Dutch") lc_code = "nl";
+            else if (lang == "English") lc_code = "en";
+            else if (lang == "French") lc_code = "fr";
+            else if (lang == "German") lc_code = "de";
+            else if (lang == "Hebrew") lc_code = "he";
+            else if (lang == "Hungarian") lc_code = "hu";
+            else if (lang == "Indonesian") lc_code = "id";
+            else if (lang == "Italian") lc_code = "it";
+            else if (lang == "Korean") lc_code = "ko";
+            else if (lang == "Persian") lc_code = "fa";
+            else if (lang == "Polish") lc_code = "pl";
+            else if (lang == "Portuguese_BR") lc_code = "pt_BR";
+            else if (lang == "Portuguese_EU") lc_code = "pt_PT";
+            else if (lang == "Russian") lc_code = "ru";
+            else if (lang == "Slovak") lc_code = "sk";
+            else if (lang == "Slovenian") lc_code = "sl";
+            else if (lang == "Spanish") lc_code = "es";
+            else if (lang == "Thai") lc_code = "th";
+            else if (lang == "Turkish") lc_code = "tr";
+            else if (lang == "Vietnamese") lc_code = "vi";
+            ttSettings->setValue(SETTINGS_DISPLAY_LANGUAGE, lc_code);
+        }
 
         // Shortcuts changed in 5.4 format
         Hotkeys hks = HOTKEY_NONE;


### PR DESCRIPTION
migrateSettings is call before language selection, if TT has never been started, migrateSettings define a lanauge, so SETTINGS_DISPLAY_LANGUAGE is always set and the language selection isn't trigger.
So, I changed the check to ask for language selection if it is the first startup and not only if SETTINGS_DISPLAY_LANGUAGE isn't present, and I add a check to ensure migrateSettings define a new language only if SETTINGS_DISPLAY_LANGUAGE is previously set.