### PR TITLE
Allow TTS on item selection for all Qt versions on macOS

### DIFF
--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -6356,10 +6356,8 @@ void MainWindow::slotTreeSelectionChanged()
         updateChannelFiles(channelid);
     }
 #if defined(Q_OS_DARWIN)
-#if QT_VERSION < QT_VERSION_CHECK(6,4,0) || QT_VERSION > QT_VERSION_CHECK(6,9,0)
     if (ttSettings->value(SETTINGS_TTS_SPEAKLISTS, SETTINGS_TTS_SPEAKLISTS_DEFAULT).toBool() == true)
         addTextToSpeechMessage(ui.channelsWidget->getItemText());
-#endif
 #endif
 }
 

--- a/Client/qtTeamTalk/mytableview.cpp
+++ b/Client/qtTeamTalk/mytableview.cpp
@@ -89,14 +89,12 @@ void MyTableView::currentChanged(const QModelIndex &current, const QModelIndex &
 {
     QTableView::currentChanged(current, previous);
 #if defined(Q_OS_DARWIN)
-#if QT_VERSION < QT_VERSION_CHECK(6,4,0) || QT_VERSION > QT_VERSION_CHECK(6,9,0)
     if (current.isValid() && ttSettings->value(SETTINGS_TTS_SPEAKLISTS, SETTINGS_TTS_SPEAKLISTS_DEFAULT).toBool() == true)
     {
         QString text = this->model()->data(current, Qt::AccessibleTextRole).toString();
         if (text.size())
             addTextToSpeechMessage(text);
     }
-#endif
 #endif
 }
 

--- a/Client/qtTeamTalk/preferencesdlg.cpp
+++ b/Client/qtTeamTalk/preferencesdlg.cpp
@@ -1052,9 +1052,7 @@ void PreferencesDlg::slotSaveChanges()
 #endif
         ttSettings->setValueOrClear(SETTINGS_TTS_OUTPUT_MODE, getCurrentItemData(ui.ttsOutputModeComboBox, ""), SETTINGS_TTS_OUTPUT_MODE_DEFAULT);
 #elif defined(Q_OS_DARWIN)
-#if QT_VERSION < QT_VERSION_CHECK(6,4,0) || QT_VERSION > QT_VERSION_CHECK(6,9,0)
         ttSettings->setValueOrClear(SETTINGS_TTS_SPEAKLISTS, ui.ttsSpeakListsChkBox->isChecked(), SETTINGS_TTS_SPEAKLISTS_DEFAULT);
-#endif
 #endif
         ttSettings->setValue(SETTINGS_DISPLAY_TTSHEADER, ui.ttsTableView->horizontalHeader()->saveState());
         saveCurrentMessage();
@@ -1439,9 +1437,7 @@ void PreferencesDlg::slotUpdateTTSTab()
         ui.label_ttsvoicevolume->show();
         ui.ttsVoiceVolumeSpinBox->show();
 #if defined(Q_OS_DARWIN)
-#if QT_VERSION < QT_VERSION_CHECK(6,4,0) || QT_VERSION > QT_VERSION_CHECK(6,9,0)
         ui.ttsSpeakListsChkBox->show();
-#endif
 #endif
         delete ttSpeech;
         ttSpeech = new QTextToSpeech(this);
@@ -1463,9 +1459,7 @@ void PreferencesDlg::slotUpdateTTSTab()
         ui.ttsVoiceComboBox->model()->sort(0);
         setCurrentItemData(ui.ttsVoiceComboBox, ttSettings->value(SETTINGS_TTS_VOICE));
 #if defined(Q_OS_DARWIN)
-#if QT_VERSION < QT_VERSION_CHECK(6,4,0) || QT_VERSION > QT_VERSION_CHECK(6,9,0)
         ui.ttsSpeakListsChkBox->setChecked(ttSettings->value(SETTINGS_TTS_SPEAKLISTS, SETTINGS_TTS_SPEAKLISTS_DEFAULT).toBool());
-#endif
 #endif
 #endif /* QT_TEXTTOSPEECH_LIB */
     }

--- a/Client/qtTeamTalk/settings.h
+++ b/Client/qtTeamTalk/settings.h
@@ -420,10 +420,8 @@
 #define SETTINGS_TTS_OUTPUT_MODE                         "texttospeech/output-mode"
 #define SETTINGS_TTS_OUTPUT_MODE_DEFAULT                 TTS_OUTPUTMODE_SPEECHBRAILLE
 #elif defined(Q_OS_DARWIN)
-#if QT_VERSION < QT_VERSION_CHECK(6,4,0) || QT_VERSION > QT_VERSION_CHECK(6,9,0)
 #define SETTINGS_TTS_SPEAKLISTS                         "texttospeech/speak-lists"
-#define SETTINGS_TTS_SPEAKLISTS_DEFAULT                 true
-#endif
+#define SETTINGS_TTS_SPEAKLISTS_DEFAULT                 isScreenReaderActive()
 #endif
 #if QT_VERSION >= QT_VERSION_CHECK(6,8,0)
 #define SETTINGS_TTS_ASSERTIVE                         "texttospeech/assertive"


### PR DESCRIPTION
The missing accessibility text for VoiceOver seems more related to macOS version than due to changes in Qt versions.