### PR TITLE
Fix crash issue when toggling echo cancellation off

### DIFF
--- a/Client/qtTeamTalk/utilsound.cpp
+++ b/Client/qtTeamTalk/utilsound.cpp
@@ -283,6 +283,9 @@ QStringList initSelectedSoundDevices(SoundDevice& indev, SoundDevice& outdev)
 {
     QStringList result;
 
+    AudioPreprocessor preprocess = {};
+    TT_GetSoundInputPreprocessEx(ttInst, &preprocess);
+
     TT_CloseSoundInputDevice(ttInst);
     TT_CloseSoundOutputDevice(ttInst);
     TT_CloseSoundDuplexDevices(ttInst);
@@ -314,6 +317,14 @@ QStringList initSelectedSoundDevices(SoundDevice& indev, SoundDevice& outdev)
     }
 
     TT_SetSoundDeviceEffects(ttInst, &effects);
+
+    // disable WebRTC echo cancel if duplex mode is disabled
+    if (preprocess.nPreprocessor == WEBRTC_AUDIOPREPROCESSOR)
+    {
+        preprocess.webrtc.echocanceller.bEnable &= duplex;
+    }
+
+    TT_SetSoundInputPreprocessEx(ttInst, & preprocess);
 
     if (duplex)
     {


### PR DESCRIPTION
When duplex mode is disabled (due to echo cancellation = off) then WebRTC preprocessor is still active in echo cancellation mode. WebRTC then tries to access an AudioFrame::output_samples which is no longer available.

In other words the WebRTC preprocessor is configured in a way that is incompatible with the sound device configuration. WebRTC can only echo cancel when sound devices are initialized with
TT_InitSoundDuplexDevices().