### PR TITLE
Android client: minor accessibility fix

### DIFF
--- a/Client/TeamTalkAndroid/src/main/res/layout/activity_server_entry.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/activity_server_entry.xml
@@ -139,8 +139,7 @@
                         android:maxLength="5"
                         android:text="@string/default_port"
                         android:singleLine="true"
-                        android:selectAllOnFocus="true"
-                        android:contentDescription="@string/pref_title_tcp_port" />
+                        android:selectAllOnFocus="true" />
                 </com.google.android.material.textfield.TextInputLayout>
             </LinearLayout>
 


### PR DESCRIPTION
This element does not require contentDescription attribute since it can
shadow real content. And, moreover, in this particular case it
duplicates label.
