### PR TITLE
complete fix ui overlap for android 15

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/AudioCodecActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/AudioCodecActivity.java
@@ -80,6 +80,7 @@ public class AudioCodecActivity extends AppCompatActivity implements
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_audiocodec);
+        EdgeToEdgeHelper.enableEdgeToEdge(this);
 
         audiocodec = Utils.getAudioCodec(this.getIntent());
 

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ChannelPropActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ChannelPropActivity.java
@@ -83,6 +83,8 @@ implements TeamTalkConnectionListener, ClientEventListener.OnCmdErrorListener, C
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_channel_prop);
+        EdgeToEdgeHelper.enableEdgeToEdge(this);
+
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);        
     }
 

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/EdgeToEdgeHelper.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/EdgeToEdgeHelper.java
@@ -23,16 +23,16 @@
 
 package dk.bearware.gui;
 
+import android.app.Activity;
 import android.os.Build;
 import android.view.View;
 
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 
 public class EdgeToEdgeHelper {
 
-    public static void enableEdgeToEdge(AppCompatActivity activity) {
+    public static void enableEdgeToEdge(Activity activity) {
         View rootView = activity.findViewById(android.R.id.content);
         ViewCompat.setOnApplyWindowInsetsListener(rootView, (v, insets) -> {
             int topInset = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top;

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/OnlineUsersActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/OnlineUsersActivity.java
@@ -84,6 +84,7 @@ public class OnlineUsersActivity extends AppCompatActivity implements
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_online_users);
+        EdgeToEdgeHelper.enableEdgeToEdge(this);
 
         onlineUsersList = findViewById(R.id.online_users_list);
         adapter = new OnlineUserAdapter(this, onlineUsers);

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/PreferencesActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/PreferencesActivity.java
@@ -91,6 +91,8 @@ public class PreferencesActivity extends PreferenceActivity implements TeamTalkC
         getDelegate().installViewFactory();
         getDelegate().onCreate(savedInstanceState);
         super.onCreate(savedInstanceState);
+        EdgeToEdgeHelper.enableEdgeToEdge(this);
+
     }
 
     @Override

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerEntryActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerEntryActivity.java
@@ -71,6 +71,8 @@ public class ServerEntryActivity extends AppCompatActivity
         super.onCreate(savedInstanceState);
         binding = ActivityServerEntryBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+        EdgeToEdgeHelper.enableEdgeToEdge(this);
+
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         
         setupListeners();

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/StreamMediaActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/StreamMediaActivity.java
@@ -64,6 +64,8 @@ extends AppCompatActivity implements TeamTalkConnectionListener {
         super.onCreate(savedInstanceState);
         
         setContentView(R.layout.activity_stream_media);
+        EdgeToEdgeHelper.enableEdgeToEdge(this);
+
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         file_path = this.findViewById(R.id.file_path_txt);
         file_path.setText(PreferenceManager.getDefaultSharedPreferences(getBaseContext()).getString(lastMedia, ""));

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/TextMessageActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/TextMessageActivity.java
@@ -67,6 +67,8 @@ extends AppCompatActivity implements TeamTalkConnectionListener, ClientEventList
         super.onCreate(savedInstanceState);
         
         setContentView(R.layout.activity_text_message);
+        EdgeToEdgeHelper.enableEdgeToEdge(this);
+
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         accessibilityAssistant = new AccessibilityAssistant(this);

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/UserPropActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/UserPropActivity.java
@@ -62,6 +62,8 @@ public class UserPropActivity extends AppCompatActivity implements TeamTalkConne
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_user_prop);
+        EdgeToEdgeHelper.enableEdgeToEdge(this);
+
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
     }


### PR DESCRIPTION
instead of ap compat, this needed to be acsept normal activitys, so it can be used in all activitys, for example, settings activity.
this pull request fixes the issue completely forever.
tested on android 12 myself, android 15 my friend's phone, and android 11 my mother's phone.