### PR TITLE
Android. Old 4 buttons has been replaced with 2 new brand nice seekbars

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -28,6 +28,7 @@ Default Qt Client
 - Fixed OPUS DTX mode sending too big packets when variable bitrate mode (VBR) was disabled
 - Fixed ask to use default sounds pack at every language change (will be asked one last time)
 Android Client
+- Replaced the old turn up/down buttons for speaker volume and microphone gain with new brand sliders that has a lot of advantages over the buttons, and looks more beautiful!
 - Added popup menu actions in Server List dialog
 - Added "Message" and "User properties" user menu actions in channel list tab
 - Ability to export each server in to a .tt file separately

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -28,7 +28,7 @@ Default Qt Client
 - Fixed OPUS DTX mode sending too big packets when variable bitrate mode (VBR) was disabled
 - Fixed ask to use default sounds pack at every language change (will be asked one last time)
 Android Client
-- Replaced the old turn up/down buttons for speaker volume and microphone gain with new brand sliders that has a lot of advantages over the buttons, and looks more beautiful!
+- Replaced turn up/down buttons for speaker volume, microphone gain and voice activation level with sliders
 - Added popup menu actions in Server List dialog
 - Added "Message" and "User properties" user menu actions in channel list tab
 - Ability to export each server in to a .tt file separately

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -455,7 +455,7 @@ extends AppCompatActivity
             final SeekBar micSeekBar = findViewById(R.id.mic_gainSeekBar);
             masterSeekBar.setProgress(Utils.refVolumeToPercent(ttclient.getSoundOutputVolume()));
             if (ttservice.isVoiceActivationEnabled()) {
-                micSeekBar.setProgress(Utils.refVolumeToPercent(ttclient.getVoiceActivationLevel()));
+                micSeekBar.setProgress(ttclient.getVoiceActivationLevel());
             } else {
                 micSeekBar.setProgress(Utils.refVolumeToPercent(ttclient.getSoundInputGainLevel()));
             }
@@ -1587,7 +1587,7 @@ private EditText newmsg;
             mikeLevel.setContentDescription(getString(R.string.vox_level_description, mikeLevel.getText()));
             voxSwitch.setImageResource(R.drawable.microphone);
             voxSwitch.setContentDescription(getString(R.string.voice_activation_off));
