### PR TITLE
Add --disable-securetransport to iOS build of FFmpeg

### DIFF
--- a/Library/TeamTalkLib/build/ffmpeg/CMakeLists.txt
+++ b/Library/TeamTalkLib/build/ffmpeg/CMakeLists.txt
@@ -246,6 +246,7 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "iOS")
       # External libraries:
       --disable-videotoolbox
       --disable-audiotoolbox
+      --disable-securetransport
       # Programs/docs
       --disable-doc
       --disable-programs


### PR DESCRIPTION
Otherwise causes build error on deployment target iOS 8.0:

src/libavformat/tls_securetransport.c:168:16: error: 'SecIdentityCreate' is only available on iOS 11.2 or newer [-Werror,-Wunguarded-availability-new] 168 | if (!(id = SecIdentityCreate(kCFAllocatorDefault,