### PR TITLE
Android: Apply gradle/actions for caching and dependency submission

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -44,6 +44,11 @@ jobs:
         ndk-version: r29
         add-to-path: false
 
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@v6
+      with:
+        validate-wrappers: true
+
     - name: Update Ubuntu repository
       run: sudo apt-get update
 

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,26 @@
+name: Android Dependency Submission
+
+on:
+  push:
+    branches: [ "master" ]
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+
+    - name: Set up Java
+      uses: actions/setup-java@v5
+      with:
+        distribution: 'temurin'
+        java-version: '25'
+
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@v6
+      with:
+        build-root-directory: ${{github.workspace}}/Client/TeamTalkAndroid


### PR DESCRIPTION
Add setup-gradle to the Android workflow for Gradle User Home caching and automatic wrapper validation, and introduce a dedicated dependency-submission workflow so Dependabot can alert on Android dependency vulnerabilities.
