### PR TITLE
Fix CodeQL

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,4 @@
+name: "TeamTalk5 CodeQL config"
+
+paths-ignore:
+  - Build/build-*

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build:
     if: "!startsWith(github.head_ref, 'debug') || startsWith(github.head_ref, 'debug-android')"
+    permissions:
+      security-events: write
+      packages: read
     strategy:
       matrix:
         include:
@@ -49,6 +52,14 @@ jobs:
       with:
         validate-wrappers: true
 
+    - name: Initialize CodeQL
+      if: matrix.arch == 'arm64-v8a'
+      uses: github/codeql-action/init@v4
+      with:
+        languages: java-kotlin
+        build-mode: manual
+        config-file: ./.github/codeql-config.yml
+
     - name: Update Ubuntu repository
       run: sudo apt-get update
 
@@ -86,3 +97,9 @@ jobs:
       with:
         name: teamtalksdk-${{ matrix.maketarget }}
         path: ${{runner.workspace}}/install-${{ matrix.maketarget }}
+
+    - name: Perform CodeQL Analysis
+      if: matrix.arch == 'arm64-v8a'
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:java-kotlin"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-name: "CodeQL Advanced"
+name: "CodeQL (Python)"
 
 on:
   push:
@@ -8,22 +8,11 @@ on:
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
+    name: Analyze (python)
     runs-on: ubuntu-latest
     permissions:
       security-events: write
       packages: read
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-        - language: csharp
-          build-mode: none
-        - language: java-kotlin
-          build-mode: none
-        - language: python
-          build-mode: none
 
     steps:
     - name: Checkout
@@ -32,10 +21,11 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
       with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
+        languages: python
+        build-mode: none
+        config-file: ./.github/codeql-config.yml
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4
       with:
-        category: "/language:${{matrix.language}}"
+        category: "/language:python"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,6 +18,9 @@ env:
 jobs:
   build:
     if: "!startsWith(github.head_ref, 'debug') || startsWith(github.head_ref, 'debug-windows')"
+    permissions:
+      security-events: write
+      packages: read
     strategy:
       matrix:
         arch: [x86, x64]
@@ -107,6 +110,14 @@ jobs:
         start /wait Win32OpenSSL.exe /silent /sp- /suppressmsgboxes /DIR="C:\Program Files (x86)\OpenSSL"
         echo C:\Program Files (x86)\OpenSSL\bin>> %GITHUB_PATH%
 
+    - name: Initialize CodeQL
+      if: matrix.arch == 'x64'
+      uses: github/codeql-action/init@v4
+      with:
+        languages: csharp
+        build-mode: manual
+        config-file: ./.github/codeql-config.yml
+
     - name: Configure CMake for toolchain build
       working-directory: ${{runner.workspace}}
       run: >-
@@ -114,7 +125,6 @@ jobs:
         -DBUILD_TEAMTALK_LIBRARY_UNITTEST_CATCH2=ON
         -DBUILD_TEAMTALK_LIBRARY_UNITTEST_CATCH2_PERF=OFF
         -DFEATURE_WEBRTC=OFF
-        -DBUILD_TEAMTALK_CLIENT_TEAMTALKAPP_DOTNET=OFF
         -DTOOLCHAIN_INSTALL_PREFIX=${{runner.workspace}}/install-toolchain
         -DCMAKE_INSTALL_PREFIX=${{runner.workspace}}/install-teamtalk
 
@@ -333,3 +343,9 @@ jobs:
       with:
         name: teamtalkpro-${{ matrix.portablearch }}
         path: ${{github.workspace}}/Setup/Portable/teamtalkpro-*-${{ matrix.portablearch }}
+
+    - name: Perform CodeQL Analysis
+      if: matrix.arch == 'x64'
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:csharp"


### PR DESCRIPTION
- Add .github/codeql-config.yml that excludes Build/build-* from scans
- Enable .Net Client build and Move csharp to windows.yml with manual build (x64 only)
- Move java-kotlin to android.yml with manual Gradle build (arm64-v8a only)
- Drop matrix from codeql.yml; now only analyzes python
