### PR TITLE
Ask to retranslate TTS Events and Status Messages on language change

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -22,6 +22,7 @@ Default Qt Client
 - OPUS updated to v1.5.2
 - Ability to custom chat templates
 - Remove option "Timestamp messages", use custom templates instead
+- Ask to retranslate TTS events and status messages on language change
 - Fixed gender changed from female to male when migrating to 5.17 release
 - Fixed sound events disabled when migrating to 5.17 release
 - Fixed language not set at first start

--- a/Client/qtTeamTalk/preferencesdlg.cpp
+++ b/Client/qtTeamTalk/preferencesdlg.cpp
@@ -771,6 +771,38 @@ void PreferencesDlg::slotSaveChanges()
             if(lang != ttSettings->value(SETTINGS_DISPLAY_LANGUAGE).toString())
             {
                 switchLanguage(lang);
+                QMessageBox answer;
+                answer.setText(tr("%1 language has been changed. Should the default values of Text-to-Speech events and Status Messages be restored? This ensures all messages are retranslated, but your custom messages will be lost.").arg(APPNAME_SHORT));
+                QAbstractButton *YesButton = answer.addButton(tr("&Yes"), QMessageBox::YesRole);
+                QAbstractButton *NoButton = answer.addButton(tr("&No"), QMessageBox::NoRole);
+                Q_UNUSED(YesButton);
+                answer.setIcon(QMessageBox::Question);
+                answer.setWindowTitle(tr("Language configuration changed"));
+                answer.exec();
+                if(answer.clickedButton() == NoButton)
+                    return;
+                auto eventMap = UtilUI::eventToSettingMap();
+                for (StatusBarEvents event = STATUSBAR_USER_LOGGEDIN; event < STATUSBAR_NEXT_UNUSED; event <<= 1)
+                {
+                    StatusBarEvents eventId = static_cast<StatusBarEvents>(event);
+                    if (eventMap.contains(eventId))
+                    {
+                        const StatusBarEventInfo& eventInfo = eventMap[eventId];
+                        QString defaultValue = UtilUI::getDefaultValue(eventInfo.settingKey);
+                        ttSettings->setValue(eventInfo.settingKey, defaultValue);
+                    }
+                }
+                auto eventMapTTS = UtilTTS::eventToSettingMap();
+                for (TTSEvents eventTTS = TTS_USER_LOGGEDIN; eventTTS < TTS_NEXT_UNUSED; eventTTS <<= 1)
+                {
+                    TTSEvents eventIdTTS = static_cast<TTSEvents>(eventTTS);
+                    if (eventMapTTS.contains(eventIdTTS))
+                    {
+                        const TTSEventInfo& eventInfoTTS = eventMapTTS[eventIdTTS];
+                        QString defaultValue = UtilTTS::getDefaultValue(eventInfoTTS.settingKey);
+                        ttSettings->setValue(eventInfoTTS.settingKey, defaultValue);
+                    }
+                }
             }
             ttSettings->setValue(SETTINGS_DISPLAY_LANGUAGE,
                         ui.languageBox->itemData(index).toString());

