### PR TITLE
Bump qtTeamTalk CMAKE_OSX_DEPLOYMENT_TARGET to 12.0

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -4,7 +4,7 @@
 
 Version 5.21, unreleased
 Default Qt Client
--
+- macOS 12 (Monterey) is now minimum
 Android Client
 -
 iOS Client

--- a/Client/qtTeamTalk/CMakeLists.txt
+++ b/Client/qtTeamTalk/CMakeLists.txt
@@ -66,7 +66,7 @@ if (Qt5_FOUND OR Qt6_FOUND)
 
   if (Qt6_FOUND)
     set (CMAKE_CXX_STANDARD 17)
-    set (CMAKE_OSX_DEPLOYMENT_TARGET 11.0) # Qt 6.5.0 requires
+    set (CMAKE_OSX_DEPLOYMENT_TARGET 12.0) # Qt 6.9.2 requires
   else()
     set (CMAKE_CXX_STANDARD 17)
   endif()


### PR DESCRIPTION
Qt v6.9.2 is built for macOS 12