### PR TITLE
Android. made user interface better and more sinked with qt client

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -32,6 +32,7 @@ Android Client
 - Ability to play sound for intercept subscription toggled
 - Ability to use Text-To-Speech to announce transmission changes
 - Ability to use Text-To-Speech to announce subscription changes
+message button for users has been removed, klick on users to open text message dialog from now on, and both user profile and text message dialogs can also be opened in popup menu
 - Fixed bug where user's status message is not announced when away
 - Minimum supported is now Android v7.0 (Nougat)
 iOS Client

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -1355,15 +1355,6 @@ private EditText newmsg;
                 usericon.setImageResource(icon_resource);
                 usericon.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
                 
-                Button sndmsg = convertView.findViewById(R.id.msg_btn);
-                OnClickListener listener = v -> {
-                    if (v.getId() == R.id.msg_btn) {
-                        Intent intent = new Intent(MainActivity.this, TextMessageActivity.class);
-                        startActivity(intent.putExtra(TextMessageActivity.EXTRA_USERID, user.nUserID));
-                    }
-                };
-                sndmsg.setOnClickListener(listener);
-                sndmsg.setAccessibilityDelegate(accessibilityAssistant);
             }
             convertView.setAccessibilityDelegate(accessibilityAssistant);
             return convertView;
@@ -1452,10 +1443,8 @@ private EditText newmsg;
         Object item = channelsAdapter.getItem(position);
         if(item instanceof User) {
             User user = (User)item;
-            Intent intent = new Intent(this, UserPropActivity.class);
-            // TODO: check 'curchannel' for null
-            startActivityForResult(intent.putExtra(UserPropActivity.EXTRA_USERID, user.nUserID),
-                                   REQUEST_EDITUSER);
+            Intent intent = new Intent(MainActivity.this, TextMessageActivity.class);
+            startActivity(intent.putExtra(TextMessageActivity.EXTRA_USERID, user.nUserID));
         }
         else if(item instanceof Channel) {
             Channel channel = (Channel) item;

--- a/Client/TeamTalkAndroid/src/main/res/layout/item_user.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/item_user.xml
@@ -34,18 +34,4 @@
             android:textSize="14sp" />
     </LinearLayout>
     
-	<LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentRight="true">
-	    
-	    <Button
-	    android:id="@+id/msg_btn"
-	    android:layout_width="wrap_content"
-	    android:layout_height="wrap_content"
-	    android:text="@string/button_msg"
-	    android:focusable="false" 
-	    android:clickable="true" />
-    </LinearLayout>
-
 </RelativeLayout>

--- a/Client/TeamTalkAndroid/src/main/res/values/strings.xml
+++ b/Client/TeamTalkAndroid/src/main/res/values/strings.xml
@@ -234,7 +234,6 @@
     <string name="action_stream">Stream a media file</string>
     <string name="button_select_media_file">Browse</string>
     <string name="button_stream_media_file">Stream</string>
-    <string name="button_msg">Message</string>
     <string name="button_send">Send</string>
 
     <string name="channel_prop_title_name">Name</string>


### PR DESCRIPTION
in qt client, pressing enter on users names opens text message dialog, and you can open user prop dialog and text message dialog, and all other dialogs from the context menu.
So, for the following reasons.
1. Text message dialog is used more than the user prop dialog,
2. For eas of access, faster swipe and usage of screenreaders for blind users,
3. To sink with qt client,
By request, removed the message button from beside of the users, and made it so that klicking on users opens the text message dialog, and opening all of the dialogs are possible from the popup menu. This also makes the dialog modernised and beautiful, i've done the same for server list screen before.