### PR TITLE
Android client. Added a new option to prevent talking users to be moved to the top of users list

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -15,6 +15,7 @@ Default Qt Client
 - Fixed crash issue in "Connect to a Server" dialog on macOS 15.1
 - macOS updated to Qt 6.10.0 beta1
 Android Client
+- Added a new option to prevent talking users from moving to the top of users list
 - Added the ability to set status messages
 - Option to automatically join root channel in preferences
 - Added the ability to control user's transmissions

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -1118,7 +1118,7 @@ private EditText newmsg;
             Collections.sort(stickychannels, (c1, c2) -> c1.szName.compareToIgnoreCase(c2.szName));
 
             Collections.sort(currentusers, (u1, u2) -> {
-                if (PreferenceManager.getDefaultSharedPreferences(getBaseContext()).getBoolean("movetalk_checkbox", false)) {
+                if (PreferenceManager.getDefaultSharedPreferences(getBaseContext()).getBoolean("movetalk_checkbox", true)) {
                     if (((u1.uUserState & UserState.USERSTATE_VOICE) != 0) &&
                         ((u2.uUserState & UserState.USERSTATE_VOICE) == 0))
                         return -1;

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -1118,12 +1118,14 @@ private EditText newmsg;
             Collections.sort(stickychannels, (c1, c2) -> c1.szName.compareToIgnoreCase(c2.szName));
 
             Collections.sort(currentusers, (u1, u2) -> {
-                if (((u1.uUserState & UserState.USERSTATE_VOICE) != 0) &&
-                    ((u2.uUserState & UserState.USERSTATE_VOICE) == 0))
-                    return -1;
-                else if (((u1.uUserState & UserState.USERSTATE_VOICE) == 0) &&
-                         ((u2.uUserState & UserState.USERSTATE_VOICE) != 0))
-                    return 1;
+                if (PreferenceManager.getDefaultSharedPreferences(getBaseContext()).getBoolean("movetalk_checkbox", false)) {
+                    if (((u1.uUserState & UserState.USERSTATE_VOICE) != 0) &&
+                        ((u2.uUserState & UserState.USERSTATE_VOICE) == 0))
+                        return -1;
+                    else if (((u1.uUserState & UserState.USERSTATE_VOICE) == 0) &&
+                             ((u2.uUserState & UserState.USERSTATE_VOICE) != 0))
+                        return 1;
+                }
 
                 String name1 = Utils.getDisplayName(getBaseContext(), u1);
                 String name2 = Utils.getDisplayName(getBaseContext(), u2);

--- a/Client/TeamTalkAndroid/src/main/res/values/strings.xml
+++ b/Client/TeamTalkAndroid/src/main/res/values/strings.xml
@@ -153,6 +153,8 @@
     <string name="pref_summary_mute_speakers">Enable this to avoid echo from speakers</string>
     <string name="pref_title_show_usernames">Show usernames</string>
     <string name="pref_summary_show_usernames">Show usernames instead of nicknames</string>
+    <string name="pref_title_move_talking">Move talking users to top</string>
+    <string name="pref_summary_move_talking">Move talking users to the top of users list</string>
     <string name="pref_title_bearwareid">BearWare.dk WebLogin</string>
     <string name="pref_summary_bearwareid">Setup BearWare.dk WebLogin</string>
 

--- a/Client/TeamTalkAndroid/src/main/res/xml/pref_general.xml
+++ b/Client/TeamTalkAndroid/src/main/res/xml/pref_general.xml
@@ -26,6 +26,12 @@
 		android:summary="@string/pref_summary_bearwareid" />
 
     <CheckBoxPreference
+		android:key="movetalk_checkbox"
+		android:defaultValue="true"
+		android:title="@string/pref_title_move_talking"
+		android:summary="@string/pref_summary_move_talking" />
+
+    <CheckBoxPreference
 		android:key="showusernames_checkbox"
 		android:defaultValue="false"
 		android:title="@string/pref_title_show_usernames"


### PR DESCRIPTION
      So many screenreader users are annoyed by this fact that talking users are moved to the top of the list of users, because in a channel that has so many users and users are constantly opening and closing their microphones, the blind user will end up messaging, moving, kicking etc, taking action on a wrong user or they cannot do that because users are constantly moving up and down.
      Added a new option, checked by default to not break current way for sited users, which if unchecked, users will no longer move up and down, which makes it stable for blind users. Sited users or whoever wants, they can check this box, and who don't wish, can uncheck it.