### PR TITLE
Option to use TeamTalk sound Output device for default sound event playback mode

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -6,6 +6,7 @@ Version 5.17.1, unreleased
 Default Qt Client
 - Support "{username}" variable for majority of TTS and status events related to user action
 - Fixed gender changed from female to male when migrating to 5.17 release
+- Option to use TeamTalk Sound Output device for default sound event playback mode
 Android Client
 -
 iOS Client

--- a/Client/qtTeamTalk/preferences.ui
+++ b/Client/qtTeamTalk/preferences.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1119</width>
+    <width>1125</width>
     <height>706</height>
    </rect>
   </property>
@@ -1415,6 +1415,16 @@
             </item>
             <item>
              <widget class="QComboBox" name="sndeventPlaybackComboBox"/>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="ttDeviceChkBox">
+              <property name="toolTip">
+               <string>Use the sound output device selected in TeamTalk for playing sound events</string>
+              </property>
+              <property name="text">
+               <string>Use selected sound output device for playback</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>

--- a/Client/qtTeamTalk/preferencesdlg.cpp
+++ b/Client/qtTeamTalk/preferencesdlg.cpp
@@ -149,6 +149,10 @@ PreferencesDlg::PreferencesDlg(SoundDevice& devin, SoundDevice& devout, QWidget 
     //sound events
     m_soundmodel = new SoundEventsModel(this);
     ui.soundEventsTableView->setModel(m_soundmodel);
+    connect(ui.sndeventPlaybackComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [&]()
+    {
+        ui.ttDeviceChkBox->setVisible(PlaybackMode(ui.sndeventPlaybackComboBox->currentData().toInt()) == PLAYBACKMODE_DEFAULT);
+    });
     connect(ui.soundEventsTableView, &QAbstractItemView::doubleClicked, this, &PreferencesDlg::slotSoundEventToggled);
     connect(ui.soundEventsTableView->selectionModel(), &QItemSelectionModel::currentChanged, this, &PreferencesDlg::SoundEventSelected);
     connect(ui.soundEventsBrowseButton, &QPushButton::clicked, this, &PreferencesDlg::slotBrowseSoundEvent);
@@ -578,6 +582,7 @@ void PreferencesDlg::initSoundEventsTab()
     ui.sndeventPlaybackComboBox->addItem(tr("One by One"), PLAYBACKMODE_ONEBYONE);
     ui.sndeventPlaybackComboBox->addItem(tr("Overlapping"), PLAYBACKMODE_OVERLAPPING);
     setCurrentItemData(ui.sndeventPlaybackComboBox, ttSettings->value(SETTINGS_SOUNDEVENT_PLAYBACKMODE, SETTINGS_SOUNDEVENT_PLAYBACKMODE_DEFAULT));
+    ui.ttDeviceChkBox->setChecked(ttSettings->value(SETTINGS_SOUNDEVENT_TTDEVICE, SETTINGS_SOUNDEVENT_TTDEVICE_DEFAULT).toBool());
     SoundEvents events = ttSettings->value(SETTINGS_SOUNDEVENT_ACTIVEEVENTS, SETTINGS_SOUNDEVENT_ACTIVEEVENTS_DEFAULT).toULongLong();
     m_soundmodel->setSoundEvents(events);
 }
@@ -923,6 +928,7 @@ void PreferencesDlg::slotSaveChanges()
     {
         ttSettings->setValue(SETTINGS_SOUNDEVENT_VOLUME, ui.sndVolSpinBox->value());
         ttSettings->setValue(SETTINGS_SOUNDEVENT_PLAYBACKMODE, getCurrentItemData(ui.sndeventPlaybackComboBox));
+        ttSettings->setValue(SETTINGS_SOUNDEVENT_TTDEVICE, ui.ttDeviceChkBox->isChecked());
         ttSettings->setValue(SETTINGS_SOUNDEVENT_ACTIVEEVENTS, m_soundmodel->getSoundEvents());
         ttSettings->setValue(SETTINGS_DISPLAY_SOUNDEVENTSHEADER, ui.soundEventsTableView->horizontalHeader()->saveState());
         saveCurrentFile();

--- a/Client/qtTeamTalk/settings.h
+++ b/Client/qtTeamTalk/settings.h
@@ -327,6 +327,8 @@
 #define SETTINGS_SOUNDEVENT_VOLUME_DEFAULT                 100
 #define SETTINGS_SOUNDEVENT_PLAYBACKMODE            "soundevents/playback-mode"
 #define SETTINGS_SOUNDEVENT_PLAYBACKMODE_DEFAULT    PLAYBACKMODE_DEFAULT
+#define SETTINGS_SOUNDEVENT_TTDEVICE                 "soundevents/use-tt-device"
+#define SETTINGS_SOUNDEVENT_TTDEVICE_DEFAULT                 true
 #define SETTINGS_SOUNDEVENT_ACTIVEEVENTS                   "soundevents/active-events"
 #define SETTINGS_SOUNDEVENT_ACTIVEEVENTS_DEFAULT    SoundEvents(SOUNDEVENT_NEWUSER | \
                                                     SOUNDEVENT_REMOVEUSER | \

--- a/Client/qtTeamTalk/utilsound.cpp
+++ b/Client/qtTeamTalk/utilsound.cpp
@@ -661,7 +661,8 @@ void PlaySoundEvent::playDefaultSoundEvent(const QString& filename)
     static QSoundEffect* effect = nullptr;
     delete effect;
     effect = new QSoundEffect(ttSettings);
-    effect->setAudioDevice(getSelectedOutputAudioDevice());
+    if (ttSettings->value(SETTINGS_SOUNDEVENT_TTDEVICE, SETTINGS_SOUNDEVENT_TTDEVICE_DEFAULT).toBool() == true)
+        effect->setAudioDevice(getSelectedOutputAudioDevice());
     effect->setSource(QUrl::fromLocalFile(filename));
     effect->setVolume(ttSettings->value(SETTINGS_SOUNDEVENT_VOLUME, SETTINGS_SOUNDEVENT_VOLUME_DEFAULT).toInt()/100.0);
     effect->play();


### PR DESCRIPTION
Option enabled by default to follow behaviour introduced in 5.17
Fixed #2431