### PR TITLE
Android. Downgraded agp to 8.11

### DIFF
--- a/Client/TeamTalkAndroid/build.gradle
+++ b/Client/TeamTalkAndroid/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.12.0'
+        classpath 'com.android.tools.build:gradle:8.11.0'
     }
 }
 


### PR DESCRIPTION
android studio stable 2025.1.1 even doesn't support gp 8.12, I think stil only preview versions support it yet.
The project is using an incompatible version (AGP 8.12.0) of the Android Gradle plugin. Latest supported version is AGP 8.11.0
See Android Studio & AGP compatibility options.
So I downgraded it to 8.11 for now, we'll upgrade it later when it's the time