### PR TITLE
Android. fixed client not joining the channel specifyed in server prop dialog

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
@@ -757,7 +757,7 @@ public class TeamTalkService extends Service
         if (joinchannel == null) {
 
             // join last channel if enabled
-            if (this.ttserver.rememberLastChannel && !ttserver.channel.isEmpty()) {
+            if (ttserver.channel != null && !ttserver.channel.isEmpty()) {
                 int chanid = ttclient.getChannelIDFromPath(ttserver.channel);
                 joinchannel = getChannels().get(chanid);
                 if (joinchannel != null) {

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
@@ -756,7 +756,7 @@ public class TeamTalkService extends Service
     private void loginComplete() {
         if (joinchannel == null) {
 
-            // join last channel if enabled
+            // join channel specified in ServerEntry
             if (ttserver.channel != null && !ttserver.channel.isEmpty()) {
                 int chanid = ttclient.getChannelIDFromPath(ttserver.channel);
                 joinchannel = getChannels().get(chanid);


### PR DESCRIPTION
@bear101 when you were implementing login complete functions in ttservice, you touched this function and due to some incorrect checks, it was became broken, whitch i've now fixed it.
this fixes https://github.com/BearWare/TeamTalk5/issues/2753