### PR TITLE
Android client. Fixed select for move option

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -20,6 +20,7 @@ Default Qt Client
 - Fixed language not set at first start
 - Fixed OPUS DTX mode sending too big packets when variable bitrate mode (VBR) was disabled
 Android Client
+Fixed the "select for move" option selected users multiple times, it is now a toggle option between select and deselect user
 - Minimum supported Android v8.1 (Oreo)
 - WebRTC updated from r4332 to r6818
 iOS Client

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -1412,6 +1412,7 @@ private EditText newmsg;
             userActions.getMenu().findItem(R.id.action_banchan).setEnabled(banRight | operatorRight).setVisible(banRight | operatorRight);
             userActions.getMenu().findItem(R.id.action_bansrv).setEnabled(banRight).setVisible(banRight);
             userActions.getMenu().findItem(R.id.action_makeop).setTitle(ttclient.isChannelOperator(selectedUser.nUserID , selectedUser.nChannelID) ? R.string.action_revoke_operator : R.string.action_make_operator);
+            userActions.getMenu().findItem(R.id.action_select).setTitle(userIDS.contains(selectedUser.nUserID) ? R.string.action_deselect : R.string.action_select);
             userActions.getMenu().findItem(R.id.action_select).setEnabled(moveRight).setVisible(moveRight);
             userActions.show();
             return true;
@@ -1425,7 +1426,7 @@ private EditText newmsg;
             PopupMenu channelActions = new PopupMenu(this, v);
             channelActions.setOnMenuItemClickListener(this);
             channelActions.inflate(R.menu.channel_actions);
-            channelActions.getMenu().findItem(R.id.action_move).setEnabled(moveRight).setVisible(moveRight);
+            channelActions.getMenu().findItem(R.id.action_move).setEnabled(moveRight && !userIDS.isEmpty()).setVisible(moveRight && !userIDS.isEmpty());
             channelActions.show();
             return true;
         }
@@ -1496,8 +1497,12 @@ private EditText newmsg;
             userIDS.clear();
             break;
         case R.id.action_select:
-            userIDS.add(selectedUser.nUserID);
-            break;
+    if (userIDS.contains(selectedUser.nUserID)) {
+        userIDS.remove((Integer) selectedUser.nUserID);
+    } else {
+        userIDS.add(selectedUser.nUserID);
+    }
+    break;
         case R.id.action_remove: {
             alert.setMessage(getString(R.string.channel_remove_confirmation, selectedChannel.szName));
             alert.setPositiveButton(android.R.string.yes, (dialog, whichButton) -> {

--- a/Client/TeamTalkAndroid/src/main/res/values/strings.xml
+++ b/Client/TeamTalkAndroid/src/main/res/values/strings.xml
@@ -146,6 +146,7 @@
     <string name="action_kicksrv">Kick from server</string>
     <string name="action_move">Move Here</string>
     <string name="action_select">Select For Move</string>
+    <string name="action_deselect">Deselect For Move</string>
     <string name="action_upload">Upload File</string>
     <string name="action_stream">Stream a media file</string>
     <string name="button_select_media_file">Browse</string>


### PR DESCRIPTION
Currently, as much as the select for move option is clicked, it selects the user, which results the app trys to move that user 20 times to the destination channel. But now, like windows clients, once clicking this option will select the user and change the title to deselect for move for that user, and clicking it again will deselect that user.