### PR TITLE
Join code for joining server with a "secret" key

### DIFF
--- a/Client/qtTeamTalk/appinfo.h
+++ b/Client/qtTeamTalk/appinfo.h
@@ -68,6 +68,8 @@
 
 #define URL_FREESERVER(official, pub, unofficial) QString("http://www.bearware.dk/teamtalk/tt5servers.php?client=" APPNAME_SHORT "&version=" APPVERSION_SHORT "&dllversion=" TEAMTALK_VERSION "&os=" OSTYPE "&official=%1&unofficial=%2").arg(official ? "1" : "0").arg(unofficial ? "1" : "0")
 #define URL_PUBLISHSERVER(uid, token) QString("https://www.bearware.dk/teamtalk/tt5servers.php?client=" APPNAME_SHORT "&version=" APPVERSION_SHORT "&dllversion=" TEAMTALK_VERSION "&os=" OSTYPE "&action=publish&username=%1&token=%2").arg(uid).arg(token)
+#define URL_PUBLISHSERVER_JOINCODE(uid, token, joincode) QString("https://www.bearware.dk/teamtalk/tt5servers.php?client=" APPNAME_SHORT "&version=" APPVERSION_SHORT "&dllversion=" TEAMTALK_VERSION "&os=" OSTYPE "&action=publish&username=%1&token=%2&joincode=1").arg(uid).arg(token)
+#define URL_SERVER_JOINCODE(joincode) QString("https://www.bearware.dk/teamtalk/tt5servers.php?client=" APPNAME_SHORT "&version=" APPVERSION_SHORT "&dllversion=" TEAMTALK_VERSION "&os=" OSTYPE "&action=joincode&joincode=%3").arg(joincode)
 #define URL_APPUPDATE(beta)       QString("http://www.bearware.dk/teamtalk/tt5update.php?client=" APPNAME_SHORT "&version=" APPVERSION_SHORT "&dllversion=" TEAMTALK_VERSION "&os=" OSTYPE "&beta=%1").arg(beta ? "1" : "0")
 
 #define TTFILE_EXT          ".tt"


### PR DESCRIPTION
Ability to publish a server (in BearWare.dk's database) that will have a "secret" key (8 characters) that other can enter to join quickly (without using .tt files or entering IP-address etc.)