### PR TITLE
Add "-v" command line argument to retrieve TT version

### DIFF
--- a/Client/qtTeamTalk/main.cpp
+++ b/Client/qtTeamTalk/main.cpp
@@ -15,6 +15,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include "mainwindow.h"
+#include "license.h"
+#include "appinfo.h"
 
 #include <QAbstractNativeEventFilter>
 #include <QApplication>
@@ -26,16 +29,13 @@
 #include <QUrl>
 #include <QtPlugin>
 
-#include <cstdio>
-#include <cstring>
-#include <vector>
+#include <iostream>
+#include <string>
 
-#ifdef Q_OS_WIN32
+#if defined(Q_OS_WIN32)
 #include <windows.h>
 #endif
 
-#include "mainwindow.h"
-#include "license.h"
 
 TTInstance* ttInst = nullptr;
 
@@ -266,9 +266,11 @@ OSStatus mac_callback(EventHandlerCallRef nextHandler, EventRef event, void*)
 static bool showVersionOnly(int argc, char* argv[])
 {
     for (int i = 1; i < argc; ++i)
-        if (!std::strcmp(argv[i], "-v"))
+    {
+        if (std::string(argv[i]) == "-v" ||
+            std::string(argv[i]) == "--version")
         {
-#ifdef Q_OS_WIN32
+#if defined(Q_OS_WIN32)
             if (!GetConsoleWindow())
             {
                 AttachConsole(ATTACH_PARENT_PROCESS);
@@ -276,10 +278,10 @@ static bool showVersionOnly(int argc, char* argv[])
                 freopen("CONOUT$", "w", stderr);
             }
 #endif
-            std::printf("TeamTalk %s\n", TEAMTALK_VERSION);
-            std::fflush(stdout);
+            std::cout << APPTITLE << std::endl;
             return true;
         }
+    }
     return false;
 }
 

--- a/Client/qtTeamTalk/main.cpp
+++ b/Client/qtTeamTalk/main.cpp
@@ -26,6 +26,14 @@
 #include <QUrl>
 #include <QtPlugin>
 
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#ifdef Q_OS_WIN32
+#include <windows.h>
+#endif
+
 #include "mainwindow.h"
 #include "license.h"
 
@@ -255,8 +263,29 @@ OSStatus mac_callback(EventHandlerCallRef nextHandler, EventRef event, void*)
 
 #endif
 
-int main(int argc, char *argv[])
+static bool showVersionOnly(int argc, char* argv[])
 {
+    for (int i = 1; i < argc; ++i)
+        if (!std::strcmp(argv[i], "-v"))
+        {
+#ifdef Q_OS_WIN32
+            if (!GetConsoleWindow())
+            {
+                AttachConsole(ATTACH_PARENT_PROCESS);
+                freopen("CONOUT$", "w", stdout);
+                freopen("CONOUT$", "w", stderr);
+            }
+#endif
+            std::printf("TeamTalk %s\n", TEAMTALK_VERSION);
+            std::fflush(stdout);
+            return true;
+        }
+    return false;
+}
+
+int main(int argc, char* argv[])
+{
+    if (showVersionOnly(argc, argv)) return 0;
 #if defined(Q_OS_WIN32)
     // Use QWindowsIntegration plugin to distinguish Alt+Gr from Ctrl+Alt on Windows
     // https://qthub.com/static/doc/qt5/qtdoc/qpa.html

--- a/Documentation/TeamTalk/advanced.md
+++ b/Documentation/TeamTalk/advanced.md
@@ -31,6 +31,9 @@ The TeamTalk 5 client supports the following command-line arguments:
 - Create new or load existing ini-file
   - Usage:\verbatim TeamTalk5.exe -cfg c:\Documents\TeamTalk5.ini \endverbatim
 
+- Print version information
+  - Usage:\verbatim TeamTalk5.exe --version \endverbatim
+
 # Load settings file (TeamTalk5.ini) {#settingsfile}
 
 By default the TeamTalk client first looks in the directory of the


### PR DESCRIPTION
Requested by @Nardol for automatic update detection, download and installation. Can probably be useful to others.
@bear101 I see a strange behaviour on Windows, version is print directly in the prompt, not on another line as it is habitually the case. Do you know a better way to handle info on Windows?