-            ((SeekBar) findViewById(R.id.mic_gainSeekBar)).setProgress(Utils.refVolumeToPercent(ttclient.getVoiceActivationLevel()));
+            ((SeekBar) findViewById(R.id.mic_gainSeekBar)).setProgress(ttclient.getVoiceActivationLevel());
             findViewById(R.id.mic_gainSeekBar).setContentDescription(getString(R.string.voxlevel));
         }
         else {
@@ -1700,7 +1700,7 @@ private EditText newmsg;
                     volLevel.setContentDescription(getString(R.string.speaker_volume_description, volLevel.getText()));
             }     else if (seekBar == micSeekBar) {
                     if (ttservice.isVoiceActivationEnabled()) {
-                        ttclient.setVoiceActivationLevel(Utils.refGain(progress));
+                        ttclient.setVoiceActivationLevel(progress);
                         mikeLevel.setText(progress + "%");
                         mikeLevel.setContentDescription(getString(R.string.vox_level_description, mikeLevel.getText()));
                     } else {
@@ -1848,7 +1848,7 @@ private EditText newmsg;
         final SeekBar micSeekBar = findViewById(R.id.mic_gainSeekBar);
         masterSeekBar.setProgress(Utils.refVolumeToPercent(ttclient.getSoundOutputVolume()));
         if (ttservice.isVoiceActivationEnabled()) {
-            micSeekBar.setProgress(Utils.refVolumeToPercent(ttclient.getVoiceActivationLevel()));
+            micSeekBar.setProgress(ttclient.getVoiceActivationLevel());
         } else {
             micSeekBar.setProgress(Utils.refVolumeToPercent(ttclient.getSoundInputGainLevel()));
         }

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -451,6 +451,14 @@ extends AppCompatActivity
             adjustVoxState(voxState, voxState ? voxlevel : gain);
             adjustTxState(txState);
 
+            final SeekBar masterSeekBar = findViewById(R.id.master_volSeekBar);
+            final SeekBar micSeekBar = findViewById(R.id.mic_gainSeekBar);
+            masterSeekBar.setProgress(Utils.refVolumeToPercent(ttclient.getSoundOutputVolume()));
+            if (ttservice.isVoiceActivationEnabled()) {
+                micSeekBar.setProgress(Utils.refVolumeToPercent(ttclient.getVoiceActivationLevel()));
+            } else {
+                micSeekBar.setProgress(Utils.refVolumeToPercent(ttclient.getSoundInputGainLevel()));
+            }
             TextView volLevel = findViewById(R.id.vollevel_text);
             volLevel.setText(Utils.refVolumeToPercent(mastervol) + "%");
             volLevel.setContentDescription(getString(R.string.speaker_volume_description, volLevel.getText()));

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -1597,7 +1597,6 @@ private EditText newmsg;
             voxSwitch.setContentDescription(getString(R.string.voice_activation_on));
             ((SeekBar) findViewById(R.id.mic_gainSeekBar)).setProgress(Utils.refVolumeToPercent(ttclient.getSoundInputGainLevel()));
             findViewById(R.id.mic_gainSeekBar).setContentDescription(getString(R.string.micgain));
-            adjustTxState(false);
         }
     }
 

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -1597,6 +1597,7 @@ private EditText newmsg;
             voxSwitch.setContentDescription(getString(R.string.voice_activation_on));
             ((SeekBar) findViewById(R.id.mic_gainSeekBar)).setProgress(Utils.refVolumeToPercent(ttclient.getSoundInputGainLevel()));
             findViewById(R.id.mic_gainSeekBar).setContentDescription(getString(R.string.micgain));
+            adjustTxState(false);
         }
     }
 

--- a/Client/TeamTalkAndroid/src/main/res/layout/activity_main.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/activity_main.xml
@@ -84,17 +84,11 @@
 	            android:layout_gravity="center"
 	            android:textAppearance="?android:attr/textAppearanceSmall" />
 
-    <LinearLayout
-        android:id="@+id/mastervolLayout"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_column="1"
-        android:layout_gravity="fill_horizontal" >
-
         <SeekBar
             android:id="@+id/master_volSeekBar"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_column="1"
             android:layout_gravity="center_vertical"
             android:layout_weight="0.9"
             android:contentDescription="@string/mastervolume"
@@ -110,8 +104,6 @@
 	            android:contentDescription="@string/speaker_mute"
 	            android:src="@drawable/speaker_blue" />
 
-    </LinearLayout>
-
 	        <!-- Row 1 -->
 
 	        <TextView
@@ -122,17 +114,11 @@
 	            android:layout_gravity="center"
 	            android:textAppearance="?android:attr/textAppearanceSmall" />
 
-    <LinearLayout
-        android:id="@+id/ganeLayout"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_column="1"
-        android:layout_gravity="fill_horizontal" >
-
         <SeekBar
             android:id="@+id/mic_gainSeekBar"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_column="1"
             android:layout_gravity="center_vertical"
             android:contentDescription="@string/micgain"
             android:layout_weight="0.9" />
@@ -146,8 +132,6 @@
 	            android:layout_row="1"
 	            android:contentDescription="@string/voice_activation_on"
 	            android:src="@drawable/mike_green" />
-
-    </LinearLayout>
 
 	    </GridLayout>
 	    

--- a/Client/TeamTalkAndroid/src/main/res/layout/activity_main.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/activity_main.xml
@@ -33,7 +33,7 @@
 	        android:layout_height="wrap_content"
 	        android:layout_centerVertical="true"
 	        android:layout_gravity="center_vertical"
