### PR TITLE
Android client. Recoded server list dialog

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -20,6 +20,7 @@ Default Qt Client
 - Fixed language not set at first start
 - Fixed OPUS DTX mode sending too big packets when variable bitrate mode (VBR) was disabled
 Android Client
+- Redesigned server list dialog to remove the old remove server button and make it to use popup menus, results in a more clear and modern dialog, and fast navigating for screenreader users
 - IP Address and status message is now shown in User Properties dialog
 - Ability to select/deselect user for move to other channel
 - Minimum supported Android v8.1 (Oreo)

--- a/Client/TeamTalkAndroid/src/main/res/layout-land/item_serverentry.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout-land/item_serverentry.xml
@@ -36,30 +36,5 @@
             android:textSize="14sp" />
 
     </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentTop="true"
-        android:orientation="horizontal" >
-
-        <Button
-            android:id="@+id/server_edit"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/button_edit"
-            android:focusable="false" 
-            android:clickable="true"
-            style="?android:attr/buttonBarButtonStyle" />
-        <Button
-            android:id="@+id/server_remove"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/button_remove"
-            android:focusable="false" 
-            android:clickable="true"
-            style="?android:attr/buttonBarButtonStyle" />
-    </LinearLayout>
  
 </RelativeLayout>

--- a/Client/TeamTalkAndroid/src/main/res/layout/item_serverentry.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/item_serverentry.xml
@@ -36,21 +36,5 @@
             android:textSize="14sp" />
 
     </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentTop="true"
-        android:orientation="horizontal" >
-
-        <Button
-            android:id="@+id/server_remove"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/button_remove"
-            android:focusable="false" 
-            android:clickable="true" />
-    </LinearLayout>
  
 </RelativeLayout>

--- a/Client/TeamTalkAndroid/src/main/res/menu/server_actions.xml
+++ b/Client/TeamTalkAndroid/src/main/res/menu/server_actions.xml
@@ -1,0 +1,11 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item
+        android:id="@+id/action_editsrv"
+        android:title="@string/action_editsrv"/>
+
+    <item
+        android:id="@+id/action_removesrv"
+        android:title="@string/action_removesrv"/>
+
+</menu>

--- a/Client/TeamTalkAndroid/src/main/res/values/strings.xml
+++ b/Client/TeamTalkAndroid/src/main/res/values/strings.xml
@@ -147,6 +147,8 @@
     <string name="action_move">Move Here</string>
     <string name="action_select">Select For Move</string>
     <string name="action_deselect">Deselect For Move</string>
+    <string name="action_editsrv">Edit server</string>
+    <string name="action_removesrv">Remove server</string>
     <string name="action_upload">Upload File</string>
     <string name="action_stream">Stream a media file</string>
     <string name="button_select_media_file">Browse</string>


### PR DESCRIPTION
before, a remove button was existed beside all servers, and long pressing a server would edit that server. that way, screenreader users needed to swipe twice to reach the next server, so for example, to find 20th server, we needed to swipe 40 times, because there was a remove button beside every server. But now, exactly like the desktop qt client's host manager that was recoded in 5.17, I recoded android client's server list to make it use popup menus, modern, and much more cleaner and clear.
This fixes
https://github.com/BearWare/TeamTalk5/issues/2536