### PR TITLE
Add cmake_minimum_required(VERSION 3.16) so qtTeamTalk builds standalone under CMake 4

### DIFF
--- a/Client/qtTeamTalk/CMakeLists.txt
+++ b/Client/qtTeamTalk/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.16)
+
 if (CMAKE_VERSION VERSION_LESS "3.7.0")
   set(CMAKE_INCLUDE_CURRENT_DIR ON)
 endif()


### PR DESCRIPTION
## Summary

Adding a `cmake_minimum_required(VERSION 3.16)` to `Client/qtTeamTalk/CMakeLists.txt` so the qtTeamTalk subproject can be configured directly with current CMake (4.x).

## Diagnosis

CMake 4 (released 2025) hard-fails the configure step on any subproject that lacks a top-level `cmake_minimum_required()`. When invoked via `cmake -S Client/qtTeamTalk -B builddir` the current `CMakeLists.txt` falls over with:

```
CMake Error in CMakeLists.txt:
  No cmake_minimum_required command is present.  A line of code such as

    cmake_minimum_required(VERSION 4.3)

  should be added at the top of the file.
```

`-DCMAKE_POLICY_VERSION_MINIMUM=3.5` and the equivalent env var no longer suppress this in CMake 4.x. The only fix is the explicit declaration.

## Fix

Add `cmake_minimum_required(VERSION 3.16)` as the first line. 3.16 is well below the actually-used feature set (Qt 6 integration, AUTOMOC/UIC/RCC) and matches the version range supported by Qt's own CMake integration.

## Test plan

- [ ] `cmake -S Client/qtTeamTalk -B builddir -DBUILD_TEAMTALK_LIBRARY_DLL=OFF` configures cleanly under CMake 4.
- [ ] `cmake --build builddir` produces the same `teamtalk5` binary as before.
- [ ] No effect on the parent build (the parent `CMakeLists.txt` already declares its own minimum).