### PR TITLE
ServerList refactor

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerListActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerListActivity.java
@@ -356,15 +356,7 @@ extends AppCompatActivity
                     startActivityForResult(Utils.putServerEntry(intent, entry).putExtra(POSITION_NAME, position), REQUEST_EDITSERVER);
                     return true;
                 case R.id.action_removesrv:
-                    AlertDialog.Builder alert = new AlertDialog.Builder(ServerListActivity.this);
-                    alert.setMessage(getString(R.string.server_remove_confirmation, entry.servername));
-                    alert.setPositiveButton(android.R.string.yes, (dialog, whichButton) -> {
-                        servers.remove(position);
-                        adapter.notifyDataSetChanged();
-                        saveServers();
-                    });
-                    alert.setNegativeButton(android.R.string.no, null);
-                    alert.show();
+                    showRemoveServerDialog(entry, position);
                     return true;
                 default:
                     return false;
@@ -827,4 +819,15 @@ extends AppCompatActivity
         return (ListFragment) getSupportFragmentManager().findFragmentById(R.id.list_fragment);
     }
 
+    private void showRemoveServerDialog(ServerEntry entry, int position) {
+        AlertDialog.Builder alert = new AlertDialog.Builder(this);
+        alert.setMessage(getString(R.string.server_remove_confirmation, entry.servername));
+        alert.setPositiveButton(android.R.string.yes, (dialog, whichButton) -> {
+            servers.remove(position);
+            adapter.notifyDataSetChanged();
+            saveServers();
+        });
+        alert.setNegativeButton(android.R.string.no, null);
+        alert.show();
+    }
 }

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerListActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerListActivity.java
@@ -49,6 +49,7 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.view.ViewCompat;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -515,6 +516,36 @@ public class ServerListActivity extends AppCompatActivity
                     onServerLongClick(v, entry, position);
                     return true;
                 });
+                
+                setupAccessibilityActions(entry, position);
+            }
+
+            private void setupAccessibilityActions(ServerEntry entry, int position) {
+                ViewCompat.addAccessibilityAction(itemView, 
+                    getString(R.string.action_editsrv),
+                    (view, arguments) -> {
+                        Intent intent = new Intent(ServerListActivity.this, ServerEntryActivity.class);
+                        startActivityForResult(Utils.putServerEntry(intent, entry)
+                            .putExtra(POSITION_NAME, position), REQUEST_EDITSERVER);
+                        return true;
+                    });
+                    
+                ViewCompat.addAccessibilityAction(itemView,
+                    getString(R.string.action_exportsrv), 
+                    (view, arguments) -> {
+                        if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) || 
+                            Permissions.WRITE_EXTERNAL_STORAGE.request(ServerListActivity.this)) {
+                            exportServer(entry);
+                        }
+                        return true;
+                    });
+                    
+                ViewCompat.addAccessibilityAction(itemView,
+                    getString(R.string.action_removesrv),
+                    (view, arguments) -> {
+                        showRemoveServerDialog(entry);
+                        return true;
+                    });
             }
 
             private void setServerIcon(ServerEntry entry) {

--- a/Client/TeamTalkAndroid/src/main/res/layout/activity_server_list.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/activity_server_list.xml
@@ -10,6 +10,19 @@
     android:paddingTop="0dp"
     tools:context=".ServerListActivity" >
 
+    <EditText
+        android:id="@+id/search_edit_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/search_servers_hint"
+        android:imeOptions="actionSearch"
+        android:inputType="text"
+        android:maxLines="1"
+        android:drawableStart="@android:drawable/ic_menu_search"
+        android:drawablePadding="8dp"
+        android:padding="12dp"
+        android:layout_marginBottom="8dp" />
+    
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/servers_recycler_view"
         android:layout_width="match_parent"

--- a/Client/TeamTalkAndroid/src/main/res/layout/activity_server_list.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/activity_server_list.xml
@@ -4,18 +4,28 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="0dp"
+    android:paddingLeft="0dp"
+    android:paddingRight="0dp"
+    android:paddingTop="0dp"
     tools:context=".ServerListActivity" >
-    
-     <fragment android:name="androidx.fragment.app.ListFragment"
-               android:id="@+id/list_fragment"
-               android:layout_width="match_parent"
-               android:layout_height="match_parent"
-               android:layout_weight="0.8"
-               android:drawSelectorOnTop="false"/>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/servers_recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:scrollbars="vertical" />
+
+    <TextView
+        android:id="@+id/empty_view"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:text="@string/server_list_empty"
+        android:textAppearance="?android:attr/textAppearanceLarge"
+        android:visibility="gone" />
 
      <Space
          android:layout_width="match_parent"

--- a/Client/TeamTalkAndroid/src/main/res/layout/item_serverentry.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/item_serverentry.xml
@@ -1,39 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="horizontal">
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:paddingLeft="8dp"
+    android:paddingRight="8dp"
+    android:paddingTop="2dp"
+    android:paddingBottom="2dp"
+    android:minHeight="32dp">
     
     <ImageView
         android:id="@+id/servericon"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="28dp"
+        android:layout_height="28dp"
         android:layout_alignParentStart="true"
+        android:layout_centerVertical="true"
+        android:layout_marginEnd="6dp"
+        android:scaleType="centerInside"
         android:src="@drawable/teamtalk_yellow"
         android:contentDescription="@string/text_localserver" />
 
     <LinearLayout
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
+        android:layout_centerVertical="true"
         android:layout_toEndOf="@id/servericon"
         android:orientation="vertical" >
  
         <TextView
             android:id="@+id/server_name"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:singleLine="true"
+            android:ellipsize="end"
             android:text=""
-            android:textSize="18sp" />
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/server_summary"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:singleLine="true"
+            android:ellipsize="end"
             android:text=""
-            android:textSize="14sp" />
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textColor="?android:attr/textColorSecondary" />
 
     </LinearLayout>
  

--- a/Client/TeamTalkAndroid/src/main/res/values/strings.xml
+++ b/Client/TeamTalkAndroid/src/main/res/values/strings.xml
@@ -248,6 +248,7 @@
     <string name="default_">Default</string>
 
     <string name="server_list_empty">TeamTalk 5 Server List is empty</string>
+    <string name="search_servers_hint">Search servers by name</string>
     <string name="no_nickname">No Nickname</string>
     <string name="message_text">Message Text</string>
     <string name="time_date">Time Date</string>


### PR DESCRIPTION
Made several changes in Server list dialog to modernize code and ui:
* Extract remove server dialog into its own method
* Refactor server export, reduce code repetition
* Refactor load servers from the network using executor instead of deprecated AsyncTask
* Refactore versionCheck to use executorService instead of now deprecated AsyncTask
* Migrate to Recycler view for displaying list of servers instead of using ListFragment
* Add possibility to filter servers using a search field on top of list to quickly find needed server, especially if user has unofficial servers checked or lots of local servers added.
* Add accessibility actions for edit, export and remove server. Now it is possible to use vertical swipes with recent Talkback to have the similar UX s in iOS
* General code cleanups and refactorings