### PR TITLE
Label PulseAudio sound system as "PulseAudio / PipeWire" when PipeWire is detected

### DIFF
--- a/Client/qtTeamTalk/preferencesdlg.cpp
+++ b/Client/qtTeamTalk/preferencesdlg.cpp
@@ -36,9 +36,14 @@
 
 #include <QDebug>
 #include <QMessageBox>
+#include <QFile>
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QDir>
+
+#if defined(Q_OS_LINUX)
+#include <unistd.h>
+#endif
 #include <QVariant>
 #include <QKeyEvent>
 #if defined(QT_TEXTTOSPEECH_LIB)
@@ -561,7 +566,13 @@ void PreferencesDlg::initSoundSystemTab()
     ui.sndSysBox->addItem(tr("CoreAudio"), SOUNDSYSTEM_COREAUDIO);
 #else
     ui.sndSysBox->addItem(tr("Advanced Linux Sound Architecture (ALSA)"), SOUNDSYSTEM_ALSA);
-    ui.sndSysBox->addItem(tr("PulseAudio"), SOUNDSYSTEM_PULSEAUDIO);
+    {
+        // On a PipeWire system the PulseAudio backend is served by
+        // pipewire-pulse, so reflect that in the label when detected.
+        bool pipewire = QFile::exists(QString("/run/user/%1/pipewire-0").arg(getuid()));
+        QString label = pipewire ? tr("PulseAudio / PipeWire") : tr("PulseAudio");
+        ui.sndSysBox->addItem(label, SOUNDSYSTEM_PULSEAUDIO);
+    }
 #endif
     int comboIndex = ui.sndSysBox->findData(SoundSystem(ttSettings->value(SETTINGS_SOUND_SOUNDSYSTEM, SOUNDSYSTEM_NONE).toInt()));
     if(comboIndex>=0)


### PR DESCRIPTION
## Summary

Cosmetic UX nudge: when running on a PipeWire-based system (where the PulseAudio backend is in fact served by `pipewire-pulse`), label the PulseAudio entry in the sound-system dropdown as "PulseAudio / PipeWire" so users on modern Linux distributions can identify the correct option.

## Background

Most contemporary Linux distros (Fedora, Ubuntu 22.10+, Arch by default, etc.) replace the standalone PulseAudio daemon with `pipewire-pulse`, which serves the PulseAudio protocol but routes audio through PipeWire. To a TeamTalk user this is invisible — selecting "PulseAudio" in the dropdown actually uses PipeWire — and PipeWire users sometimes assume there's no PipeWire support at all and stick with ALSA, missing the cleaner integration.

This PR doesn't change behaviour at all: it only adjusts the displayed label when a PipeWire socket is detected at `/run/user/$UID/pipewire-0`. The persisted `SoundSystem` value remains `SOUNDSYSTEM_PULSEAUDIO` either way.

## Implementation notes

- Detection is a single `QFile::exists()` check — no PipeWire library dependency added.
- Guarded by `defined(Q_OS_UNIX) && !defined(Q_OS_DARWIN)` for the `unistd.h` include (`getuid()` is POSIX).
- Label change only applies inside the existing `#else` branch (i.e. the Linux-non-Mac block), so Windows/macOS UX is unchanged.

## Test plan

- [ ] On a PipeWire system: dropdown shows "PulseAudio / PipeWire".
- [ ] On a system with stand-alone PulseAudio (no `pipewire-0` socket): dropdown shows "PulseAudio".
- [ ] Switching between the two labels mid-session is not required — the check runs once when the prefs dialog initialises.

Happy to drop this if it's deemed too cosmetic; the bug-fix PRs (#3238, #3239) are the ones that actually matter.