### PR TITLE
Do not patch CMake file in Tolk

### DIFF
--- a/Client/Tolk/CMakeLists.txt
+++ b/Client/Tolk/CMakeLists.txt
@@ -7,10 +7,9 @@ include(ExternalProject)
 ##################################################
 
 ExternalProject_Add(tolk-src
-  GIT_REPOSITORY    https://github.com/dkager/tolk.git
-  GIT_TAG           e5149f0
+  GIT_REPOSITORY    https://github.com/bear101/tolk
+  GIT_TAG           1e538e2
   UPDATE_COMMAND    ""
-  PATCH_COMMAND     git apply ${CMAKE_CURRENT_LIST_DIR}/0001-Add-CMake-script-for-building-tolk.patch
   CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> -DTOLK_WITH_JAVAJNI=OFF -DTOLK_MULTITHREADED=ON
   BUILD_COMMAND     ${CMAKE_COMMAND} --build . --config Release
   INSTALL_DIR       ${CMAKE_CURRENT_BINARY_DIR}/Tolk


### PR DESCRIPTION
Otherwise "Rebuild" in VS2022 cannot compile tolk-src