### PR TITLE
Fix MOTD not displayed in chat list

### DIFF
--- a/Client/qtTeamTalk/chattextedit.cpp
+++ b/Client/qtTeamTalk/chattextedit.cpp
@@ -160,18 +160,11 @@ void ChatTextEdit::updateServer(const ServerProperties& srvprop)
     appendPlainText(line);
     if (_Q(srvprop.szMOTD).size() > 0)
     {
-        if (ttSettings->value(SETTINGS_DISPLAY_MOTD_DLG, SETTINGS_DISPLAY_MOTD_DLG_DEFAULT).toBool() == true)
-        {
-            QMessageBox::information(this, tr("Welcome"), QString(tr("Welcome to %1.\r\nMessage of the day: %2")).arg(_Q(srvprop.szServerName)).arg(_Q(srvprop.szMOTD)));
-        }
-        else
-        {
-            line = dt + " " + tr("Message of the Day: %1").arg(_Q(srvprop.szMOTD)) + "\r\n";
-            format.setForeground(QBrush(Qt::darkCyan));
-            cursor.setCharFormat(format);
-            setTextCursor(cursor);
-            appendPlainText(line);
-        }
+        line = dt + " " + tr("Message of the Day: %1").arg(_Q(srvprop.szMOTD)) + "\r\n";
+        format.setForeground(QBrush(Qt::darkCyan));
+        cursor.setCharFormat(format);
+        setTextCursor(cursor);
+        appendPlainText(line);
     }
 
     //revert bold

--- a/Client/qtTeamTalk/chattextedit.cpp
+++ b/Client/qtTeamTalk/chattextedit.cpp
@@ -155,7 +155,7 @@ void ChatTextEdit::updateServer(const ServerProperties& srvprop)
     font.setBold(true);
     format.setFont(font);
     cursor.setCharFormat(format);
-    QString line = dt + tr("Server Name: %1").arg(_Q(srvprop.szServerName));
+    QString line = dt + " " + tr("Server Name: %1").arg(_Q(srvprop.szServerName));
     setTextCursor(cursor);
     appendPlainText(line);
     if (_Q(srvprop.szMOTD).size() > 0)
