### PR TITLE
Only migrate settings if first start=false

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -4,7 +4,7 @@
 
 Version 5.17.1, unreleased
 Default Qt Client
--
+- Fixed a lot of settings keys not defined correctly on new config
 Android Client
 -
 iOS Client

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -625,7 +625,8 @@ MainWindow::~MainWindow()
 
 void MainWindow::loadSettings()
 {
-    migrateSettings();
+    if (!ttSettings->value(SETTINGS_GENERAL_FIRSTSTART, SETTINGS_GENERAL_FIRSTSTART_DEFAULT).toBool())
+        migrateSettings();
 
     // Ask to set language at first start
     if (!ttSettings->contains(SETTINGS_DISPLAY_LANGUAGE))


### PR DESCRIPTION
When migrateSettings() is call with a blank ini file, a lot of settings aren't incorrectly set to empty values, E.G. sound events. Also some keys aren't incorrectly redefine, E.G. gender define to female instead of neutral.