### PR TITLE
Only indicate "Online" status if authenticated

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -1331,7 +1331,14 @@ private EditText newmsg;
                     String con = getString(R.string.stat_offline);
                     int con_color = Color.RED;
                     int flags = ttclient.getFlags(); 
-                    if((flags & ClientFlag.CLIENT_CONNECTED) == ClientFlag.CLIENT_CONNECTED) {
+                    if ((flags & ClientFlag.CLIENT_CONNECTING) == ClientFlag.CLIENT_CONNECTING) {
+                        con = getString(R.string.stat_connecting);
+                    }
+                    else if ((flags & ClientFlag.CLIENT_AUTHORIZED) == ClientFlag.CLIENT_CLOSED) {
+                        // indicate 'offline' if not authorized
+                        con = getString(R.string.stat_unauthorized);
+                    }
+                    else if ((flags & ClientFlag.CLIENT_AUTHORIZED) == ClientFlag.CLIENT_AUTHORIZED) {
                         con = getString(R.string.stat_online);
                         con_color = Color.GREEN;
                     }

--- a/Client/TeamTalkAndroid/src/main/res/values/strings.xml
+++ b/Client/TeamTalkAndroid/src/main/res/values/strings.xml
@@ -206,6 +206,7 @@
     <string name="stat_online">Online</string>
     <string name="stat_offline">Offline</string>
     <string name="stat_connecting">Connecting</string>
+    <string name="stat_unauthorized">Unauthorized</string>
     <string name="label_voice">Voice:</string>
     <string name="label_desktop">Desktop:</string>
     <string name="label_ping">Ping:</string>


### PR DESCRIPTION
When kicked from server then "Connection Status" should not be online. Instead indicate "Unauthorized".