### PR TITLE
Fix notify-send arguments for Linux desktop notifications

### DIFF
--- a/Client/qtTeamTalk/utilui.cpp
+++ b/Client/qtTeamTalk/utilui.cpp
@@ -851,13 +851,8 @@ void showNotification(const QString &title, const QString &message)
 #elif defined(Q_OS_LINUX)
 void showNotification(const QString &title, const QString &message)
 {
-    QString noquote = message;
-    noquote.replace('"', ' ');
     QStringList arguments;
-    arguments << "-t" << "500" 
-            << "-a" << title
-            << "-u" << "low"
-            << QString("%1: %2").arg(APPNAME_SHORT, noquote);
+    arguments << "-a" << "TeamTalk" << title << message;
 
     QProcess::startDetached(NOTIFY_PATH, arguments);
 }


### PR DESCRIPTION
## Summary

- The previous `notify-send` invocation was not compatible with modern libnotify (>= 0.8)
- Switches to the standard two-argument form: `notify-send <summary> <body>`

## Test plan

- [ ] Trigger a desktop notification on Linux (e.g. connect to server, user joins)
- [ ] Verify notification appears correctly with libnotify >= 0.8