### PR TITLE
perf(network): Optimize file transfer speed

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -4,6 +4,7 @@
 
 Version 5.20, unreleased
 Default Qt Client
+- Optimized file transfer performance by increasing buffer sizes and enabling TCP_NODELAY
 -
 Android Client
 - Minimum supported Android version is now 5.0 (Lollipop)


### PR DESCRIPTION
I've made a few tweaks to the networking code to speed things up, mostly around buffer sizes and enabling the `TCP_NODELAY` option.

Why these changes?
*   **Buffers:** More data moved at once, no pauses.
*   **`TCP_NODELAY`:** Data sent instantly, smooth flow.

The results are looking good:

*   My friend with a 300mb/s connection went from ~6 MB/s to ~16 MB/s on uploads.
*   Another friend on a 1gbit/s connection is now seeing speeds around 100 MB/s.