-	        android:columnCount="2"
+	        android:columnCount="1"
 	        android:rowCount="3" >
 
 	        <!-- Row 0 -->
@@ -73,18 +73,24 @@
 	        android:layout_height="wrap_content"
 	        android:layout_centerHorizontal="true"
 	        android:layout_centerVertical="true"
-	        android:columnCount="4"
+	        android:columnCount="3"
 	        android:rowCount="2" >
 
-	        <ImageButton
-	            android:id="@+id/volDec"
-	            android:layout_width="wrap_content"
-	            android:layout_height="wrap_content"
-	            android:layout_column="0"
-	            android:layout_gravity="center"
-	            android:layout_row="0"
-	            android:contentDescription="@string/decvolume"
-	            android:src="@drawable/minus_blue" />
+    <LinearLayout
+        android:id="@+id/mastervolLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_column="0"
+        android:layout_gravity="fill_horizontal" >
+
+        <SeekBar
+            android:id="@+id/master_volSeekBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_weight="0.9"
+            android:contentDescription="@string/mastervolume"
+            android:gravity="center" />
 
 	        <ImageButton
 	            android:id="@+id/speakerBtn"
@@ -96,19 +102,11 @@
 	            android:contentDescription="@string/speaker_mute"
 	            android:src="@drawable/speaker_blue" />
 
-	        <ImageButton
-	            android:id="@+id/volInc"
-	            android:layout_width="wrap_content"
-	            android:layout_height="wrap_content"
-	            android:layout_column="2"
-	            android:layout_gravity="center"
-	            android:layout_row="0"
-	            android:contentDescription="@string/incvolume"
-	            android:src="@drawable/plus_blue" />
+    </LinearLayout>
 
 	        <TextView
 	            android:id="@+id/vollevel_text"
-	            android:layout_column="3"
+	            android:layout_column="2"
 	            android:layout_row="0"
 	            android:text=""
 	            android:layout_gravity="center"
@@ -116,15 +114,20 @@
 
 	        <!-- Row 1 -->
 
-	        <ImageButton
-	            android:id="@+id/mikeDec"
-	            android:layout_width="wrap_content"
-	            android:layout_height="wrap_content"
-	            android:layout_column="0"
-	            android:layout_gravity="center"
-	            android:layout_row="1"
-	            android:contentDescription="@string/decgain"
-	            android:src="@drawable/minus_green" />
+    <LinearLayout
+        android:id="@+id/ganeLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_column="0"
+        android:layout_gravity="fill_horizontal" >
+
+        <SeekBar
+            android:id="@+id/mic_gainSeekBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:contentDescription="@string/micgain"
+            android:layout_weight="0.9" />
 
 	        <ImageButton
 	            android:id="@+id/voxSwitch"
@@ -136,19 +139,11 @@
 	            android:contentDescription="@string/voice_activation_on"
 	            android:src="@drawable/mike_green" />
 
-	        <ImageButton
-	            android:id="@+id/mikeInc"
-	            android:layout_width="wrap_content"
-	            android:layout_height="wrap_content"
-	            android:layout_column="2"
-	            android:layout_gravity="center"
-	            android:layout_row="1"
-	            android:contentDescription="@string/incgain"
-	            android:src="@drawable/plus_green" />
+    </LinearLayout>
 
 	        <TextView
 	            android:id="@+id/mikelevel_text"
-	            android:layout_column="3"
+	            android:layout_column="2"
 	            android:layout_row="1"
 	            android:text=""
 	            android:layout_gravity="center"

--- a/Client/TeamTalkAndroid/src/main/res/layout/activity_main.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/activity_main.xml
@@ -73,8 +73,8 @@
 	        android:layout_height="wrap_content"
 	        android:layout_centerHorizontal="true"
 	        android:layout_centerVertical="true"
-	        android:columnCount="3"
-	        android:rowCount="2" >
+	        android:columnCount="1"
+	        android:rowCount="6" >
 
 	        <TextView
 	            android:id="@+id/vollevel_text"
