### PR TITLE
Make WEBRTC_FETCH_PATH configurable

### DIFF
--- a/Library/TeamTalkLib/build/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/CMakeLists.txt
@@ -2,8 +2,8 @@ project(Toolchain)
 
 include(ExternalProject)
 
-set (TOOLCHAIN_BUILD_PREFIX build CACHE STRING "Specify alternative 'clone' directory to build all toolchain dependencies. Default: CMAKE_CURRENT_BINARY_DIR/build")
-set (TOOLCHAIN_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/install CACHE STRING "Install path for TeamTalk toolchain. Default: CMAKE_CURRENT_BINARY_DIR/install")
+set (TOOLCHAIN_BUILD_PREFIX build CACHE FILEPATH "Specify alternative 'clone' directory to build all toolchain dependencies. Default: CMAKE_CURRENT_BINARY_DIR/build")
+set (TOOLCHAIN_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/install CACHE FILEPATH "Install path for TeamTalk toolchain. Default: CMAKE_CURRENT_BINARY_DIR/install")
 
 option (TOOLCHAIN_BUILD_EXTERNALPROJECTS "Build toolchain libraries from scratch in TOOLCHAIN_BUILD_PREFIX. Alternatively reuse existing libraries installed in TOOLCHAIN_INSTALL_PREFIX" ON)
 add_feature_info(TOOLCHAIN_BUILD_EXTERNALPROJECTS TOOLCHAIN_BUILD_EXTERNALPROJECTS "Build toolchain's external projects, i.e. TOOLCHAIN_*")

--- a/Library/TeamTalkLib/build/webrtc/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/webrtc/CMakeLists.txt
@@ -16,7 +16,7 @@ if (MSVC)
   # This can be installed from Visual Studio Installer.
 
   # Force C:\webrtc to avoid build errors due to long path names (MAX_PATH=260)
-  set (WEBRTC_FETCH_PATH C:/webrtc/${CMAKE_SYSTEM_NAME})
+  set (WEBRTC_FETCH_PATH C:/webrtc/${CMAKE_SYSTEM_NAME} CACHE STRING "Root folder for WebRTC repository")
   file(TO_NATIVE_PATH ${WEBRTC_FETCH_PATH} WEBRTC_FETCH_PATH_NATIVE)
 
   set (WEBRTC_SOURCE_ROOT ${WEBRTC_FETCH_PATH}/src)
@@ -155,7 +155,7 @@ else()
   endif()
 
   if (${CMAKE_SYSTEM_NAME} MATCHES "iOS")
-    set (WEBRTC_FETCH_PATH $ENV{HOME}/webrtc/${CMAKE_SYSTEM_NAME})
+    set (WEBRTC_FETCH_PATH $ENV{HOME}/webrtc/${CMAKE_SYSTEM_NAME} CACHE STRING "Root folder for WebRTC repository")
 
     if ("armv7" STREQUAL "${CMAKE_OSX_ARCHITECTURES}")
       set (WEBRTC_ARCH arm)
@@ -173,7 +173,7 @@ else()
     configure_file(${CMAKE_CURRENT_LIST_DIR}/args.gn_ios ${WEBRTC_INSTALL_ROOT}/args.gn @ONLY)
 
   elseif(${CMAKE_SYSTEM_NAME} MATCHES "Android")
-    set (WEBRTC_FETCH_PATH $ENV{HOME}/webrtc/${CMAKE_SYSTEM_NAME})
+    set (WEBRTC_FETCH_PATH $ENV{HOME}/webrtc/${CMAKE_SYSTEM_NAME} CACHE STRING "Root folder for WebRTC repository")
 
     if ("armeabi-v7a" STREQUAL "${ANDROID_ABI}")
       set (WEBRTC_ARCH arm)
@@ -191,14 +191,14 @@ else()
     configure_file(${CMAKE_CURRENT_LIST_DIR}/args.gn_android ${WEBRTC_INSTALL_ROOT}/args.gn @ONLY)
 
   elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    set (WEBRTC_FETCH_PATH $ENV{HOME}/webrtc/${CMAKE_SYSTEM_NAME})
+    set (WEBRTC_FETCH_PATH $ENV{HOME}/webrtc/${CMAKE_SYSTEM_NAME} CACHE STRING "Root folder for WebRTC repository")
     set (WEBRTC_ARCH x64)
     configure_file(${CMAKE_CURRENT_LIST_DIR}/args.gn_mac ${WEBRTC_INSTALL_ROOT}-intel/args.gn @ONLY)
     set (WEBRTC_ARCH arm64)
     configure_file(${CMAKE_CURRENT_LIST_DIR}/args.gn_mac ${WEBRTC_INSTALL_ROOT}-arm64/args.gn @ONLY)
 
   elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    set (WEBRTC_FETCH_PATH $ENV{HOME}/webrtc/${CMAKE_SYSTEM_NAME})
