### PR TITLE
Don't translate "Default" sound pack name

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -24,6 +24,7 @@ Default Qt Client
 - Fixed sound events disabled when migrating to 5.17 release
 - Fixed language not set at first start
 - Fixed OPUS DTX mode sending too big packets when variable bitrate mode (VBR) was disabled
+- Fixed ask to use default sounds pack at every language change (will be ask one last time)
 Android Client
 - Ability to export each server in to a .tt file separately
 - Nickname and Last Joined Channel are now stored in .tt file

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -831,7 +831,7 @@ void MainWindow::loadSettings()
     QString packset = ttSettings->value(SETTINGS_SOUNDS_PACK).toString();
     QString packname = QString("%1/%2").arg(SOUNDSPATH).arg(packset);
     QDir packdir(packname);
-    if((!packdir.exists()) && packset != tr("Default"))
+    if((!packdir.exists()) && packset != SETTINGS_SOUNDS_PACK_DEFAULT)
     {
         QMessageBox answer;
         answer.setText(tr("The sound pack %1 does not exist. Would you like to use the default sound pack?").arg(packset));

--- a/Client/qtTeamTalk/preferencesdlg.cpp
+++ b/Client/qtTeamTalk/preferencesdlg.cpp
@@ -575,7 +575,7 @@ void PreferencesDlg::initSoundSystemTab()
 void PreferencesDlg::initSoundEventsTab()
 {
     ui.spackBox->clear();
-    ui.spackBox->addItem(tr("Default"));
+    ui.spackBox->addItem(tr("Default"), SETTINGS_SOUNDS_PACK_DEFAULT);
     QDir dir( SOUNDSPATH, "", QDir::Name, QDir::AllDirs|QDir::NoSymLinks|QDir::NoDotAndDotDot);
     QStringList aspack = dir.entryList();
     for(int i=0;i<aspack.size();i++)
@@ -583,7 +583,7 @@ void PreferencesDlg::initSoundEventsTab()
         QString packname = aspack[i].left(aspack[i].size());
         ui.spackBox->addItem(packname, packname);
     }
-    QString pack = ttSettings->value(SETTINGS_SOUNDS_PACK, QCoreApplication::translate("MainWindow", SETTINGS_SOUNDS_PACK_DEFAULT)).toString();
+    QString pack = ttSettings->value(SETTINGS_SOUNDS_PACK, SETTINGS_SOUNDS_PACK_DEFAULT).toString();
     int index = ui.spackBox->findData(pack);
     if(index>=0)
         ui.spackBox->setCurrentIndex(index);
@@ -1889,7 +1889,7 @@ void PreferencesDlg::slotTTSRevert(bool /*checked*/)
 
 void PreferencesDlg::slotSPackChange()
 {
-    if (ui.spackBox->currentText() != ttSettings->value(SETTINGS_SOUNDS_PACK, QCoreApplication::translate("MainWindow", SETTINGS_SOUNDS_PACK_DEFAULT)).toString())
+    if (ui.spackBox->currentText() != ttSettings->value(SETTINGS_SOUNDS_PACK, SETTINGS_SOUNDS_PACK_DEFAULT).toString())
     {
         resetDefaultSoundsPack();
 
@@ -1914,7 +1914,9 @@ void PreferencesDlg::slotSPackChange()
                 }
             }
         }
-        ttSettings->setValue(SETTINGS_SOUNDS_PACK, ui.spackBox->currentText());
+        int index = ui.spackBox->currentIndex();
+        if(index >= 0)
+            ttSettings->setValue(SETTINGS_SOUNDS_PACK, ui.spackBox->itemData(index).toString());
     }
     updateSoundEventFileEdit();
 }

--- a/Client/qtTeamTalk/settings.h
+++ b/Client/qtTeamTalk/settings.h
@@ -318,7 +318,7 @@
 #define SETTINGS_SOUNDEVENT_TYPING           "soundevents/user-typing"
 #define SETTINGS_SOUNDEVENT_TYPING_DEFAULT           (SOUNDSPATH"/typing.wav")
 #define SETTINGS_SOUNDS_PACK           "soundevents/sounds-pack"
-#define SETTINGS_SOUNDS_PACK_DEFAULT           QT_TRANSLATE_NOOP("MainWindow", "Default")
+#define SETTINGS_SOUNDS_PACK_DEFAULT           "Default"
 #define SETTINGS_SOUNDEVENT_ENABLE                   "soundevents/sounds-enable"
 #define SETTINGS_SOUNDEVENT_ENABLE_DEFAULT           true
 #define SETTINGS_SOUNDEVENT_VOLUME                 "soundevents/volume"

--- a/Client/qtTeamTalk/utilsound.cpp
+++ b/Client/qtTeamTalk/utilsound.cpp
@@ -679,7 +679,7 @@ void resetDefaultSoundsPack()
         ttSettings->setValue(paramKey, defaultValue);
     }
 
-    ttSettings->setValue(SETTINGS_SOUNDS_PACK, QCoreApplication::translate("MainWindow", SETTINGS_SOUNDS_PACK_DEFAULT));
+    ttSettings->setValue(SETTINGS_SOUNDS_PACK, SETTINGS_SOUNDS_PACK_DEFAULT);
 }
 
 QString UtilSound::getDefaultFile(const QString& paramKey)

--- a/Client/qtTeamTalk/utilui.cpp
+++ b/Client/qtTeamTalk/utilui.cpp
@@ -177,6 +177,10 @@ void migrateSettings()
             ttSettings->remove("texttospeech/tts-timestamp");
         }
 #endif
+
+        // Default sounds pack name changed in 5.5 format
+        if (ttSettings->value(SETTINGS_SOUNDS_PACK, SETTINGS_SOUNDS_PACK_DEFAULT).toString() == QCoreApplication::translate("UtilUI", "Default"))
+            ttSettings->setValue(SETTINGS_SOUNDS_PACK, SETTINGS_SOUNDS_PACK_DEFAULT);
     }
 
     if (ttSettings->value(SETTINGS_GENERAL_VERSION).toString() != SETTINGS_VERSION)

--- a/Client/qtTeamTalk/utilui.cpp
+++ b/Client/qtTeamTalk/utilui.cpp
@@ -177,10 +177,6 @@ void migrateSettings()
             ttSettings->remove("texttospeech/tts-timestamp");
         }
 #endif
-
-        // Default sounds pack name changed in 5.5 format
-        if (ttSettings->value(SETTINGS_SOUNDS_PACK, SETTINGS_SOUNDS_PACK_DEFAULT).toString() == QCoreApplication::translate("UtilUI", "Default"))
-            ttSettings->setValue(SETTINGS_SOUNDS_PACK, SETTINGS_SOUNDS_PACK_DEFAULT);
     }
 
     if (ttSettings->value(SETTINGS_GENERAL_VERSION).toString() != SETTINGS_VERSION)


### PR DESCRIPTION
Avoid to ask for default sound pack usage at every language change.
@bear101 The migratioon of SETTINGS_SOUNDS_PACK in utilui.cpp isn't apply, do you know why, I don't understand :(