@@ -166,7 +166,7 @@ void ChatTextEdit::updateServer(const ServerProperties& srvprop)
         }
         else
         {
-            line = dt + tr("Message of the Day: %1").arg(_Q(srvprop.szMOTD)) + "\r\n";
+            line = dt + " " + tr("Message of the Day: %1").arg(_Q(srvprop.szMOTD)) + "\r\n";
             format.setForeground(QBrush(Qt::darkCyan));
             cursor.setCharFormat(format);
             setTextCursor(cursor);
@@ -208,7 +208,7 @@ void ChatTextEdit::joinedChannel(int channelid)
     format.setForeground(QBrush(Qt::darkGreen));
     cursor.setCharFormat(format);
     setTextCursor(cursor);
-    QString line = dt + tr("Joined channel %1").arg(_Q(buff));
+    QString line = dt + " " + tr("Joined channel %1").arg(_Q(buff));
     appendPlainText(line);
     //revert bold
     font.setBold(false);

--- a/Client/qtTeamTalk/chattextlist.cpp
+++ b/Client/qtTeamTalk/chattextlist.cpp
@@ -196,7 +196,7 @@ QString ChatTextList::addTextMessage(const MyTextMessage& msg)
     QListWidgetItem* item = new QListWidgetItem(line);
 
     item->setData(Qt::UserRole + 1, dt);
-    item->setData(Qt::UserRole + 2, sender);
+    item->setData(Qt::UserRole + 2, (TT_GetMyUserID(ttInst) == msg.nFromUserID)?tr("You"):getDisplayName(user));
     item->setData(Qt::UserRole + 3, content);
 
     if (TT_GetMyUserID(ttInst) == msg.nFromUserID)

--- a/Client/qtTeamTalk/chattextlist.cpp
+++ b/Client/qtTeamTalk/chattextlist.cpp
@@ -100,7 +100,7 @@ void ChatTextList::updateServer(const ServerProperties& srvprop)
 {
     QString dt = getTimeStamp(QDateTime::currentDateTime());
 
-    QListWidgetItem* item = new QListWidgetItem(dt + tr("Server Name: %1").arg(_Q(srvprop.szServerName)));
+    QListWidgetItem* item = new QListWidgetItem(dt + " " + tr("Server Name: %1").arg(_Q(srvprop.szServerName)));
     item->setFont(QFont("Arial", -1, QFont::Bold));
 
     item->setData(Qt::UserRole + 1, dt);
@@ -110,16 +110,23 @@ void ChatTextList::updateServer(const ServerProperties& srvprop)
     addItem("");
     addItem(item);
 
-    if (_Q(srvprop.szMOTD).size() > 0 && !ttSettings->value(SETTINGS_DISPLAY_MOTD_DLG, SETTINGS_DISPLAY_MOTD_DLG_DEFAULT).toBool())
+    if (_Q(srvprop.szMOTD).size() > 0)
     {
-        QListWidgetItem* motdItem = new QListWidgetItem(dt + tr("Message of the Day: %1").arg(_Q(srvprop.szMOTD)));
-        motdItem->setForeground(Qt::darkCyan);
+        if (ttSettings->value(SETTINGS_DISPLAY_MOTD_DLG, SETTINGS_DISPLAY_MOTD_DLG_DEFAULT).toBool() == true)
+        {
+            QMessageBox::information(this, tr("Welcome"), QString(tr("Welcome to %1.\r\nMessage of the day: %2")).arg(_Q(srvprop.szServerName)).arg(_Q(srvprop.szMOTD)));
+        }
+        else
+        {
+            QListWidgetItem* motdItem = new QListWidgetItem(dt + " " + tr("Message of the Day: %1").arg(_Q(srvprop.szMOTD)));
+            motdItem->setForeground(Qt::darkCyan);
 
-        motdItem->setData(Qt::UserRole + 1, dt);
-        motdItem->setData(Qt::UserRole + 2, tr("Server"));
-        motdItem->setData(Qt::UserRole + 3, tr("Message of the Day: %1").arg(_Q(srvprop.szMOTD)));
+            motdItem->setData(Qt::UserRole + 1, dt);
+            motdItem->setData(Qt::UserRole + 2, tr("Server"));
+            motdItem->setData(Qt::UserRole + 3, tr("Message of the Day: %1").arg(_Q(srvprop.szMOTD)));
 
-        addItem(motdItem);
+            addItem(motdItem);
+        }
     }
 
     limitText();
@@ -132,7 +139,7 @@ void ChatTextList::joinedChannel(int channelid)
 
     QString dt = getTimeStamp(QDateTime::currentDateTime());
 
-    QListWidgetItem* item = new QListWidgetItem(dt + tr("Joined channel %1").arg(_Q(buff)));
+    QListWidgetItem* item = new QListWidgetItem(dt + " " + tr("Joined channel %1").arg(_Q(buff)));
     item->setFont(QFont("Arial", -1, QFont::Bold));
     item->setForeground(Qt::darkGreen);
 
@@ -140,7 +147,8 @@ void ChatTextList::joinedChannel(int channelid)
     item->setData(Qt::UserRole + 2, tr("Channel"));
     item->setData(Qt::UserRole + 3, tr("Joined channel %1").arg(_Q(buff)));
 
-    addItem(""); addItem(item);
+    addItem("");
+    addItem(item);
 
     QListWidgetItem* topicItem = new QListWidgetItem(tr("Topic: %1").arg(_Q(chan.szTopic)));
     topicItem->setForeground(Qt::darkYellow);

--- a/Client/qtTeamTalk/chattextlist.cpp
+++ b/Client/qtTeamTalk/chattextlist.cpp
@@ -112,21 +112,12 @@ void ChatTextList::updateServer(const ServerProperties& srvprop)
 
     if (_Q(srvprop.szMOTD).size() > 0)
     {
-        if (ttSettings->value(SETTINGS_DISPLAY_MOTD_DLG, SETTINGS_DISPLAY_MOTD_DLG_DEFAULT).toBool() == true)
-        {
-            QMessageBox::information(this, tr("Welcome"), QString(tr("Welcome to %1.\r\nMessage of the day: %2")).arg(_Q(srvprop.szServerName)).arg(_Q(srvprop.szMOTD)));
-        }
-        else
-        {
-            QListWidgetItem* motdItem = new QListWidgetItem(dt + " " + tr("Message of the Day: %1").arg(_Q(srvprop.szMOTD)));
-            motdItem->setForeground(Qt::darkCyan);
-
-            motdItem->setData(Qt::UserRole + 1, dt);
-            motdItem->setData(Qt::UserRole + 2, tr("Server"));
-            motdItem->setData(Qt::UserRole + 3, tr("Message of the Day: %1").arg(_Q(srvprop.szMOTD)));
-
-            addItem(motdItem);
-        }
+        QListWidgetItem* motdItem = new QListWidgetItem(dt + " " + tr("Message of the Day: %1").arg(_Q(srvprop.szMOTD)));
+        motdItem->setForeground(Qt::darkCyan);
+        motdItem->setData(Qt::UserRole + 1, dt);
+        motdItem->setData(Qt::UserRole + 2, tr("Server"));
+        motdItem->setData(Qt::UserRole + 3, tr("Message of the Day: %1").arg(_Q(srvprop.szMOTD)));
+        addItem(motdItem);
     }
 
     limitText();

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -1718,6 +1718,8 @@ void MainWindow::processTTMessage(const TTMessage& msg)
             c->updateServer(msg.serverproperties);
         emit serverUpdate(msg.serverproperties);
         m_srvprop = msg.serverproperties;
+        if (ttSettings->value(SETTINGS_DISPLAY_MOTD_DLG, SETTINGS_DISPLAY_MOTD_DLG_DEFAULT).toBool() == true)
+            QMessageBox::information(this, tr("Welcome"), QString(tr("Welcome to %1.\r\nMessage of the day: %2")).arg(_Q(m_srvprop.szServerName)).arg(_Q(m_srvprop.szMOTD)));
         updateWindowTitle();
     break;
     case CLIENTEVENT_CMD_SERVERSTATISTICS :

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -1135,7 +1135,7 @@ void MainWindow::clienteventCmdServerUpdate(const ServerProperties& srvprop)
         c->updateServer(srvprop);
 
     if (ttSettings->value(SETTINGS_DISPLAY_MOTD_DLG, SETTINGS_DISPLAY_MOTD_DLG_DEFAULT).toBool() == true)
-        QMessageBox::information(this, tr("Welcome"), QString(tr("Welcome to %1.\r\nMessage of the day: %2")).arg(_Q(m_srvprop.szServerName)).arg(_Q(m_srvprop.szMOTD)));
+        QMessageBox::information(this, tr("Welcome"), QString(tr("Welcome to %1.\r\nMessage of the day: %2")).arg(_Q(srvprop.szServerName)).arg(_Q(srvprop.szMOTD)));
 
     updateWindowTitle();
 }

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -1129,6 +1129,17 @@ void MainWindow::clienteventMyselfKicked(const TTMessage& msg)
     }
 }
 
