### PR TITLE
Qt TTS: stop deleting the QTextToSpeech instance on every other prefs close

### DIFF
--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -4277,8 +4277,8 @@ void MainWindow::slotClientPreferences(bool /*checked =false */)
     if(!b)return;
 
 #if defined(QT_TEXTTOSPEECH_LIB)
-    if (ttSettings->value(SETTINGS_TTS_ENGINE, SETTINGS_TTS_ENGINE_DEFAULT).toUInt() == TTSENGINE_QT && ttSpeech == nullptr)
-        ttSpeech = new QTextToSpeech(this);
+    if (ttSettings->value(SETTINGS_TTS_ENGINE, SETTINGS_TTS_ENGINE_DEFAULT).toUInt() == TTSENGINE_QT)
+        startTTS();
     else
     {
         delete ttSpeech;


### PR DESCRIPTION
## Summary

The Qt TextToSpeech engine silently breaks on every other launch / preferences-close cycle on Linux. This PR fixes that.

## Diagnosis

In `MainWindow::slotClientPreferences()` (mainwindow.cpp around line 4279), after the dialog accepts:

```cpp
#if defined(QT_TEXTTOSPEECH_LIB)
    if (ttSettings->value(SETTINGS_TTS_ENGINE, SETTINGS_TTS_ENGINE_DEFAULT).toUInt() == TTSENGINE_QT && ttSpeech == nullptr)
        ttSpeech = new QTextToSpeech(this);
    else
    {
        delete ttSpeech;
        ttSpeech = nullptr;
    }
#endif
```

When the user has selected `TTSENGINE_QT` and `ttSpeech` already exists (the steady-state case after the first preferences close), the `&& ttSpeech == nullptr` guard fails and we fall into the `else` branch — which **deletes** the live instance. The next preferences close then re-creates it; the one after that deletes it again, and so on.

The visible symptom is "TTS works, then doesn't, then works, then doesn't" with no apparent cause.

## Fix

Replace the conditional `new` with a call to the existing `startTTS()` helper, which already:
- destroys any prior instance,
- constructs a fresh `QTextToSpeech` with the persisted locale / voice / rate / volume,
- handles `TTSENGINE_TOLK` and `TTSENGINE_QTANNOUNCEMENT` correctly too.

The `else` branch is unchanged — when the engine is anything other than `TTSENGINE_QT`, the existing instance is still torn down.

## Verification

- Linux (Arch, Qt 6.8): set engine to "Qt", close prefs (works), reopen + close prefs (still works), repeat — TTS now stays available indefinitely instead of toggling.
- The same fix path also makes voice/rate/volume edits in the prefs dialog take effect immediately (previously they required a restart because the existing instance was being kept rather than reinitialized).

## Test plan

- [ ] Set TTS engine to "Qt", change voice/rate/volume in prefs, close — verify new settings apply without restart.
- [ ] Open and close prefs five times in a row — verify TTS still announces afterwards.
- [ ] Switch engine to "None" / "Tolk" / "Qt Announcement" — verify tear-down still happens.