### PR TITLE
Setup chat history after language load

### DIFF
--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -182,7 +182,6 @@ MainWindow::MainWindow(const QString& cfgfile)
     }
 
     ui.setupUi(this);
-    setupChatHistory();
 
     setWindowIcon(QIcon(APPICON));
     updateWindowTitle();
@@ -729,6 +728,7 @@ void MainWindow::loadSettings()
             }
         }
     }
+    setupChatHistory();
 
     initSound();
 


### PR DESCRIPTION
When setupChatHistory() is called before lanauge load, accessible name of chat history isn't translated.