--- a/Client/qtTeamTalk/preferencesdlg.cpp
+++ b/Client/qtTeamTalk/preferencesdlg.cpp
@@ -771,39 +771,7 @@ void PreferencesDlg::slotSaveChanges()
             if(lang != ttSettings->value(SETTINGS_DISPLAY_LANGUAGE).toString())
             {
                 switchLanguage(lang);
-                QMessageBox answer;
-                answer.setText(tr("%1 language has been changed. Should the default values of Text-to-Speech events and Status Messages be restored? This ensures all messages are retranslated, but your custom messages will be lost.").arg(APPNAME_SHORT));
-                QAbstractButton *YesButton = answer.addButton(tr("&Yes"), QMessageBox::YesRole);
-                QAbstractButton *NoButton = answer.addButton(tr("&No"), QMessageBox::NoRole);
-                Q_UNUSED(NoButton);
-                answer.setIcon(QMessageBox::Question);
-                answer.setWindowTitle(tr("Language configuration changed"));
-                answer.exec();
-                if(answer.clickedButton() == YesButton)
-                {
-                    auto eventMap = UtilUI::eventToSettingMap();
-                    for (StatusBarEvents event = STATUSBAR_USER_LOGGEDIN; event < STATUSBAR_NEXT_UNUSED; event <<= 1)
-                    {
-                        StatusBarEvents eventId = static_cast<StatusBarEvents>(event);
-                        if (eventMap.contains(eventId))
-                        {
-                            const StatusBarEventInfo& eventInfo = eventMap[eventId];
-                            QString defaultValue = UtilUI::getDefaultValue(eventInfo.settingKey);
-                            ttSettings->setValue(eventInfo.settingKey, defaultValue);
-                        }
-                    }
-                    auto eventMapTTS = UtilTTS::eventToSettingMap();
-                    for (TTSEvents eventTTS = TTS_USER_LOGGEDIN; eventTTS < TTS_NEXT_UNUSED; eventTTS <<= 1)
-                    {
-                        TTSEvents eventIdTTS = static_cast<TTSEvents>(eventTTS);
-                        if (eventMapTTS.contains(eventIdTTS))
-                        {
-                            const TTSEventInfo& eventInfoTTS = eventMapTTS[eventIdTTS];
-                            QString defaultValue = UtilTTS::getDefaultValue(eventInfoTTS.settingKey);
-                            ttSettings->setValue(eventInfoTTS.settingKey, defaultValue);
-                        }
-                    }
-                }
+                retranslateStatusAndTTS();
             }
             ttSettings->setValue(SETTINGS_DISPLAY_LANGUAGE,
                         ui.languageBox->itemData(index).toString());
@@ -1964,4 +1932,44 @@ void PreferencesDlg::slotEditChatTemplates()
     ChatTemplatesDlg dlg(this);
     dlg.exec();
     ui.chatTemplateChkBox->setChecked(hasEditedTextMessages());
+}
+
+void PreferencesDlg::retranslateStatusAndTTS()
+{
+    if (ttSettings->value(SETTINGS_TTS_ACTIVEEVENTS, SETTINGS_TTS_ACTIVEEVENTS_DEFAULT).toULongLong() != TTS_NONE || ttSettings->value(SETTINGS_STATUSBAR_ACTIVEEVENTS, SETTINGS_STATUSBAR_ACTIVEEVENTS_DEFAULT).toULongLong() != STATUSBAR_NONE)
+    {
+        QMessageBox answer;
+        answer.setText(tr("%1 language has been changed. Should the default values of Text-to-Speech events and Status Messages be restored? This ensures all messages are retranslated, but your custom messages will be lost.").arg(APPNAME_SHORT));
+        QAbstractButton *YesButton = answer.addButton(tr("&Yes"), QMessageBox::YesRole);
+        QAbstractButton *NoButton = answer.addButton(tr("&No"), QMessageBox::NoRole);
+        Q_UNUSED(NoButton);
+        answer.setIcon(QMessageBox::Question);
+        answer.setWindowTitle(tr("Language configuration changed"));
+        answer.exec();
+        if(answer.clickedButton() == YesButton)
+        {
+            auto eventMap = UtilUI::eventToSettingMap();
+            for (StatusBarEvents event = STATUSBAR_USER_LOGGEDIN; event < STATUSBAR_NEXT_UNUSED; event <<= 1)
+            {
+                StatusBarEvents eventId = static_cast<StatusBarEvents>(event);
+                if (eventMap.contains(eventId))
+                {
+                    const StatusBarEventInfo& eventInfo = eventMap[eventId];
+                    QString defaultValue = UtilUI::getDefaultValue(eventInfo.settingKey);
+                    ttSettings->setValue(eventInfo.settingKey, defaultValue);
+                }
+            }
+            auto eventMapTTS = UtilTTS::eventToSettingMap();
+            for (TTSEvents eventTTS = TTS_USER_LOGGEDIN; eventTTS < TTS_NEXT_UNUSED; eventTTS <<= 1)
+            {
+                TTSEvents eventIdTTS = static_cast<TTSEvents>(eventTTS);
+                if (eventMapTTS.contains(eventIdTTS))
+                {
+                    const TTSEventInfo& eventInfoTTS = eventMapTTS[eventIdTTS];
+                    QString defaultValue = UtilTTS::getDefaultValue(eventInfoTTS.settingKey);
+                    ttSettings->setValue(eventInfoTTS.settingKey, defaultValue);
+                }
+            }
+        }
+    }
 }

