### PR TITLE
fix time notification on linux

### DIFF
--- a/Client/qtTeamTalk/utilui.cpp
+++ b/Client/qtTeamTalk/utilui.cpp
@@ -850,7 +850,7 @@ void showNotification(const QString &title, const QString &message)
     QString noquote = message;
     noquote.replace('"', ' ');
     QStringList arguments;
-    arguments << "-t" << "3" 
+    arguments << "-t" << "500" 
             << "-a" << title
             << "-u" << "low"
             << QString("%1: %2").arg(APPNAME_SHORT, noquote);


### PR DESCRIPTION
In the current setup, the notification stays on the screen for 3 ms. Orca doesn't have time to read it, so we get empty notifications.
By increasing the time to 0.5 s, Orca has time to read the notification.