### PR TITLE
Android: Speacker is reactivated when microphone is disabled vire voice activation button same as transmit button

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -37,6 +37,7 @@ Android Client
 - Added the ability to send broadcast messages
 - Ability to select/deselect user for move to other channel
 - Simplified labels in User Properties dialog
+- Fixed speacker didn't enabled back when voice activation option is disabled. Note that this was working fine with transmit option, only voice activation had this problem wich is now been fixed!
 - IP address, user ID and status message are now in "User Properties" dialog
 - Added missing labels for sliders in audio codec configuration
 - The labels in Main Window and User Properties dialog no longer have duplicate texts

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
@@ -593,6 +593,7 @@ public class TeamTalkService extends Service
             ttclient.enableVoiceActivation(false);
             ttclient.closeSoundInputDevice();
         }
+    adjustMuteOnTx(enable);
     }
 
     public void syncToUserCache(User user) {


### PR DESCRIPTION
this fixes https://github.com/BearWare/TeamTalk5/issues/1500