### PR TITLE
Limit builds of iTeamTalk to source code modifications

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -67,6 +67,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - uses: dorny/paths-filter@v3
+      id: changes
+      with:
+        filters: |
+          src:
+            - 'Library/TeamTalk_DLL/**'
+            - 'Client/iTeamTalk/**'
+
     - name: Download arch arm64
       uses: actions/download-artifact@v4
       with:
@@ -89,3 +97,13 @@ jobs:
       with:
         name: teamtalksdk-ios-universal
         path: ${{runner.workspace}}/TeamTalk5
+
+    - name: Build iTeamTalk from Xcode
+      if: steps.changes.outputs.src == 'true'
+      working-directory: ${{runner.workspace}}/TeamTalk5
+      run: >-
+        xcodebuild -project Client/iTeamTalk/iTeamTalk.xcodeproj
+        CODE_SIGN_IDENTITY=-
+        AD_HOC_CODE_SIGNING_ALLOWED=YES
+        CODE_SIGN_STYLE=Automatic
+        COMPILER_INDEX_STORE_ENABLE=NO


### PR DESCRIPTION
Use dorny/paths-filter GitHub action to limit builds of iTeamTalk using 'xcodebuild' because the build time is 4 hours.

2025-04-20T07:10:56.2240450Z     /Applications/Xcode_15.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend -c ...
...
2025-04-20T11:19:00.9301740Z /Users/runner/work/TeamTalk5/TeamTalk5/Client/iTeamTalk/iTeamTalk/WebLoginViewController.swift:134:29: warning: 'UIAlertView' was deprecated in iOS 9.0: UIAlertView is deprecated. Use