### PR TITLE
Android. remember last channel value saved on tt files

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -23,7 +23,7 @@ Default Qt Client
 - Fixed language not set at first start
 - Fixed OPUS DTX mode sending too big packets when variable bitrate mode (VBR) was disabled
 Android Client
-- The "last joined channel" checkbox's value now saves on tt files up on export and loads up on impoart, so your settings for this option will no longer be lost!
+- The "last joined channel" checkbox and nickname's value now saves on tt files up on export and loads up on impoart, so your settings for these options will no longer be lost!
 - Ability to export each server in to a .tt file separately
 - Broadcast messages are now shown in the chat tab
 - Added the ability to send broadcast messages

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -23,6 +23,7 @@ Default Qt Client
 - Fixed language not set at first start
 - Fixed OPUS DTX mode sending too big packets when variable bitrate mode (VBR) was disabled
 Android Client
+- The "last joined channel" checkbox's value now saves on tt files up on export and loads up on impoart, so your settings for this option will no longer be lost!
 - Ability to export each server in to a .tt file separately
 - Broadcast messages are now shown in the chat tab
 - Added the ability to send broadcast messages

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerEntryActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerEntryActivity.java
@@ -122,12 +122,7 @@ implements OnPreferenceChangeListener,
     @Override
     protected void onStart() {
         super.onStart();
-        
-        if ((serverentry != null) && serverentry.rememberLastChannel) {
-            showServer(serverentry);
-            serverentry = null;
-        }
-        
+                
         // Bind to LocalService if not already
         if (mConnection == null)
             mConnection = new TeamTalkConnection(this);

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerEntryActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerEntryActivity.java
@@ -122,7 +122,12 @@ implements OnPreferenceChangeListener,
     @Override
     protected void onStart() {
         super.onStart();
-                
+
+        if (serverentry != null) {
+            showServer(serverentry);
+            serverentry = null;
+        }
+
         // Bind to LocalService if not already
         if (mConnection == null)
             mConnection = new TeamTalkConnection(this);

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerListActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerListActivity.java
@@ -275,7 +275,6 @@ extends AppCompatActivity
                     if (entries != null) {
                         for (ServerEntry entry : entries) {
                             entry.servertype = ServerEntry.ServerType.LOCAL;
-                            entry.rememberLastChannel = true;
                         }
                         servers.addAll(entries);
                         Collections.sort(servers, this);

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerListActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerListActivity.java
@@ -164,6 +164,10 @@ extends AppCompatActivity
     protected void onStart() {
         super.onStart();
 
+        if (serverentry != null) {
+            saveServers();
+        }
+
         Permissions.POST_NOTIFICATIONS.request(this);
         Permissions.INTERNET.request(this);
         Permissions.RECORD_AUDIO.request(this);

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerListActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerListActivity.java
@@ -164,10 +164,6 @@ extends AppCompatActivity
     protected void onStart() {
         super.onStart();
 
-        if ((serverentry != null) && serverentry.rememberLastChannel) {
-            saveServers();
-        }
-
         Permissions.POST_NOTIFICATIONS.request(this);
         Permissions.INTERNET.request(this);
         Permissions.RECORD_AUDIO.request(this);

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/Utils.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/Utils.java
@@ -371,7 +371,7 @@ public class Utils {
                     Node joinnode = joinlist.item(0);
                     if (joinnode.getNodeType() == Node.ELEMENT_NODE) {
                         Element joinelement = (Element) joinnode;
-                        NodeList joinlastchannelnode = hostelement.getElementsByTagName("joinlastchannel");
+                        NodeList joinlastchannelnode = hostelement.getElementsByTagName("join-last-channel");
                         if (joinlastchannelnode.getLength() > 0)
                             entry.rememberLastChannel = joinlastchannelnode.item(0).getTextContent().equalsIgnoreCase("true");
                         NodeList channelnode = joinelement.getElementsByTagName("channel");
@@ -434,7 +434,7 @@ public class Utils {
                 serializer.startTag(null, "nickname").text(server.nickname).endTag(null, "nickname");
                 serializer.endTag(null, "auth");
                 serializer.startTag(null, "join");
-                serializer.startTag(null, "joinlastchannel").text(String.valueOf(server.rememberLastChannel)).endTag(null, "joinlastchannel");
+                serializer.startTag(null, "join-last-channel").text(String.valueOf(server.rememberLastChannel)).endTag(null, "join-last-channel");
                 serializer.startTag(null, "channel").text(server.channel).endTag(null, "channel");
                 serializer.startTag(null, "password").text(server.chanpasswd).endTag(null, "password");
                 serializer.endTag(null, "join");

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/Utils.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/Utils.java
@@ -294,7 +294,6 @@ public class Utils {
             if (hostnode.getNodeType() == Node.ELEMENT_NODE) {
                 Element hostelement = (Element) hostnode;
                 ServerEntry entry = new ServerEntry();
-                entry.rememberLastChannel = false;
                 NodeList namenode = hostelement.getElementsByTagName("name");
                 if (namenode.getLength() > 0)
                     entry.servername = namenode.item(0).getTextContent();
@@ -369,6 +368,9 @@ public class Utils {
                     Node joinnode = joinlist.item(0);
                     if (joinnode.getNodeType() == Node.ELEMENT_NODE) {
                         Element joinelement = (Element) joinnode;
+                        NodeList rememberLastChannelnode = hostelement.getElementsByTagName("rememberLastChannel");
+                        if (rememberLastChannelnode.getLength() > 0)
+                            entry.rememberLastChannel = rememberLastChannelnode.item(0).getTextContent().equalsIgnoreCase("true");
                         NodeList channelnode = joinelement.getElementsByTagName("channel");
                         if (channelnode.getLength() > 0)
                             entry.channel = channelnode.item(0).getTextContent();
@@ -428,6 +430,7 @@ public class Utils {
                 serializer.startTag(null, "password").text(server.password).endTag(null, "password");
                 serializer.endTag(null, "auth");
                 serializer.startTag(null, "join");
+                serializer.startTag(null, "rememberLastChannel").text(String.valueOf(server.rememberLastChannel)).endTag(null, "rememberLastChannel");
                 serializer.startTag(null, "channel").text(server.channel).endTag(null, "channel");
                 serializer.startTag(null, "password").text(server.chanpasswd).endTag(null, "password");
                 serializer.endTag(null, "join");

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/Utils.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/Utils.java
@@ -360,6 +360,9 @@ public class Utils {
                         NodeList passwordnode = authelement.getElementsByTagName("password");
                         if (passwordnode.getLength() > 0)
                             entry.password = passwordnode.item(0).getTextContent();
+                        NodeList nicknamenode = authelement.getElementsByTagName("nickname");
+                        if (nicknamenode.getLength() > 0)
+                            entry.nickname = nicknamenode.item(0).getTextContent();
                     }
                 }
                 //process <join>
@@ -368,9 +371,9 @@ public class Utils {
                     Node joinnode = joinlist.item(0);
                     if (joinnode.getNodeType() == Node.ELEMENT_NODE) {
                         Element joinelement = (Element) joinnode;
-                        NodeList rememberLastChannelnode = hostelement.getElementsByTagName("rememberLastChannel");
-                        if (rememberLastChannelnode.getLength() > 0)
-                            entry.rememberLastChannel = rememberLastChannelnode.item(0).getTextContent().equalsIgnoreCase("true");
+                        NodeList joinlastchannelnode = hostelement.getElementsByTagName("joinlastchannel");
+                        if (joinlastchannelnode.getLength() > 0)
+                            entry.rememberLastChannel = joinlastchannelnode.item(0).getTextContent().equalsIgnoreCase("true");
                         NodeList channelnode = joinelement.getElementsByTagName("channel");
                         if (channelnode.getLength() > 0)
                             entry.channel = channelnode.item(0).getTextContent();
@@ -428,9 +431,10 @@ public class Utils {
                 serializer.startTag(null, "auth");
                 serializer.startTag(null, "username").text(server.username).endTag(null, "username");
                 serializer.startTag(null, "password").text(server.password).endTag(null, "password");
+                serializer.startTag(null, "nickname").text(server.nickname).endTag(null, "nickname");
                 serializer.endTag(null, "auth");
                 serializer.startTag(null, "join");
-                serializer.startTag(null, "rememberLastChannel").text(String.valueOf(server.rememberLastChannel)).endTag(null, "rememberLastChannel");
+                serializer.startTag(null, "joinlastchannel").text(String.valueOf(server.rememberLastChannel)).endTag(null, "joinlastchannel");
                 serializer.startTag(null, "channel").text(server.channel).endTag(null, "channel");
                 serializer.startTag(null, "password").text(server.chanpasswd).endTag(null, "password");
                 serializer.endTag(null, "join");


### PR DESCRIPTION
from now on, when exporting a tt file, doesn't matter for a single server or the server list, the remember last channel checkbox's value will also be saved on tt files as how as the user have set them and will be loaded when importing tt file, so users do not have to turn it on or off again for any server, their settings are restored as how as it was before.
this fixes https://github.com/BearWare/TeamTalk5/issues/2554