@@ -88,7 +88,8 @@
             android:id="@+id/master_volSeekBar"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_column="1"
+            android:layout_column="0"
+	            android:layout_row="1"
             android:layout_gravity="center_vertical"
             android:layout_weight="0.9"
             android:contentDescription="@string/mastervolume"
@@ -98,18 +99,18 @@
 	            android:id="@+id/speakerBtn"
 	            android:layout_width="wrap_content"
 	            android:layout_height="wrap_content"
-	            android:layout_column="2"
+	            android:layout_column="0"
 	            android:layout_gravity="center"
-	            android:layout_row="0"
+	            android:layout_row="2"
 	            android:contentDescription="@string/speaker_mute"
 	            android:src="@drawable/speaker_blue" />
 
-	        <!-- Row 1 -->
+	        <!-- Row 3 -->
 
 	        <TextView
 	            android:id="@+id/mikelevel_text"
 	            android:layout_column="0"
-	            android:layout_row="1"
+	            android:layout_row="3"
 	            android:text=""
 	            android:layout_gravity="center"
 	            android:textAppearance="?android:attr/textAppearanceSmall" />
@@ -118,7 +119,8 @@
             android:id="@+id/mic_gainSeekBar"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_column="1"
+            android:layout_column="0"
+	            android:layout_row="4"
             android:layout_gravity="center_vertical"
             android:contentDescription="@string/micgain"
             android:layout_weight="0.9" />
@@ -127,9 +129,9 @@
 	            android:id="@+id/voxSwitch"
 	            android:layout_width="wrap_content"
 	            android:layout_height="wrap_content"
-	            android:layout_column="2"
+	            android:layout_column="0"
 	            android:layout_gravity="center"
-	            android:layout_row="1"
+	            android:layout_row="5"
 	            android:contentDescription="@string/voice_activation_on"
 	            android:src="@drawable/mike_green" />
 

--- a/Client/TeamTalkAndroid/src/main/res/layout/activity_main.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/activity_main.xml
@@ -76,11 +76,19 @@
 	        android:columnCount="3"
 	        android:rowCount="2" >
 
+	        <TextView
+	            android:id="@+id/vollevel_text"
+	            android:layout_column="0"
+	            android:layout_row="0"
+	            android:text=""
+	            android:layout_gravity="center"
+	            android:textAppearance="?android:attr/textAppearanceSmall" />
+
     <LinearLayout
         android:id="@+id/mastervolLayout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_column="0"
+        android:layout_column="1"
         android:layout_gravity="fill_horizontal" >
 
         <SeekBar
@@ -96,7 +104,7 @@
 	            android:id="@+id/speakerBtn"
 	            android:layout_width="wrap_content"
 	            android:layout_height="wrap_content"
-	            android:layout_column="1"
+	            android:layout_column="2"
 	            android:layout_gravity="center"
 	            android:layout_row="0"
 	            android:contentDescription="@string/speaker_mute"
@@ -104,21 +112,21 @@
 
     </LinearLayout>
 
+	        <!-- Row 1 -->
+
 	        <TextView
-	            android:id="@+id/vollevel_text"
-	            android:layout_column="2"
-	            android:layout_row="0"
+	            android:id="@+id/mikelevel_text"
+	            android:layout_column="0"
+	            android:layout_row="1"
 	            android:text=""
 	            android:layout_gravity="center"
 	            android:textAppearance="?android:attr/textAppearanceSmall" />
-
-	        <!-- Row 1 -->
 
     <LinearLayout
         android:id="@+id/ganeLayout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_column="0"
+        android:layout_column="1"
         android:layout_gravity="fill_horizontal" >
 
         <SeekBar
@@ -133,7 +141,7 @@
 	            android:id="@+id/voxSwitch"
 	            android:layout_width="wrap_content"
 	            android:layout_height="wrap_content"
