### PR TITLE
Change android.focusable back to false

### DIFF
--- a/Client/TeamTalkAndroid/src/main/res/layout/item_channel.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/item_channel.xml
@@ -66,7 +66,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/action_join"
-        android:focusable="true"
+        android:focusable="false"
         android:clickable="true" />
     
     </LinearLayout>

--- a/Client/TeamTalkAndroid/src/main/res/layout/item_file_transfer.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/item_file_transfer.xml
@@ -37,7 +37,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@android:string/cancel"
-            android:focusable="true"
+            android:focusable="false"
             android:clickable="true" />
     </LinearLayout>
 

--- a/Client/TeamTalkAndroid/src/main/res/layout/item_remote_file.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/item_remote_file.xml
@@ -37,7 +37,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/button_download"
-            android:focusable="true"
+            android:focusable="false"
             android:clickable="true"
             style="?android:attr/buttonBarButtonStyle" />
         <Button
@@ -45,7 +45,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/button_remove"
-            android:focusable="true"
+            android:focusable="false"
             android:clickable="true"
             style="?android:attr/buttonBarButtonStyle" />
     </LinearLayout>

--- a/Client/TeamTalkAndroid/src/main/res/layout/item_user.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/item_user.xml
@@ -46,7 +46,7 @@
 	    android:layout_width="wrap_content"
 	    android:layout_height="wrap_content"
 	    android:text="@string/button_msg"
-	    android:focusable="true"
+	    android:focusable="false"
 	    android:clickable="true" />
     </LinearLayout>
 


### PR DESCRIPTION
In my commit (053730dec), I changed android.focusable to true to resolve a lint warning, but this caused several elements to become unclickable. We must change it back to false.
