### PR TITLE
Exclude third-party libraries from CodeQL C/C++ analysis

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -35,13 +35,6 @@ jobs:
       with:
         submodules: true
 
-    - name: Initialize CodeQL
-      if: matrix.os == 'ubuntu-26.04'
-      uses: github/codeql-action/init@v4
-      with:
-        languages: c-cpp
-        build-mode: manual
-
     - name: Set up Java
       uses: actions/setup-java@v5
       with:
@@ -174,12 +167,25 @@ jobs:
       working-directory: ${{github.workspace}}/Build/build-release-ubuntu${{ matrix.version }}
       run: cmake --build . --target install
 
+    - name: Initialize CodeQL
+      if: matrix.os == 'ubuntu-26.04'
+      uses: github/codeql-action/init@v4
+      with:
+        languages: c-cpp
+        build-mode: manual
+
     - name: Build debug TeamTalk using prebuilt toolchain
       working-directory: ${{github.workspace}}
       run: |
         source env.sh
         make CONFIGTYPE=debug CMAKE_EXTRA="-DTOOLCHAIN_INSTALL_PREFIX=${{runner.workspace}}/toolchain-install -DTOOLCHAIN_BUILD_EXTERNALPROJECTS=OFF -DFEATURE_WEBRTC=OFF -DBUILD_TEAMTALK_LIBRARY_UNITTEST_CATCH2=ON -DBUILD_TEAMTALK_LIBRARY_UNITTEST_CATCH2_PERF=OFF -DCMAKE_INSTALL_PREFIX=${{runner.workspace}}/install" -C Build ubuntu${{ matrix.version }}
         echo TEAMTALK_INSTALLDIR=${{runner.workspace}}/install>> $GITHUB_ENV
+
+    - name: Perform CodeQL Analysis
+      if: matrix.os == 'ubuntu-26.04'
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:c-cpp"
 
     - name: Upload TeamTalk SDK artifact
       uses: actions/upload-artifact@v7
@@ -205,9 +211,3 @@ jobs:
       with:
         name: teamtalkpro-ubuntu${{ matrix.version }}
         path: ${{github.workspace}}/Setup/Portable/teamtalkpro-*
-
-    - name: Perform CodeQL Analysis
-      if: matrix.os == 'ubuntu-26.04'
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:c-cpp"


### PR DESCRIPTION
paths-ignore does not work for compiled languages, so move the CodeQL
init to after the toolchain/externals build and trace only the TeamTalk
build (TOOLCHAIN_BUILD_EXTERNALPROJECTS=OFF). This keeps ffmpeg, libvpx,
opus and other third-party sources out of the CodeQL database.