### PR TITLE
Android client: Added the ability to set status messages.

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -15,6 +15,7 @@ Default Qt Client
 - Fixed crash issue in "Connect to a Server" dialog on macOS 15.1
 - macOS updated to Qt 6.10.0 beta1
 Android Client
+- Added the ability to set status messages
 - Option to automatically join root channel in preferences
 - Added the ability to control user's transmissions
 - Ability to play sound when voice activation is toggled

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
@@ -876,17 +876,21 @@ public class TeamTalkService extends Service
             //update status bar widget
             displayNotification(true);
 
-            // check whether to switch to female icon
+            // check whether to switch to female icon and put status message per server
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getBaseContext());
             int statusmode = TeamTalkConstants.STATUSMODE_AVAILABLE;
-            String msg = "";
+            String statusmsg = "";
             User myself = users.get(ttclient.getMyUserID());
             if (myself != null) {
                 statusmode = myself.nStatusMode;
-                msg = myself.szStatusMsg;
+                statusmsg = ttserver.statusmsg;
+            }
+            if (TextUtils.isEmpty(statusmsg)) {
+                statusmsg = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString(Preferences.PREF_GENERAL_STATUSMSG, "");
             }
             if (prefs.getBoolean(Preferences.PREF_GENERAL_GENDER, false))