--- a/Client/qtTeamTalk/preferencesdlg.cpp
+++ b/Client/qtTeamTalk/preferencesdlg.cpp
@@ -775,32 +775,33 @@ void PreferencesDlg::slotSaveChanges()
                 answer.setText(tr("%1 language has been changed. Should the default values of Text-to-Speech events and Status Messages be restored? This ensures all messages are retranslated, but your custom messages will be lost.").arg(APPNAME_SHORT));
                 QAbstractButton *YesButton = answer.addButton(tr("&Yes"), QMessageBox::YesRole);
                 QAbstractButton *NoButton = answer.addButton(tr("&No"), QMessageBox::NoRole);
-                Q_UNUSED(YesButton);
+                Q_UNUSED(NoButton);
                 answer.setIcon(QMessageBox::Question);
                 answer.setWindowTitle(tr("Language configuration changed"));
                 answer.exec();
-                if(answer.clickedButton() == NoButton)
-                    return;
-                auto eventMap = UtilUI::eventToSettingMap();
-                for (StatusBarEvents event = STATUSBAR_USER_LOGGEDIN; event < STATUSBAR_NEXT_UNUSED; event <<= 1)
+                if(answer.clickedButton() == YesButton)
                 {
-                    StatusBarEvents eventId = static_cast<StatusBarEvents>(event);
-                    if (eventMap.contains(eventId))
+                    auto eventMap = UtilUI::eventToSettingMap();
+                    for (StatusBarEvents event = STATUSBAR_USER_LOGGEDIN; event < STATUSBAR_NEXT_UNUSED; event <<= 1)
                     {
-                        const StatusBarEventInfo& eventInfo = eventMap[eventId];
-                        QString defaultValue = UtilUI::getDefaultValue(eventInfo.settingKey);
-                        ttSettings->setValue(eventInfo.settingKey, defaultValue);
+                        StatusBarEvents eventId = static_cast<StatusBarEvents>(event);
+                        if (eventMap.contains(eventId))
+                        {
+                            const StatusBarEventInfo& eventInfo = eventMap[eventId];
+                            QString defaultValue = UtilUI::getDefaultValue(eventInfo.settingKey);
+                            ttSettings->setValue(eventInfo.settingKey, defaultValue);
+                        }
                     }
-                }
-                auto eventMapTTS = UtilTTS::eventToSettingMap();
-                for (TTSEvents eventTTS = TTS_USER_LOGGEDIN; eventTTS < TTS_NEXT_UNUSED; eventTTS <<= 1)
-                {
-                    TTSEvents eventIdTTS = static_cast<TTSEvents>(eventTTS);
-                    if (eventMapTTS.contains(eventIdTTS))
+                    auto eventMapTTS = UtilTTS::eventToSettingMap();
+                    for (TTSEvents eventTTS = TTS_USER_LOGGEDIN; eventTTS < TTS_NEXT_UNUSED; eventTTS <<= 1)
                     {
-                        const TTSEventInfo& eventInfoTTS = eventMapTTS[eventIdTTS];
-                        QString defaultValue = UtilTTS::getDefaultValue(eventInfoTTS.settingKey);
-                        ttSettings->setValue(eventInfoTTS.settingKey, defaultValue);
+                        TTSEvents eventIdTTS = static_cast<TTSEvents>(eventTTS);
+                        if (eventMapTTS.contains(eventIdTTS))
+                        {
+                            const TTSEventInfo& eventInfoTTS = eventMapTTS[eventIdTTS];
+                            QString defaultValue = UtilTTS::getDefaultValue(eventInfoTTS.settingKey);
+                            ttSettings->setValue(eventInfoTTS.settingKey, defaultValue);
+                        }
                     }
                 }
             }

--- a/Client/qtTeamTalk/preferencesdlg.h
+++ b/Client/qtTeamTalk/preferencesdlg.h
@@ -69,6 +69,7 @@ private:
     void slotSelectVideoText();
     void slotConfigureStatusBar();
     void slotEditChatTemplates();
+    void retranslateStatusAndTTS();
     void slotUpdateUpdDlgChkBox();
     void insertTSFVariable();
 


### PR DESCRIPTION
Requested by Persian translator because some users asked why some messages are keeped in English when a translation is apply