+void MainWindow::clienteventCmdServerUpdate(const ServerProperties& srvprop)
+{
+    for (auto c : m_chathistory)
+        c->updateServer(srvprop);
+
+    if (ttSettings->value(SETTINGS_DISPLAY_MOTD_DLG, SETTINGS_DISPLAY_MOTD_DLG_DEFAULT).toBool() == true)
+        QMessageBox::information(this, tr("Welcome"), QString(tr("Welcome to %1.\r\nMessage of the day: %2")).arg(_Q(m_srvprop.szServerName)).arg(_Q(m_srvprop.szMOTD)));
+
+    updateWindowTitle();
+}
+
 void MainWindow::clienteventCmdProcessing(int cmdid, bool complete)
 {
     //command reply starting -> store command reply ID
@@ -1714,13 +1725,9 @@ void MainWindow::processTTMessage(const TTMessage& msg)
     break;
     case CLIENTEVENT_CMD_SERVER_UPDATE :
         Q_ASSERT(msg.ttType == __SERVERPROPERTIES);
-        for (auto c : m_chathistory)
-            c->updateServer(msg.serverproperties);
         emit serverUpdate(msg.serverproperties);
         m_srvprop = msg.serverproperties;
-        if (ttSettings->value(SETTINGS_DISPLAY_MOTD_DLG, SETTINGS_DISPLAY_MOTD_DLG_DEFAULT).toBool() == true)
-            QMessageBox::information(this, tr("Welcome"), QString(tr("Welcome to %1.\r\nMessage of the day: %2")).arg(_Q(m_srvprop.szServerName)).arg(_Q(m_srvprop.szMOTD)));
-        updateWindowTitle();
+        clienteventCmdServerUpdate(msg.serverproperties);
     break;
     case CLIENTEVENT_CMD_SERVERSTATISTICS :
         Q_ASSERT(msg.ttType == __SERVERSTATISTICS);

--- a/Client/qtTeamTalk/mainwindow.h
+++ b/Client/qtTeamTalk/mainwindow.h
@@ -458,6 +458,7 @@ private:
     void clienteventConCryptError(const TTMessage& msg);
     void clienteventConLost();
     void clienteventMyselfKicked(const TTMessage& msg);
+    void clienteventCmdServerUpdate(const ServerProperties& srvprop);
     void clienteventCmdProcessing(int cmdid, bool complete);
     void clienteventCmdChannelUpdate(const Channel& channel);
     void clienteventCmdUserLoggedIn(const User& user);


### PR DESCRIPTION
MOTD wasn't displayed if dialog box to display MOTD was enabled and chat control was configured as a list.
Also fix some missing spaces in updateServer() and joinedChannel()