-                ttclient.doChangeStatus(statusmode | TeamTalkConstants.STATUSMODE_FEMALE, msg);
+                statusmode |= TeamTalkConstants.STATUSMODE_FEMALE;
+            ttclient.doChangeStatus(statusmode, statusmsg);
         }
     }
 

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/Preferences.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/Preferences.java
@@ -28,6 +28,7 @@ public class Preferences {
     //duplicates of pref_connection.xml (isn't there an easier way to do this??)
     public static final String 
             PREF_GENERAL_NICKNAME = "nickname_text",
+            PREF_GENERAL_STATUSMSG = "statusmsg_text",
             PREF_GENERAL_SHOWUSERNAMES = "showusernames_checkbox",
             PREF_GENERAL_OFFICIALSERVERS = "showofficialservers_checkbox",
             PREF_GENERAL_UNOFFICIALSERVERS = "showunofficialservers_checkbox",

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/ServerEntry.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/ServerEntry.java
@@ -41,6 +41,7 @@ public class ServerEntry {
                                KEY_PASSWORD = "password",
                                KEY_WEBLOGIN = "bearwarelogin",
                                KEY_NICKNAME = "nickname",
+                               KEY_STATUSMSG = "statusmsg",
                                KEY_CHANNEL = "channel",
                                KEY_CHANPASSWD = "chanpasswd",
                                KEY_REMEMBER_LAST_CHANNEL = "remember_last_channel",
@@ -56,6 +57,7 @@ public class ServerEntry {
     public int tcpport = 0, udpport = 0;
     public String username = "", password = "";
     public String nickname = "";
+    public String statusmsg = "";
     public String channel = "", chanpasswd = "";
     public boolean rememberLastChannel = true;
     public boolean encrypted = false;

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/PreferencesActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/PreferencesActivity.java
@@ -201,9 +201,13 @@ public class PreferencesActivity extends PreferenceActivity implements TeamTalkC
                 ttinst.doChangeNickname(nickname);
             }
             int statusmode = (myself.nStatusMode & ~TeamTalkConstants.STATUSMODE_FEMALE);
+            String statusmsg = ttservice.getServerEntry().statusmsg;
+            if (TextUtils.isEmpty(statusmsg)) {
+                statusmsg = prefs.getString(Preferences.PREF_GENERAL_STATUSMSG, "");
+            }
             if (prefs.getBoolean(Preferences.PREF_GENERAL_GENDER, false))
                 statusmode |= TeamTalkConstants.STATUSMODE_FEMALE;
-            ttinst.doChangeStatus(statusmode, myself.szStatusMsg);
+            ttinst.doChangeStatus(statusmode, statusmsg);
         }
         
         int mf_volume = prefs.getInt(Preferences.PREF_SOUNDSYSTEM_MEDIAFILE_VOLUME, 100);
@@ -343,6 +347,7 @@ public class PreferencesActivity extends PreferenceActivity implements TeamTalkC
             // updated to reflect the new value, per the Android Design
             // guidelines.
             bindPreferenceSummaryToValue(findPreference(Preferences.PREF_GENERAL_NICKNAME));
+            bindPreferenceSummaryToValue(findPreference(Preferences.PREF_GENERAL_STATUSMSG));
 
             Preference bearwareLogin = findPreference(Preferences.PREF_GENERAL_BEARWARE_CHECKED);
             bearwareLogin.setOnPreferenceChangeListener((preference, o) -> {

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerEntryActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerEntryActivity.java
@@ -262,6 +262,7 @@ public class ServerEntryActivity extends AppCompatActivity
         server.username = getTextValue(binding.usernameEdit);
         server.password = getTextValue(binding.passwordEdit);
         server.nickname = getTextValue(binding.nicknameEdit);
+        server.statusmsg = getTextValue(binding.statusmsgEdit);
         server.rememberLastChannel = binding.rememberLastChannelCheckbox.isChecked();
         server.channel = getTextValue(binding.channelEdit);
         server.chanpasswd = getTextValue(binding.channelPasswordEdit);
@@ -336,6 +337,7 @@ public class ServerEntryActivity extends AppCompatActivity
         setAuthFieldsEnabled(!weblogin);
         binding.webLoginCheckbox.setChecked(weblogin);
         binding.nicknameEdit.setText(entry.nickname);
+        binding.statusmsgEdit.setText(entry.statusmsg);
     }
 
     private void populateChannelSettings(ServerEntry entry) {

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerListActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerListActivity.java
@@ -615,7 +615,7 @@ public class ServerListActivity extends AppCompatActivity
         String[] keys = {
             ServerEntry.KEY_SERVERNAME, ServerEntry.KEY_IPADDR, ServerEntry.KEY_TCPPORT,
             ServerEntry.KEY_UDPPORT, ServerEntry.KEY_ENCRYPTED, ServerEntry.KEY_USERNAME,
-            ServerEntry.KEY_PASSWORD, ServerEntry.KEY_NICKNAME, ServerEntry.KEY_REMEMBER_LAST_CHANNEL,
+            ServerEntry.KEY_PASSWORD, ServerEntry.KEY_NICKNAME, ServerEntry.KEY_STATUSMSG, ServerEntry.KEY_REMEMBER_LAST_CHANNEL,
             ServerEntry.KEY_CHANNEL, ServerEntry.KEY_CHANPASSWD
         };
         
@@ -643,6 +643,7 @@ public class ServerListActivity extends AppCompatActivity
         edit.putString(index + ServerEntry.KEY_USERNAME, server.username);
         edit.putString(index + ServerEntry.KEY_PASSWORD, server.password);
         edit.putString(index + ServerEntry.KEY_NICKNAME, server.nickname);
+        edit.putString(index + ServerEntry.KEY_STATUSMSG, server.statusmsg);
         edit.putBoolean(index + ServerEntry.KEY_REMEMBER_LAST_CHANNEL, server.rememberLastChannel);
         edit.putString(index + ServerEntry.KEY_CHANNEL, server.channel);
         edit.putString(index + ServerEntry.KEY_CHANPASSWD, server.chanpasswd);
@@ -671,6 +672,7 @@ public class ServerListActivity extends AppCompatActivity
         entry.username = pref.getString(index + ServerEntry.KEY_USERNAME, "");
         entry.password = pref.getString(index + ServerEntry.KEY_PASSWORD, "");
         entry.nickname = pref.getString(index + ServerEntry.KEY_NICKNAME, "");
+        entry.statusmsg = pref.getString(index + ServerEntry.KEY_STATUSMSG, "");
         entry.rememberLastChannel = pref.getBoolean(index + ServerEntry.KEY_REMEMBER_LAST_CHANNEL, true);
         entry.channel = pref.getString(index + ServerEntry.KEY_CHANNEL, "");
         entry.chanpasswd = pref.getString(index + ServerEntry.KEY_CHANPASSWD, "");

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/Utils.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/Utils.java
@@ -605,6 +605,9 @@ public class Utils {
                         NodeList nicknamenode = authelement.getElementsByTagName("nickname");
                         if (nicknamenode.getLength() > 0)
                             entry.nickname = nicknamenode.item(0).getTextContent();
+                        NodeList statusmsgnode = authelement.getElementsByTagName("statusmsg");
+                        if (statusmsgnode.getLength() > 0)
+                            entry.statusmsg = statusmsgnode.item(0).getTextContent();
                     }
                 }
                 //process <join>
@@ -674,6 +677,7 @@ public class Utils {
                 serializer.startTag(null, "username").text(server.username).endTag(null, "username");
                 serializer.startTag(null, "password").text(server.password).endTag(null, "password");
                 serializer.startTag(null, "nickname").text(server.nickname).endTag(null, "nickname");
+                serializer.startTag(null, "statusmsg").text(server.statusmsg).endTag(null, "statusmsg");
                 serializer.endTag(null, "auth");
                 serializer.startTag(null, "join");
                 serializer.startTag(null, "join-last-channel").text(String.valueOf(server.rememberLastChannel)).endTag(null, "join-last-channel");

--- a/Client/TeamTalkAndroid/src/main/res/layout/activity_server_entry.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/activity_server_entry.xml
@@ -267,6 +267,27 @@
         </com.google.android.material.textfield.TextInputLayout>
 
         <TextView
+            android:id="@+id/statusmsg_label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/pref_title_statusmsg"
+            android:labelFor="@+id/statusmsg_edit"
+            android:layout_marginBottom="4dp" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/statusmsg_edit"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:singleLine="true"
+                android:selectAllOnFocus="true" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/pref_title_join_channel"

--- a/Client/TeamTalkAndroid/src/main/res/values/strings.xml
+++ b/Client/TeamTalkAndroid/src/main/res/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="pref_cat_soundtest">Sound Test</string>
     <string name="pref_header_general">General</string>
     <string name="pref_title_nickname">Nickname</string>
+    <string name="pref_title_statusmsg">Status message</string>
     <string name="pref_default_nickname">NoName</string>
     <string name="pref_title_proximity_sensor">Proximity sensor</string>
     <string name="pref_title_keep_screen_on">Keep screen on when connected</string>

--- a/Client/TeamTalkAndroid/src/main/res/xml/pref_general.xml
+++ b/Client/TeamTalkAndroid/src/main/res/xml/pref_general.xml
@@ -7,6 +7,12 @@
 		android:selectAllOnFocus="true"
 		android:singleLine="true" />
 
+    <EditTextPreference
+		android:key="statusmsg_text"
+		android:title="@string/pref_title_statusmsg"
+		android:selectAllOnFocus="true"
+		android:singleLine="true" />
+
 	<CheckBoxPreference
 		android:defaultValue="false"
 		android:key="gender_checkbox"


### PR DESCRIPTION
As promiced before, i've added the ability to set status message for android client, and more surprise, is that I've desighned it like nickname, Which means you'll be able to set difrent status messages for each server seperatly if you want, and if you don't, your general status message will be used, exactly like nickname. Also, status messages for servers are stored on .tt files as well, so no worrys about losing them! enjoy!