+    set (WEBRTC_FETCH_PATH $ENV{HOME}/webrtc/${CMAKE_SYSTEM_NAME} CACHE STRING "Root folder for WebRTC repository")
     configure_file(${CMAKE_CURRENT_LIST_DIR}/args.gn_deb ${WEBRTC_INSTALL_ROOT}/args.gn @ONLY)
 
   else()

--- a/Library/TeamTalkLib/build/webrtc/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/webrtc/CMakeLists.txt
@@ -16,7 +16,7 @@ if (MSVC)
   # This can be installed from Visual Studio Installer.
 
   # Force C:\webrtc to avoid build errors due to long path names (MAX_PATH=260)
-  set (WEBRTC_FETCH_PATH C:/webrtc/${CMAKE_SYSTEM_NAME} CACHE STRING "Root folder for WebRTC repository")
+  set (WEBRTC_FETCH_PATH C:/webrtc/${CMAKE_SYSTEM_NAME} CACHE FILEPATH "Root folder for WebRTC repository")
   file(TO_NATIVE_PATH ${WEBRTC_FETCH_PATH} WEBRTC_FETCH_PATH_NATIVE)
 
   set (WEBRTC_SOURCE_ROOT ${WEBRTC_FETCH_PATH}/src)
@@ -155,7 +155,7 @@ else()
   endif()
 
   if (${CMAKE_SYSTEM_NAME} MATCHES "iOS")
-    set (WEBRTC_FETCH_PATH $ENV{HOME}/webrtc/${CMAKE_SYSTEM_NAME} CACHE STRING "Root folder for WebRTC repository")
+    set (WEBRTC_FETCH_PATH $ENV{HOME}/webrtc/${CMAKE_SYSTEM_NAME} CACHE FILEPATH "Root folder for WebRTC repository")
 
     if ("armv7" STREQUAL "${CMAKE_OSX_ARCHITECTURES}")
       set (WEBRTC_ARCH arm)
@@ -173,7 +173,7 @@ else()
     configure_file(${CMAKE_CURRENT_LIST_DIR}/args.gn_ios ${WEBRTC_INSTALL_ROOT}/args.gn @ONLY)
 
   elseif(${CMAKE_SYSTEM_NAME} MATCHES "Android")
-    set (WEBRTC_FETCH_PATH $ENV{HOME}/webrtc/${CMAKE_SYSTEM_NAME} CACHE STRING "Root folder for WebRTC repository")
+    set (WEBRTC_FETCH_PATH $ENV{HOME}/webrtc/${CMAKE_SYSTEM_NAME} CACHE FILEPATH "Root folder for WebRTC repository")
 
     if ("armeabi-v7a" STREQUAL "${ANDROID_ABI}")
       set (WEBRTC_ARCH arm)
@@ -191,14 +191,14 @@ else()
     configure_file(${CMAKE_CURRENT_LIST_DIR}/args.gn_android ${WEBRTC_INSTALL_ROOT}/args.gn @ONLY)
 
   elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    set (WEBRTC_FETCH_PATH $ENV{HOME}/webrtc/${CMAKE_SYSTEM_NAME} CACHE STRING "Root folder for WebRTC repository")
+    set (WEBRTC_FETCH_PATH $ENV{HOME}/webrtc/${CMAKE_SYSTEM_NAME} CACHE FILEPATH "Root folder for WebRTC repository")
     set (WEBRTC_ARCH x64)
     configure_file(${CMAKE_CURRENT_LIST_DIR}/args.gn_mac ${WEBRTC_INSTALL_ROOT}-intel/args.gn @ONLY)
     set (WEBRTC_ARCH arm64)
     configure_file(${CMAKE_CURRENT_LIST_DIR}/args.gn_mac ${WEBRTC_INSTALL_ROOT}-arm64/args.gn @ONLY)
 
   elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    set (WEBRTC_FETCH_PATH $ENV{HOME}/webrtc/${CMAKE_SYSTEM_NAME} CACHE STRING "Root folder for WebRTC repository")
+    set (WEBRTC_FETCH_PATH $ENV{HOME}/webrtc/${CMAKE_SYSTEM_NAME} CACHE FILEPATH "Root folder for WebRTC repository")
     configure_file(${CMAKE_CURRENT_LIST_DIR}/args.gn_deb ${WEBRTC_INSTALL_ROOT}/args.gn @ONLY)
 
   else()


### PR DESCRIPTION
On Windows it appears that WebRTC will only accept c:\webrtc