### PR TITLE
Fix toast notification saving if TTS tab wasn't be initialized

### DIFF
--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -888,7 +888,7 @@ void MainWindow::initialScreenReaderSetup()
                 ttSettings->setValue(SETTINGS_TTS_ENGINE, TTSENGINE_TOLK);
 #elif defined(Q_OS_LINUX)
                 if (QFile::exists(NOTIFY_PATH))
-                    ttSettings->value(SETTINGS_TTS_TOAST, true);
+                    ttSettings->setValue(SETTINGS_TTS_TOAST, true);
                 else
                     ttSettings->setValue(SETTINGS_TTS_ENGINE, TTSENGINE_QT);
 #endif

--- a/Client/qtTeamTalk/preferencesdlg.cpp
+++ b/Client/qtTeamTalk/preferencesdlg.cpp
@@ -1049,10 +1049,10 @@ void PreferencesDlg::slotSaveChanges()
 #endif
         ttSettings->setValue(SETTINGS_DISPLAY_TTSHEADER, ui.ttsTableView->horizontalHeader()->saveState());
         saveCurrentMessage();
-    }
 #if defined(Q_OS_WIN) || defined(Q_OS_LINUX)
-    ttSettings->setValue(SETTINGS_TTS_TOAST, ui.ttsToastChkBox->isChecked());
+        ttSettings->setValue(SETTINGS_TTS_TOAST, ui.ttsToastChkBox->isChecked());
 #endif
+    }
 }
 
 void PreferencesDlg::slotCancelChanges()


### PR DESCRIPTION
Found! The saving of toast notification checkbox was incorrectly placed after ending of test block to check if TTS tab has been changed.
Fixed #2579