### PR TITLE
Remove OpenSSL on Windows Qt

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -103,15 +103,6 @@ jobs:
         7z x nasm.zip
         echo %CD%\nasm-3.01>> %GITHUB_PATH%
 
-    - name: Download and install OpenSSL for Qt 5.15
-      if: matrix.arch == 'x86'
-      working-directory: ${{runner.workspace}}
-      shell: cmd
-      run: |
-        curl -fsSL -o Win32OpenSSL.exe https://slproweb.com/download/Win32OpenSSL-3_6_2.exe
-        start /wait Win32OpenSSL.exe /silent /sp- /suppressmsgboxes /DIR="C:\Program Files (x86)\OpenSSL"
-        echo C:\Program Files (x86)\OpenSSL\bin>> %GITHUB_PATH%
-
     - name: Initialize CodeQL
       if: matrix.arch == 'x64'
       uses: github/codeql-action/init@v4

--- a/Client/qtTeamTalk/CMakeLists.txt
+++ b/Client/qtTeamTalk/CMakeLists.txt
@@ -206,29 +206,6 @@ if (Qt5_FOUND OR Qt6_FOUND)
             COMMAND ${WINDEPLOYQT_EXE_PATH} --no-quick-import --no-translations --no-system-d3d-compiler ${QT_DEPLOY_ARGS} --no-opengl-sw --debug --dir "${CMAKE_CURRENT_SOURCE_DIR}/windeployqt-debug" "$<TARGET_FILE_DIR:${TEAMTALK_TARGET}>/$<TARGET_FILE_NAME:${TEAMTALK_TARGET}>"
             DEPENDS ${TEAMTALK_TARGET})
 
-          # OpenSSL DLLs are not deployed by windeployqt.exe so we need to copy them manually.
-          # Qt Maintenance Tool is able to download and install Qt's OpenSSL binaries. These files
-          # will be located in <Qt install dir>/Tools/OpenSSL
-          if (${CMAKE_SIZEOF_VOID_P} EQUAL 8)
-            find_file (QT_OPENSSL_LIBCRYPTODLL_PATH NAMES libcrypto-3-x64.dll PATHS "C:/Program Files/OpenSSL/bin")
-            find_file (QT_OPENSSL_LIBSSLDLL_PATH NAMES libssl-3-x64.dll PATHS "C:/Program Files/OpenSSL/bin")
-          else()
-            find_file (QT_OPENSSL_LIBCRYPTODLL_PATH NAMES libcrypto-3.dll PATHS "C:/Program Files (x86)/OpenSSL/bin")
-            find_file (QT_OPENSSL_LIBSSLDLL_PATH NAMES libssl-3.dll PATHS "C:/Program Files (x86)/OpenSSL/bin")
-          endif()
-          if (QT_OPENSSL_LIBCRYPTODLL_PATH-NOTFOUND OR QT_OPENSSL_LIBSSLDLL_PATH-NOTFOUND)
-            message (WARNING "Cannot find OpenSSL 3.x DLLs for Qt deployed DLLs")
-          else()
-            message ("OpenSSL libcrypto.dll for Qt deployment found here: ${QT_OPENSSL_LIBCRYPTODLL_PATH}")
-            message ("OpenSSL libssl.dll for Qt deployment found here: ${QT_OPENSSL_LIBSSLDLL_PATH}")
-            add_custom_target (QtTeamTalk5-openssl-deploy-release ALL
-              COMMAND ${CMAKE_COMMAND} -E copy ${QT_OPENSSL_LIBCRYPTODLL_PATH} ${QT_OPENSSL_LIBSSLDLL_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/windeployqt"
-              DEPENDS QtTeamTalk5-windeploy-release)
-            add_custom_target (QtTeamTalk5-openssl-deploy-debug ALL
-              COMMAND ${CMAKE_COMMAND} -E copy ${QT_OPENSSL_LIBCRYPTODLL_PATH} ${QT_OPENSSL_LIBSSLDLL_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/windeployqt-debug"
-              DEPENDS QtTeamTalk5-windeploy-debug)
-          endif()
-
           install (DIRECTORY windeployqt DESTINATION Client/qtTeamTalk/)
         endif()
       endif()

--- a/Setup/Installer/Windows/TeamTalk5.iss
+++ b/Setup/Installer/Windows/TeamTalk5.iss
@@ -162,6 +162,9 @@ Root: HKCR; Subkey: "TeamTalk\DefaultIcon"; ValueType: none; ValueName: "Install
 Type: files; Name: "{app}\Tolk.dll"
 Type: files; Name: "{app}\nvdaControllerClient64.dll"
 Type: files; Name: "{app}\SAAPI64.dll"
+; Delete OpenSSL DLLs from previous installations (no longer deployed)
+Type: files; Name: "{app}\libcrypto-3-x64.dll"
+Type: files; Name: "{app}\libssl-3-x64.dll"
 ; Delete pre version 5.17 language files
 Type: files; Name: "{app}\Languages\Bulgarian.qm"
 Type: files; Name: "{app}\Languages\Chinese_Simplified.qm"


### PR DESCRIPTION
Since Schannel is used on Windows, OpenSSL is not needed.
