### PR TITLE
Android client. Fixed the bug that sounds were not properly muted in outgoing calls like incoming calls

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
@@ -442,6 +442,7 @@ public class TeamTalkService extends Service
 
                 switch (state) {
                 case TelephonyManager.CALL_STATE_IDLE:
+                    if (inPhoneCall) {
                     if (voxSuspended)
                         enableVoiceActivation(true);
                     else if (txSuspended)
@@ -451,9 +452,12 @@ public class TeamTalkService extends Service
                         ttclient.doChangeStatus(myself.nStatusMode & ~TeamTalkConstants.STATUSMODE_AWAY, myself.szStatusMsg);
                     inPhoneCall = false;
                     scheduleReconnectBluetoothScoAfterCall();
+                    }
                     break;
                 case TelephonyManager.CALL_STATE_RINGING:
-                    inPhoneCall = true;
+                case TelephonyManager.CALL_STATE_OFFHOOK:
+                    if (!inPhoneCall) {
+                        inPhoneCall = true;
                     if (!isMute()) {
                         ttclient.setSoundOutputMute(true);
                         currentMuteState = true;
@@ -468,7 +472,8 @@ public class TeamTalkService extends Service
                     }
                     myStatus = myself.nStatusMode;
                     if ((myStatus & TeamTalkConstants.STATUSMODE_AWAY) == 0)
-                        ttclient.doChangeStatus(myStatus | TeamTalkConstants.STATUSMODE_AWAY, myself.szStatusMsg);
+                            ttclient.doChangeStatus(myStatus | TeamTalkConstants.STATUSMODE_AWAY, myself.szStatusMsg);
+                    }
                     break;
                 default:
                     break;

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
@@ -443,35 +443,35 @@ public class TeamTalkService extends Service
                 switch (state) {
                 case TelephonyManager.CALL_STATE_IDLE:
                     if (inPhoneCall) {
-                    if (voxSuspended)
-                        enableVoiceActivation(true);
-                    else if (txSuspended)
-                        enableVoiceTransmission(true);
-                    setMute(permanentMuteState);
-                    if ((myself != null) && ((myStatus & TeamTalkConstants.STATUSMODE_AWAY) == 0))
-                        ttclient.doChangeStatus(myself.nStatusMode & ~TeamTalkConstants.STATUSMODE_AWAY, myself.szStatusMsg);
-                    inPhoneCall = false;
-                    scheduleReconnectBluetoothScoAfterCall();
+                        if (voxSuspended)
+                            enableVoiceActivation(true);
+                        else if (txSuspended)
+                            enableVoiceTransmission(true);
+                        setMute(permanentMuteState);
+                        if ((myself != null) && ((myStatus & TeamTalkConstants.STATUSMODE_AWAY) == 0))
+                            ttclient.doChangeStatus(myself.nStatusMode & ~TeamTalkConstants.STATUSMODE_AWAY, myself.szStatusMsg);
+                        inPhoneCall = false;
+                        scheduleReconnectBluetoothScoAfterCall();
                     }
                     break;
                 case TelephonyManager.CALL_STATE_RINGING:
                 case TelephonyManager.CALL_STATE_OFFHOOK:
                     if (!inPhoneCall) {
                         inPhoneCall = true;
-                    if (!isMute()) {
-                        ttclient.setSoundOutputMute(true);
-                        currentMuteState = true;
-                    }
-                    if (isVoiceActivationEnabled()) {
-                        voxSuspended = true;
-                        enableVoiceActivation(false);
-                    }
-                    else if (isVoiceTransmissionEnabled()) {
-                        txSuspended = true;
-                        enableVoiceTransmission(false);
-                    }
-                    myStatus = myself.nStatusMode;
-                    if ((myStatus & TeamTalkConstants.STATUSMODE_AWAY) == 0)
+                        if (!isMute()) {
+                            ttclient.setSoundOutputMute(true);
+                            currentMuteState = true;
+                        }
+                        if (isVoiceActivationEnabled()) {
+                            voxSuspended = true;
+                            enableVoiceActivation(false);
+                        }
+                        else if (isVoiceTransmissionEnabled()) {
+                            txSuspended = true;
+                            enableVoiceTransmission(false);
+                        }
+                        myStatus = myself.nStatusMode;
+                        if ((myStatus & TeamTalkConstants.STATUSMODE_AWAY) == 0)
                             ttclient.doChangeStatus(myStatus | TeamTalkConstants.STATUSMODE_AWAY, myself.szStatusMsg);
                     }
                     break;


### PR DESCRIPTION
in teamtalk android,  we were handling incoming calls grately so there was no problem with them, but outgoing calls when you were in teamtalk was very annoying. If you had an outgoing call and you were in teamtalk and someone logged out and logged back in and opened their microphone, their microphone would play on your call. Incoming calls didn't have this bug. This was because we were not handling the offhook case for the calls. it has now been fixed