### PR TITLE
Use Ctrl+Shift+R to generate tt:// URL for current channel

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -6,6 +6,7 @@ Version 5.18.1, unreleased
 Default Qt Client
 - Ctrl+Shift+C to copy only message content in chat list
 - Ctrl+Alt+Shift+C to copy all chat list history
+- Ctrl+Shift+R to generate tt:// URL for current channel
 - In the channel dialog, the bitrate range for OPUS is limited to 6-510
 - Fixed "Speak Client Statistics", "Enable/Disable Text-To-Speech Events", "Speak User/Channel Info" and "Speak Channel Statistics" availability if TTS events are only sent using push notification
 - Fixed idle status message not being restored after network reconnection

--- a/Client/qtTeamTalk/mainwindow.ui
+++ b/Client/qtTeamTalk/mainwindow.ui
@@ -2341,7 +2341,7 @@
     <string>&amp;Generate tt:// URL to Clipboard</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+C</string>
+    <string>Ctrl+Shift+R</string>
    </property>
   </action>
   <action name="actionDesktopInput">


### PR DESCRIPTION
Following addition of CTRL+Shift+C to copy message content, to avoid conflict bitween shortcuts