### PR TITLE
Fixed status message change

### DIFF
--- a/Client/qtTeamTalk/changestatusdlg.cpp
+++ b/Client/qtTeamTalk/changestatusdlg.cpp
@@ -70,6 +70,7 @@ void ChangeStatusDlg::slotAccepted()
         Q_ASSERT(false /* this status mode is not implemented*/);
         break;
     }
+    m_statusmsg = ui.msgEdit->text();
 
     ttSettings->setValue(SETTINGS_GENERAL_STREAMING_STATUS, ui.streamChkBox->isChecked());
 }

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -4595,10 +4595,11 @@ void MainWindow::slotMeChangeStatus(bool /*checked =false */)
     if(dlg.exec())
     {
         m_statusmode = dlg.m_user.nStatusMode;
-        QString statusmsg = dlg.m_statusmsg;
+        statusmsg = dlg.m_statusmsg;
         if(TT_GetFlags(ttInst) & CLIENT_AUTHORIZED)
         {
-            TT_DoChangeStatus(ttInst, m_statusmode, _W(statusmsg));
+            m_host.statusmsg = statusmsg;
+            TT_DoChangeStatus(ttInst, m_statusmode, (statusmsg.isEmpty() && !ttSettings->value(SETTINGS_GENERAL_STATUSMESSAGE).toString().isEmpty())?_W(ttSettings->value(SETTINGS_GENERAL_STATUSMESSAGE).toString()):_W(statusmsg));
             HostEntry tmp = HostEntry();
             int serv, lasthost, index = 0;
             while (getServerEntry(index, tmp, false))

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -4599,6 +4599,7 @@ void MainWindow::slotMeChangeStatus(bool /*checked =false */)
         if(TT_GetFlags(ttInst) & CLIENT_AUTHORIZED)
         {
             m_host.statusmsg = statusmsg;
+            // Change status message using host specific message if not empty or general message otherwise
             TT_DoChangeStatus(ttInst, m_statusmode, (statusmsg.isEmpty() && !ttSettings->value(SETTINGS_GENERAL_STATUSMESSAGE).toString().isEmpty())?_W(ttSettings->value(SETTINGS_GENERAL_STATUSMESSAGE).toString()):_W(statusmsg));
             HostEntry tmp = HostEntry();
             int serv, lasthost, index = 0;


### PR DESCRIPTION
Following #2711, status message change was partially broken using "Change status" dialog