### PR TITLE
Add hotkey to speak ping status

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -4,7 +4,7 @@
 
 Version 5.18.1, unreleased
 Default Qt Client
--
+- Added a hotkey to announce the current ping status
 Android Client
 - Option to automatically join root channel in preferences
 - Added the ability to control user's transmissions

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -2423,6 +2423,56 @@ void MainWindow::hotkeyToggle(HotKeyID id, bool active)
             else
                 showMinimized();
         }
+            case HOTKEY_SPEAK_PING:
+        if (active)
+        {
+            ClientStatistics stats = {};
+            if (TT_GetClientStatistics(ttInst, &stats))
+            {
+                int ping = stats.nUdpPingTimeMs;
+                QString pingMsg;
+                if (ping >= 0)
+                {
+                    pingMsg = QObject::tr("Current ping is %1 milliseconds.").arg(ping);
+                }
+                else
+                {
+                    pingMsg = QObject::tr("Ping status is not available.");
+                }
+                addTextToSpeechMessage(pingMsg);
+            }
+            else
+            {
+                addTextToSpeechMessage(QObject::tr("Failed to get ping status."));
+            }
+        }
+break;
+    }
+}
+
+    case HOTKEY_SPEAK_PING:
+        if (active)
+        {
+            ClientStatistics stats = {};
+            if (TT_GetClientStatistics(ttInst, &stats))
+            {
+                int ping = stats.nUdpPingTimeMs;
+                QString pingMsg;
+                if (ping >= 0)
+                {
+                    pingMsg = QObject::tr("Current ping is %1 milliseconds.").arg(ping);
+                }
+                else
+                {
+                    pingMsg = QObject::tr("Ping status is not available.");
+                }
+                addTextToSpeechMessage(pingMsg);
+            }
+            else
+            {
+                addTextToSpeechMessage(QObject::tr("Failed to get ping status."));
+            }
+        }
         break;
     }
 }

--- a/Client/qtTeamTalk/shortcutsmodel.cpp
+++ b/Client/qtTeamTalk/shortcutsmodel.cpp
@@ -43,6 +43,7 @@ ShortcutsModel::ShortcutsModel(QObject* parent)
     m_shortcuts.push_back(HOTKEY_VIDEOTX);
     m_shortcuts.push_back(HOTKEY_REINITSOUNDDEVS);
     m_shortcuts.push_back(HOTKEY_SHOWHIDE_WINDOW);
+    m_shortcuts.push_back(HOTKEY_SPEAK_PING);
 }
 
 QVariant ShortcutsModel::headerData ( int section, Qt::Orientation orientation, int role /*= Qt::DisplayRole*/ ) const

--- a/Client/qtTeamTalk/utilhotkey.cpp
+++ b/Client/qtTeamTalk/utilhotkey.cpp
@@ -51,6 +51,8 @@ QString getHotKeyName(HotKeyID id)
         return QObject::tr("Reinitialize sound devices");
     case HOTKEY_SHOWHIDE_WINDOW :
         return QObject::tr("Show/hide main window");
+    case HOTKEY_SPEAK_PING:
+        return QObject::tr("Speak Ping Status");
     case HOTKEY_NEXT_UNUSED :
     case HOTKEY_NONE :
         break;

--- a/Client/qtTeamTalk/utilhotkey.h
+++ b/Client/qtTeamTalk/utilhotkey.h
@@ -34,6 +34,7 @@ enum HotKeyID
     HOTKEY_VIDEOTX = qulonglong(1) << 7,
     HOTKEY_REINITSOUNDDEVS = qulonglong(1) << 8,
     HOTKEY_SHOWHIDE_WINDOW = qulonglong(1) << 9,
+    HOTKEY_SPEAK_PING = qulonglong(1) << 10,
 
     HOTKEY_FIRST = HOTKEY_PUSHTOTALK,
     HOTKEY_NEXT_UNUSED = qulonglong(1) << 10,


### PR DESCRIPTION
Adds a configurable hotkey to announce the current ping status via Text-To-Speech.

This feature provides a convenient way to check ping status, and crucially, it improves accessibility as the ping information in the toolbar is not readily available to screen reader users.