### PR TITLE
Android client. Fixed away status and added Channel operator

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -18,6 +18,8 @@ Default Qt Client
 - Fixed crash issue in "Connect to a Server" dialog on macOS 15.1
 - macOS updated to Qt 6.10.0 beta1
 Android Client
+- Show Channel operator when it's the case
+- Fixed a bug where away user's status message were not shown
 - Added a new option to prevent talking users from moving to the top of users list
 - Added the ability to set status messages
 - Option to automatically join root channel in preferences

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -1299,6 +1299,7 @@ private EditText newmsg;
                 nickname.setText(name);
                 status.setText(user.szStatusMsg);
                 
+                boolean isOperator = ttclient.isChannelOperator(user.nUserID, user.nChannelID);
                 boolean talking = (user.uUserState & UserState.USERSTATE_VOICE) != 0;
                 boolean female = (user.nStatusMode & TeamTalkConstants.STATUSMODE_FEMALE) != 0;
                 boolean neutral = (user.nStatusMode & TeamTalkConstants.STATUSMODE_NEUTRAL) != 0;
@@ -1309,35 +1310,10 @@ private EditText newmsg;
                 if(user.nUserID == ttservice.getTTInstance().getMyUserID()) {
                     talking = ttservice.isVoiceTransmitting();
                 }
-                if(talking) {
-                    if(female) {
-                        icon_resource = R.drawable.woman_green;
-                        nickname.setContentDescription(getString(R.string.user_state_now_speaking, name) + " 👩");
-                    }
-                    else if(male) {
-                        icon_resource = R.drawable.man_green;
-                        nickname.setContentDescription(getString(R.string.user_state_now_speaking, name) + " 👨");
-                    }
-                    else {
-                        icon_resource = R.drawable.man_green;
-                        nickname.setContentDescription(getString(R.string.user_state_now_speaking, name));
-                    }
-                }
-                else {
-                    if(female) {
-                        icon_resource = away? R.drawable.woman_orange : R.drawable.woman_blue;
-                        nickname.setContentDescription(name + " 👩");
-                    }
-                    else if(male) {
-                        icon_resource = away? R.drawable.man_orange : R.drawable.man_blue;
-                        nickname.setContentDescription(name + " 👨");
-                    }
-                    else {
-                        icon_resource = away? R.drawable.man_orange : R.drawable.man_blue;
-                        nickname.setContentDescription(name);
-                    }
-                }
-                status.setContentDescription(away ? getString(R.string.user_state_away) : null);
+nickname.setContentDescription((talking ? getString(R.string.user_state_now_speaking, name) : name) + (female ? " 👩 " : neutral ? " 🧑 " : male ? " 👨 " : "") + (isOperator ? getString(R.string.user_state_operator) : ""));
+icon_resource = talking ? (female ? R.drawable.woman_green : (male ? R.drawable.man_green : R.drawable.man_green)) : (female ? (away ? R.drawable.woman_orange : R.drawable.woman_blue) : (male ? (away ? R.drawable.man_orange : R.drawable.man_blue) : (away ? R.drawable.man_orange : R.drawable.man_blue)));
+
+                status.setContentDescription(away ? getString(R.string.user_state_away) + " " + user.szStatusMsg : null);
 
                 usericon.setImageResource(icon_resource);
                 usericon.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);

--- a/Client/TeamTalkAndroid/src/main/res/values/strings.xml
+++ b/Client/TeamTalkAndroid/src/main/res/values/strings.xml
@@ -475,6 +475,7 @@
     <string name="pref_title_gender">Gender</string>
     <string name="pref_summary_gender">Check for female icon</string>
     <string name="user_state_away">Away</string>
+    <string name="user_state_operator">Channel operator</string>
     <string name="pref_title_userloggedin_icon">User logged in</string>
     <string name="pref_summary_userloggedin_icon">Play sound when an user logs in</string>
     <string name="pref_title_userloggedoff_icon">User logged off</string>


### PR DESCRIPTION
Fixed the case if a user's status was away and they also had a status message, screenreader just said away and didn't read the status message.
2 Added indication of Channel operator if user is channel operator.
3. Cleaned up the lojic, instead of hundrids of if and else blocks, used clean and simple turnery operators to handle these much more cleanly, + the code is now much faster, and more readable.