### PR TITLE
Hotfixes for new history list

### DIFF
--- a/Client/qtTeamTalk/chattextlist.cpp
+++ b/Client/qtTeamTalk/chattextlist.cpp
@@ -131,7 +131,7 @@ void ChatTextList::joinedChannel(int channelid)
     topicItem->setData(Qt::UserRole + 3, tr("Topic: %1").arg(_Q(chan.szTopic)));
     addItem(topicItem);
 
-    QListWidgetItem* quotaItem = new QListWidgetItem(tr("Disk quota: %1 KBytes").arg(chan.nDiskQuota/1024));
+    QListWidgetItem* quotaItem = new QListWidgetItem(tr("Disk quota: %1").arg(getFormattedSize(chan.nDiskQuota)));
     quotaItem->setForeground(Qt::darkRed);
     quotaItem->setData(Qt::UserRole + 1, dt);
     quotaItem->setData(Qt::UserRole + 2, tr("Channel"));

--- a/Client/qtTeamTalk/chattextlist.cpp
+++ b/Client/qtTeamTalk/chattextlist.cpp
@@ -348,7 +348,7 @@ void ChatTextList::contextMenuEvent(QContextMenuEvent* event)
 
     menu.addSeparator();
     menu.addAction(tr("Copy &All"), this, &ChatTextList::copyAllHistory);
-    menu.addAction(tr("&Clear"), this, &ChatTextList::clearHistory);
+    menu.addAction(tr("C&lear"), this, &ChatTextList::clearHistory);
 
     menu.exec(event->globalPos());
 }

--- a/Client/qtTeamTalk/mainwindow.ui
+++ b/Client/qtTeamTalk/mainwindow.ui
@@ -339,12 +339,6 @@
          </property>
          <item>
           <widget class="ChatTextEdit" name="chatEdit">
-           <property name="accessibleName">
-            <string notr="true">History</string>
-           </property>
-           <property name="accessibleDescription">
-            <string notr="true"/>
-           </property>
            <property name="tabChangesFocus">
             <bool>true</bool>
            </property>
@@ -975,12 +969,6 @@
                 <property name="mouseTracking">
                  <bool>false</bool>
                 </property>
-                <property name="accessibleName">
-                 <string notr="true">History</string>
-                </property>
-                <property name="accessibleDescription">
-                 <string notr="true"/>
-                </property>
                 <property name="tabChangesFocus">
                  <bool>true</bool>
                 </property>
@@ -1263,12 +1251,6 @@
                <widget class="ChatTextEdit" name="desktopchatEdit">
                 <property name="mouseTracking">
                  <bool>false</bool>
-                </property>
-                <property name="accessibleName">
-                 <string notr="true">History</string>
-                </property>
-                <property name="accessibleDescription">
-                 <string notr="true"/>
                 </property>
                 <property name="tabChangesFocus">
                  <bool>true</bool>


### PR DESCRIPTION
* Avoid to use same accelerator key multiple times
* Remove accessible name and accessible description from ui file, already defined by cpp
* Use getFormattedSize for disk quota, same as plain text history