### PR TITLE
Fix Windows TeamTalk5Server script

### DIFF
--- a/Setup/Server/Windows/tt5prosrv_console.bat
+++ b/Setup/Server/Windows/tt5prosrv_console.bat
@@ -6,7 +6,6 @@ echo.
 echo Ensure the server's configuration file 'tt5prosrv.xml' is in a writable
 echo location otherwise no changes made to the file will be saved.
 echo.
-@echo on
 tt5prosrv.exe -wizard
 tt5prosrv.exe -nd -verbose
 pause

--- a/Setup/Server/Windows/tt5prosvc_install.bat
+++ b/Setup/Server/Windows/tt5prosvc_install.bat
@@ -8,5 +8,15 @@ echo.
 echo.
 tt5prosvc.exe -wizard
 tt5prosvc.exe -i
-tt5prosvc.exe -s
+
+:ask
+set /p choice=Do you want to start the service now? (y/n): 
+if /i "%choice%"=="y" (
+    tt5prosvc.exe -s
+    goto end
+) else if /i "%choice%"=="n" (
+    goto end
+) else goto ask
+
+:end
 pause

--- a/Setup/Server/Windows/tt5srv_console.bat
+++ b/Setup/Server/Windows/tt5srv_console.bat
@@ -1,10 +1,11 @@
 @echo off
-@set TTSRVCFG=%APPDATA%\BearWare.dk\tt5srv.xml
+set TTSRVCFG=%APPDATA%\BearWare.dk\tt5srv.xml
 echo   --------------------------------------------------------------------------
 echo                       TeamTalk 5 Console Server
 echo   --------------------------------------------------------------------------
 echo.
-@echo on
+echo Config file: %TTSRVCFG%
+echo.
 tt5srv.exe -wizard -c %TTSRVCFG%
 tt5srv.exe -nd -verbose -c %TTSRVCFG%
 pause

--- a/Setup/Server/Windows/tt5svc_install.bat
+++ b/Setup/Server/Windows/tt5svc_install.bat
@@ -8,5 +8,15 @@ echo.
 echo.
 tt5svc.exe -wizard
 tt5svc.exe -i
-tt5svc.exe -s
+
+:ask
+set /p choice=Do you want to start the service now? (y/n): 
+if /i "%choice%"=="y" (
+    tt5svc.exe -s
+    goto end
+) else if /i "%choice%"=="n" (
+    goto end
+) else goto ask
+
+:end
 pause


### PR DESCRIPTION
* Now after installing the server, it will ask you whether you want to start it
* When running the console version on a Standard server, it reads the configuration files from the current folder, just like the Pro server