### PR TITLE
fix(Server): Prevent accidental operator inheritance on channel ID reuse

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -35,7 +35,7 @@ Android Client
 iOS Client
 - Use VoiceOver to announce TTS events for screen reader users
 Server
--
+- Fixed security vulnerability where users could accidentally become channel operators if a channel ID was reused
 
 Version 5.18, 2025/05/05
 Default Qt Client

--- a/Library/TeamTalkLib/bin/ttsrv/ServerGuard.cpp
+++ b/Library/TeamTalkLib/bin/ttsrv/ServerGuard.cpp
@@ -475,19 +475,6 @@ void ServerGuard::OnChannelUpdated(const ServerChannel& channel,
 void ServerGuard::OnChannelRemoved(const ServerChannel& channel, 
                                    const ServerUser* user/* = NULL*/)
 {
-    // Clean up operator rights for the deleted channel.
-    bool operatorsModified = m_settings.CleanupChannelOperators(channel.GetChannelID());
-
-    if (operatorsModified)
-    {
-        // Log that operator privileges were cleaned up.
-        tostringstream oss_cleanup;
-        oss_cleanup << ACE_TEXT("Operator privileges for deleted channel #") << channel.GetChannelID() 
-                    << ACE_TEXT(" ('") << LogPrepare(channel.GetChannelPath()).c_str() 
-                    << ACE_TEXT("') cleaned from user configurations.");
-        TT_LOG(oss_cleanup.str().c_str());
-    }
-
     // Log the channel removal event.
     if (user) 
     {
@@ -501,7 +488,7 @@ void ServerGuard::OnChannelRemoved(const ServerChannel& channel,
             oss << ACE_TEXT(".");
         TT_LOG(oss.str().c_str());
     }
-    else if (!operatorsModified) 
+    else
     {
          // Log server-initiated removal if not already logged by operator cleanup.
          tostringstream oss_server_removed;
@@ -797,6 +784,9 @@ ErrorMsg ServerGuard::JoinChannel(const ServerUser& user, const ServerChannel& c
 
 ErrorMsg ServerGuard::RemoveChannel(const ServerChannel& chan, const ServerUser* user/* = nullptr */)
 {
+    // Clean up operator rights for the deleted channel.
+    m_settings.CleanupChannelOperators(chan.GetChannelID());
+
     return ErrorMsg(TT_CMDERR_SUCCESS);
 }
 

--- a/Library/TeamTalkLib/bin/ttsrv/ServerXML.cpp
+++ b/Library/TeamTalkLib/bin/ttsrv/ServerXML.cpp
@@ -1495,15 +1495,11 @@ namespace teamtalk{
 
 bool ServerXML::CleanupChannelOperators(int deletedChannelID)
 {
-    bool overallModified = false;
-    int userIndex = 0;
-    UserAccount currentUser;
-
     std::vector<UserAccount> usersToModify;
     std::vector<std::string> usernamesToRemove;
 
-    userIndex = 0;
-    currentUser = UserAccount();
+    int userIndex = 0;
+    UserAccount currentUser;
     while (GetNextUser(userIndex++, currentUser))
     {
         if (currentUser.auto_op_channels.count(deletedChannelID))
@@ -1511,24 +1507,25 @@ bool ServerXML::CleanupChannelOperators(int deletedChannelID)
             usernamesToRemove.push_back(UnicodeToUtf8(currentUser.username).c_str());
             currentUser.auto_op_channels.erase(deletedChannelID);
             usersToModify.push_back(currentUser);
-            overallModified = true;
         }
         currentUser = UserAccount();
     }
 
-    if (overallModified)
+    if (usersToModify.empty())
     {
-        for (const auto& username : usernamesToRemove)
-        {
-            RemoveUser(username);
-        }
-        for (const auto& userAcc : usersToModify)
-        {
-            AddNewUser(userAcc);
-        }
+        return false;
     }
 
-    return overallModified;
+    for (const auto& username : usernamesToRemove)
+    {
+        RemoveUser(username);
+    }
+
+    for (const auto& userAcc : usersToModify)
+    {
+        AddNewUser(userAcc);
+    }
+   return true;
 }
 
     /******* </users> ******/

--- a/Library/TeamTalkLib/bin/ttsrv/ServerXML.cpp
+++ b/Library/TeamTalkLib/bin/ttsrv/ServerXML.cpp
@@ -1493,6 +1493,67 @@ namespace teamtalk{
         AddNewUser(updateduser);
     }
 
+    bool ServerXML::CleanupChannelOperators(int deletedChannelID)
+    {
+        bool modified = false; // Flag to track if any changes were made
+
+        // Get the root <users> element
+        TiXmlElement* usersElement = GetUsersElement();
+        if (!usersElement)
+        {
+            // No users element, so nothing to do
+            return false;
+        }
+
+        // Iterate through each <user> element
+        TiXmlElement* userElement = usersElement->FirstChildElement("user");
+        while (userElement)
+        {
+            // Find the <channel-operator> element for this user
+            TiXmlElement* opChanElement = userElement->FirstChildElement("channel-operator");
+            if (opChanElement)
+            {
+                // Iterate through each <channel> element within <channel-operator>.
+                // It's important to get the next sibling before potentially removing the current element
+                // to avoid issues with the iterator.
+                TiXmlElement* channelElement = opChanElement->FirstChildElement("channel");
+                while (channelElement)
+                {
+                    TiXmlElement* nextChannelElement = channelElement->NextSiblingElement("channel");
+                    
+                    string channelIdStr;
+                    GetElementText(*channelElement, channelIdStr); 
+                    
+                    if (!channelIdStr.empty())
+                    {
+                        try
+                        {
+                            int currentChannelId = std::stoi(channelIdStr); // Convert string to int
+                            if (currentChannelId == deletedChannelID)
+                            {
+                                // Found the channel ID to remove
+                                opChanElement->RemoveChild(channelElement);
+                                modified = true; // Mark that a change was made
+                            }
+                        }
+                        catch (const std::invalid_argument& ia)
+                        {
+                            // Invalid channel ID format, ignore.
+                        }
+                        catch (const std::out_of_range& oor)
+                        {
+                            // Channel ID out of range, ignore.
+                        }
+                    }
+                    channelElement = nextChannelElement; // Move to the next channel
+                }
+            }
+            userElement = userElement->NextSiblingElement("user"); // Move to the next user
+        }
+
+        return modified; // Return true if any user's operator list was changed
+    }
+
     /******* </users> ******/
 
     /********** files in static channels **************/

--- a/Library/TeamTalkLib/bin/ttsrv/ServerXML.cpp
+++ b/Library/TeamTalkLib/bin/ttsrv/ServerXML.cpp
@@ -1496,7 +1496,6 @@ namespace teamtalk{
 bool ServerXML::CleanupChannelOperators(int deletedChannelID)
 {
     std::vector<UserAccount> usersToModify;
-    std::vector<std::string> usernamesToRemove;
 
     int userIndex = 0;
     UserAccount currentUser;
@@ -1504,28 +1503,19 @@ bool ServerXML::CleanupChannelOperators(int deletedChannelID)
     {
         if (currentUser.auto_op_channels.count(deletedChannelID))
         {
-            usernamesToRemove.push_back(UnicodeToUtf8(currentUser.username).c_str());
             currentUser.auto_op_channels.erase(deletedChannelID);
             usersToModify.push_back(currentUser);
         }
         currentUser = UserAccount();
     }
 
-    if (usersToModify.empty())
-    {
-        return false;
-    }
-
-    for (const auto& username : usernamesToRemove)
-    {
-        RemoveUser(username);
-    }
-
     for (const auto& userAcc : usersToModify)
     {
+        RemoveUser(UnicodeToUtf8(userAcc.username).c_str());
         AddNewUser(userAcc);
     }
-   return true;
+
+    return usersToModify.size();
 }
 
     /******* </users> ******/

--- a/Library/TeamTalkLib/bin/ttsrv/ServerXML.h
+++ b/Library/TeamTalkLib/bin/ttsrv/ServerXML.h
@@ -160,6 +160,9 @@ namespace teamtalk {
         bool AuthenticateUser(UserAccount& user);
         bool GetUser(const std::string& username, UserAccount& user);
         void UpdateLastLogin(const UserAccount& user);
+
+        // Removes operator privileges for a specific channel ID from all users.
+        bool CleanupChannelOperators(int deletedChannelID);
         /****** </users> *****/
 
         /********** <serverbans>  ************/


### PR DESCRIPTION
Resolves #2201 by implementing a mechanism to purge stale channel operator rights upon channel deletion.
A new public method, ServerXML::CleanupChannelOperators(int channelId), is introduced to iterate through users and remove operator privileges for a specific channel ID. The ServerGuard::OnChannelRemoved method has been updated to call this new function.