### PR TITLE
Qt client. Max profiles limit increaced

### DIFF
--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -4088,7 +4088,7 @@ void MainWindow::slotClientNewInstance(bool /*checked=false*/)
     // load existing profiles
     QMap<QString, QString> profiles;
     QStringList profilenames;
-    const int MAX_PROFILES = 16;
+    const int MAX_PROFILES = 1000;
     int freeno = -1;
     for (int i = 1;i <= MAX_PROFILES;i++)
     {


### PR DESCRIPTION
yesterday, someone asked for maximum profiles limitation should've been removed, because they have over 100 150 servers, and they don't like to use server list to add their new servers, they want to create a new profile for each server, and connect to all of them at once. So, I've increaced the maximum profiles entrys to 1000. But if you want, you can just remove the limitation completely.