-	            android:layout_column="1"
+	            android:layout_column="2"
 	            android:layout_gravity="center"
 	            android:layout_row="1"
 	            android:contentDescription="@string/voice_activation_on"
@@ -141,13 +149,6 @@
 
     </LinearLayout>
 
-	        <TextView
-	            android:id="@+id/mikelevel_text"
-	            android:layout_column="2"
-	            android:layout_row="1"
-	            android:text=""
-	            android:layout_gravity="center"
-	            android:textAppearance="?android:attr/textAppearanceSmall" />
 	    </GridLayout>
 	    
 	    <Button

--- a/Client/TeamTalkAndroid/src/main/res/layout/activity_main.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/activity_main.xml
@@ -86,12 +86,11 @@
 
         <SeekBar
             android:id="@+id/master_volSeekBar"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_column="0"
-	            android:layout_row="1"
-            android:layout_gravity="center_vertical"
-            android:layout_weight="0.9"
+			android:layout_row="1"
+            android:layout_gravity="center_horizontal"
             android:contentDescription="@string/mastervolume"
             android:gravity="center" />
 
@@ -117,13 +116,12 @@
 
         <SeekBar
             android:id="@+id/mic_gainSeekBar"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_column="0"
-	            android:layout_row="4"
-            android:layout_gravity="center_vertical"
-            android:contentDescription="@string/micgain"
-            android:layout_weight="0.9" />
+            android:layout_row="4"
+            android:layout_gravity="center_horizontal"
+            android:contentDescription="@string/micgain"/>
 
 	        <ImageButton
 	            android:id="@+id/voxSwitch"

--- a/Client/TeamTalkAndroid/src/main/res/values/strings.xml
+++ b/Client/TeamTalkAndroid/src/main/res/values/strings.xml
@@ -288,22 +288,17 @@
     <string name="speexvbrinterval">Transmit interval</string>
     <string name="voicevolume">Voice Volume</string>
     <string name="mediavolume">Media File Volume</string>
-    <string name="decvolume">Decrease volume</string>
-    <string name="incvolume">Increase volume</string>
+    <string name="mastervolume">Speaker volume</string>
+    <string name="micgain">Microphone gain</string>
+    <string name="voxlevel">Voice activation level</string>
     <string name="speaker_mute">Mute speakers</string>
     <string name="speaker_unmute">Unmute speakers</string>
     <string name="mic_mute">Mute microphone</string>
     <string name="mic_unmute">Unmute microphone</string>
-    <string name="decgain">Decrease microphone gain</string>
-    <string name="incgain">Increase microphone gain</string>
-
     <string name="speaker_volume_description">Speaker volume is %1$s</string>
     <string name="mic_gain_description">Microphone gain is %1$s</string>
-
     <string name="voice_activation_on">Turn voice activation on</string>
     <string name="voice_activation_off">Turn voice activation off</string>
-    <string name="decvoxlevel">Decrease voice activation level</string>
-    <string name="incvoxlevel">Increase voice activation level</string>
     <string name="vox_level_description">Voice activation level is %1$s</string>
 
     <string name="tx_on">Transmitting</string>


### PR DESCRIPTION
So, I've replaced these buttons finally, and made them exactly act as the buttons, the text is not removed so sited users also can have an idea of what the sliders are for, and also inclooded content description for blind users.
When activating or deactivating the voice activation, exactly like the buttons did, the content description and the text's labels will be changed to reflect the new value and change, also the slider's value will be updated to reflect the value of the gain or voice activation, So there is no mismatch, every changes are being tested, and made sure there is no crash, no unexpected bug, and sliders are completely normally, kicked out the buttons. Now people can enjoy using these. I'm really happy now when looking at teamtalk's screen now, both the server list and main screens. In this version I redesighned both screen and made them look more beautiful!, And removed everything related to those turn up/down buttons.
this fixes https://github.com/BearWare/TeamTalk5/issues/2529