### PR TITLE
Fix CodeQL warnings

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
@@ -1310,7 +1310,7 @@ public class TeamTalkService extends Service
 
             try {
                 InputSource src = new InputSource(new StringReader(xml));
-                DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+                DocumentBuilderFactory dbf = Utils.newSecureDocumentBuilderFactory();
                 DocumentBuilder db = dbf.newDocumentBuilder();
                 Document document = db.parse(src);
                 XPathFactory factory = XPathFactory.newInstance();

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -644,9 +644,15 @@ extends AppCompatActivity
             Cursor cursor = getContentResolver().query(uri, null, null, null, null);
             int columnIndex = ((cursor != null) && cursor.moveToFirst()) ? cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME) : -1;
             if (columnIndex >= 0) {
-                File transitFile = new File(getCacheDir(), cursor.getString(columnIndex));
+                String displayName = cursor.getString(columnIndex);
                 cursor.close();
+                File cacheDir = getCacheDir();
+                File transitFile = new File(cacheDir, new File(displayName).getName());
                 try {
+                    String cacheCanonical = cacheDir.getCanonicalPath() + File.separator;
+                    if (!transitFile.getCanonicalPath().startsWith(cacheCanonical)) {
+                        return null;
+                    }
                     if (((!transitFile.exists()) || transitFile.delete()) && transitFile.createNewFile()) {
                         transitFile.deleteOnExit();
                     } else {

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerListActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerListActivity.java
@@ -735,7 +735,7 @@ public class ServerListActivity extends AppCompatActivity
 
             if (!xml.isEmpty()) {
                 try {
-                    DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+                    DocumentBuilderFactory dbFactory = Utils.newSecureDocumentBuilderFactory();
                     DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
                     Document doc = dBuilder.parse(new InputSource(new StringReader(xml)));
                     doc.getDocumentElement().normalize();

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/Utils.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/Utils.java
@@ -68,6 +68,7 @@ import java.util.Vector;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 import dk.bearware.AudioCodec;
 import dk.bearware.Channel;
@@ -514,12 +515,23 @@ public class Utils {
         return result.toString();
     }
     
+    public static DocumentBuilderFactory newSecureDocumentBuilderFactory() throws ParserConfigurationException {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        dbf.setXIncludeAware(false);
+        dbf.setExpandEntityReferences(false);
+        return dbf;
+    }
+
     public static Vector<ServerEntry> getXmlServerEntries(String xml) {
         Vector<ServerEntry> servers = new Vector<>();
-        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
         DocumentBuilder dBuilder;
         Document doc;
         try {
+            DocumentBuilderFactory dbFactory = newSecureDocumentBuilderFactory();
             dBuilder = dbFactory.newDocumentBuilder();
             doc = dBuilder.parse(new InputSource(new StringReader(xml)));
         }

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/WebLoginActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/WebLoginActivity.java
@@ -122,7 +122,7 @@ public class WebLoginActivity extends AppCompatActivity {
 
             try {
                 InputSource src = new InputSource(new StringReader(xml));
-                DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+                DocumentBuilderFactory dbf = Utils.newSecureDocumentBuilderFactory();
                 DocumentBuilder db = dbf.newDocumentBuilder();
                 Document document = db.parse(src);
                 XPathFactory factory = XPathFactory.newInstance();

--- a/Client/qtTeamTalk/gridwidget.cpp
+++ b/Client/qtTeamTalk/gridwidget.cpp
@@ -114,8 +114,8 @@ void GridWidget::RepositionWidgets()
 {
     int colums = (int)sqrt((double)m_activewidgets.size());
     int rows = (int)sqrt((double)m_activewidgets.size());
-    rows = (m_activewidgets.size() <= rows*colums)? rows : rows + 1;
-    colums = (m_activewidgets.size() <= rows*colums)? colums : colums + 1;
+    rows = (m_activewidgets.size() <= static_cast<qsizetype>(rows)*colums)? rows : rows + 1;
+    colums = (m_activewidgets.size() <= static_cast<qsizetype>(rows)*colums)? colums : colums + 1;
 
     if(m_grid->columnCount() > colums || m_grid->rowCount() > rows)
     {

--- a/Client/qtTeamTalk/utilsound.cpp
+++ b/Client/qtTeamTalk/utilsound.cpp
@@ -135,7 +135,7 @@ QString getSoundDeviceUID(const SoundDevice& dev)
 
 int getSoundDuplexSampleRate(const SoundDevice& indev, const SoundDevice& outdev)
 {
-    auto isend = indev.inputSampleRates + sizeof(indev.inputSampleRates);
+    auto isend = indev.inputSampleRates + (sizeof(indev.inputSampleRates) / sizeof(indev.inputSampleRates[0]));
     auto isr = std::find_if(indev.inputSampleRates, isend,
         [outdev](int sr) { return sr == outdev.nDefaultSampleRate; });
     bool duplexmode = (indev.uSoundDeviceFeatures & SOUNDDEVICEFEATURE_DUPLEXMODE) &&

--- a/Library/TeamTalkLib/avstream/AudioInputStreamer.cpp
+++ b/Library/TeamTalkLib/avstream/AudioInputStreamer.cpp
@@ -162,8 +162,8 @@ bool AudioInputStreamer::ProcessResample()
         assert(frame.inputfmt == m_inputfmt);
         assert(m_resampler);
         int const osamples = CalcSamples(frame.inputfmt.samplerate, frame.input_samples, GetMediaOutput().audio.samplerate);
-        if (m_resamplebuffer.size() != osamples * GetMediaOutput().audio.channels)
-            m_resamplebuffer.resize(osamples * GetMediaOutput().audio.channels);
+        if (m_resamplebuffer.size() != size_t(osamples) * GetMediaOutput().audio.channels)
+            m_resamplebuffer.resize(size_t(osamples) * GetMediaOutput().audio.channels);
         ret = m_resampler->Resample(frame.input_buffer, frame.input_samples, m_resamplebuffer.data(), osamples);
         assert(ret > 0);
         media::AudioFrame const resam_frame(GetMediaOutput().audio, m_resamplebuffer.data(), osamples);

--- a/Library/TeamTalkLib/avstream/AudioResampler.cpp
+++ b/Library/TeamTalkLib/avstream/AudioResampler.cpp
@@ -96,7 +96,7 @@ void AudioResampler::SetupFixedFrameSize(const media::AudioFormat& informat,
     assert(informat.IsValid());
     assert(outformat.IsValid());
     int const output_samples_size = CalcSamples(informat.samplerate, input_samples_size, outformat.samplerate);
-    m_resampleoutput.resize(output_samples_size * outformat.channels);
+    m_resampleoutput.resize(size_t(output_samples_size) * outformat.channels);
 
     m_input_samples_size = input_samples_size;
     m_output_samples_size = output_samples_size;

--- a/Library/TeamTalkLib/avstream/OpusFileStreamer.cpp
+++ b/Library/TeamTalkLib/avstream/OpusFileStreamer.cpp
@@ -72,7 +72,7 @@ void OpusFileStreamer::Run()
     }
 
     // max opus frame size is 120 msec
-    std::vector<short> framebuf(m_decoder.GetSampleRate() * m_decoder.GetChannels());
+    std::vector<short> framebuf(size_t(m_decoder.GetSampleRate()) * m_decoder.GetChannels());
     std::vector<short> resample_framebuf;
 
     if (infmt != m_media_out.audio)
@@ -83,7 +83,7 @@ void OpusFileStreamer::Run()
             m_open.set(false);
             return;
         }
-        resample_framebuf.resize(m_media_out.audio.samplerate * m_media_out.audio.channels);
+        resample_framebuf.resize(size_t(m_media_out.audio.samplerate) * m_media_out.audio.channels);
     }
 
     // setup the audio format of input file

--- a/Library/TeamTalkLib/avstream/SoundSystem.h
+++ b/Library/TeamTalkLib/avstream/SoundSystem.h
@@ -256,7 +256,7 @@ constexpr auto VOLUME_MIN = 0;
             , inputdeviceid(indevid)
             , outputdeviceid(outdevid)
             {
-                tmpOutputBuffer.resize(outchs * fs);
+                tmpOutputBuffer.resize(size_t(outchs) * fs);
             }
 
         virtual ~DuplexStreamer()

--- a/Library/TeamTalkLib/avstream/SoundSystemEx.h
+++ b/Library/TeamTalkLib/avstream/SoundSystemEx.h
@@ -68,7 +68,7 @@ namespace soundsystem {
     public:
         StreamCaller(const SoundStreamer& streamer, int channels) : m_interval(PCM16_SAMPLES_DURATION(streamer.framesize, streamer.samplerate)), m_start(GETTIMESTAMP())
         {
-            m_buffer.resize(channels * streamer.framesize, 0);            
+            m_buffer.resize(size_t(channels) * streamer.framesize, 0);
         }
 
         ~StreamCaller() override = default;
@@ -157,7 +157,7 @@ namespace soundsystem {
             , m_sndsys(sndsys)
             , m_streamer(streamer)
         {
-            m_inputbuffer.resize(streamer->input_channels * streamer->framesize, 0);
+            m_inputbuffer.resize(size_t(streamer->input_channels) * streamer->framesize, 0);
         }
 
         ~StreamDuplexCallback() override

--- a/Library/TeamTalkLib/avstream/SoundSystemShared.h
+++ b/Library/TeamTalkLib/avstream/SoundSystemShared.h
@@ -180,8 +180,8 @@ constexpr auto DEBUG_RESAMPLER = 0;
                 int resampleoutput = CalcSamples(m_originalstream->samplerate,
                                                  m_originalstream->framesize, streamer->samplerate);
 
-                m_resample_buffers[key].resize(resampleoutput * streamer->channels);
-                m_callback_buffers[key].resize(streamer->framesize * streamer->channels);
+                m_resample_buffers[key].resize(size_t(resampleoutput) * streamer->channels);
+                m_callback_buffers[key].resize(size_t(streamer->framesize) * streamer->channels);
 
                 if (!m_resample_thread)
                 {
@@ -562,7 +562,7 @@ constexpr auto DEBUG_RESAMPLER = 0;
         {
             assert(!m_orgstream);
             m_orgstream = streamer;
-            m_tmpbuffer.resize(streamer->channels * streamer->framesize);
+            m_tmpbuffer.resize(size_t(streamer->channels) * streamer->framesize);
         }
 
         outputstreamer_t GetOrigin()
@@ -598,7 +598,7 @@ constexpr auto DEBUG_RESAMPLER = 0;
             }
 
             m_resamplers[player] = resampler;
-            m_callbackbuffers[player].resize(streamer->channels * streamer->framesize);
+            m_callbackbuffers[player].resize(size_t(streamer->channels) * streamer->framesize);
             m_resambuffers[player] = std::make_shared<ACE_Message_Queue< ACE_NULL_SYNCH >>();
             m_resambuffers[player]->high_water_mark(1024*1024);
             m_resambuffers[player]->low_water_mark(1024*1024);

--- a/Library/TeamTalkLib/codec/MediaUtil.h
+++ b/Library/TeamTalkLib/codec/MediaUtil.h
@@ -35,7 +35,7 @@
 // Returns number of bytes from number of 'samples' with 'channels'
 constexpr auto PCM16_BYTES(int samples, int channels)
 {
-    return samples * channels * sizeof(short);
+    return size_t(samples) * channels * sizeof(short);
 }
 // Returns number of msec from number of 'bytes' with 'channels' at given 'samplerate'
 constexpr auto PCM16_BYTES_DURATION(int bytes, int channels, int samplerate)

--- a/Library/TeamTalkLib/teamtalk/PacketLayout.cpp
+++ b/Library/TeamTalkLib/teamtalk/PacketLayout.cpp
@@ -1729,7 +1729,7 @@ namespace teamtalk
             return false;
 
         uint16_t byte_pos = 0;
-        for(uint16_t i=0;i<blocks_n_sizes.size();i+=2)
+        for(size_t i=0;i<blocks_n_sizes.size();i+=2)
         {
             desktop_block bb;
             bb.block_data = reinterpret_cast<const char*>(&blockdata_ptr[byte_pos]);

--- a/Library/TeamTalkLib/teamtalk/client/AudioMuxer.cpp
+++ b/Library/TeamTalkLib/teamtalk/client/AudioMuxer.cpp
@@ -829,7 +829,7 @@ void AudioMuxer::WriteAudio(int cb_samples, teamtalk::StreamTypes sts)
         int ret = 0;
         for(int i=0;i<cb_samples / m_inputformat.samples && ret >= 0;i++)
         {
-            ret = m_speexfile->Encode(&m_muxed_buffer[i * m_inputformat.GetTotalSamples()]);
+            ret = m_speexfile->Encode(&m_muxed_buffer[size_t(i) * m_inputformat.GetTotalSamples()]);
         }
     }
 #endif
@@ -839,7 +839,7 @@ void AudioMuxer::WriteAudio(int cb_samples, teamtalk::StreamTypes sts)
     {
         int ret = 0;
         for(int i=0;i<cb_samples/m_inputformat.samples && ret >= 0;i++)
-            ret = m_opusfile->Encode(&m_muxed_buffer[ i * m_inputformat.GetTotalSamples()], m_inputformat.samples, false);
+            ret = m_opusfile->Encode(&m_muxed_buffer[ size_t(i) * m_inputformat.GetTotalSamples()], m_inputformat.samples, false);
     }
 #endif
 

--- a/Library/TeamTalkLib/teamtalk/client/ClientNode.cpp
+++ b/Library/TeamTalkLib/teamtalk/client/ClientNode.cpp
@@ -894,7 +894,7 @@ void ClientNode::OpenAudioCapture(const AudioCodec& codec)
                                             ACE_TEXT("Cannot create resampler for sound output device"));
                 return;
             }
-            m_playback_buffer.resize(codec_samples * codec_channels);
+            m_playback_buffer.resize(size_t(codec_samples) * codec_channels);
         }
 
         // resample if output device already forced resampling or 
@@ -917,7 +917,7 @@ void ClientNode::OpenAudioCapture(const AudioCodec& codec)
                     ACE_TEXT("Cannot create resampler for sound input device."));
                 return;
             }
-            m_capture_buffer.resize(codec_samples * codec_channels);
+            m_capture_buffer.resize(size_t(codec_samples) * codec_channels);
 
             samples = CalcSamples(codec_samplerate, codec_samples, samplerate);
         }
@@ -965,7 +965,7 @@ void ClientNode::OpenAudioCapture(const AudioCodec& codec)
                     ACE_TEXT("Cannot create resampler for sound input device."));
                 return;
             }
-            m_capture_buffer.resize(codec_samples * codec_channels);
+            m_capture_buffer.resize(size_t(codec_samples) * codec_channels);
         }
         else
         {

--- a/Library/TeamTalkLib/teamtalk/client/DesktopShare.cpp
+++ b/Library/TeamTalkLib/teamtalk/client/DesktopShare.cpp
@@ -95,7 +95,7 @@ int DesktopInitiator::NewBitmap(const char* bmp_bits, int size, uint32_t tm)
             if((int)m_tmp_block.size() != width * height * m_pixel_size)
             {
                 char const def_color = DEFAULT_COLOR;
-                m_tmp_block.resize(width * height * m_pixel_size, def_color);
+                m_tmp_block.resize(size_t(width) * height * m_pixel_size, def_color);
             }
 
             for(int i=0;i<height;i++)
@@ -109,7 +109,7 @@ int DesktopInitiator::NewBitmap(const char* bmp_bits, int size, uint32_t tm)
                 byte_pos += GetHeight() * m_padding;
                 TTASSERT(byte_pos < size);
                 const char* byte_pos_ptr = &bmp_bits[byte_pos];
-                memcpy(&m_tmp_block[width*i*m_pixel_size], byte_pos_ptr, width * m_pixel_size);
+                memcpy(&m_tmp_block[size_t(width)*i*m_pixel_size], byte_pos_ptr, size_t(width) * m_pixel_size);
             }
 
             const int BLOCK_INDEX = w + (h * m_w_blocks);
@@ -294,7 +294,7 @@ void DesktopViewer::AddCompressedBlock(int block_no, const char* inbuf, int in_s
         byte_pos += GetHeight() * m_padding;
         TTASSERT(byte_pos < m_bitmap.size());
         char* byte_pos_ptr = &m_bitmap[byte_pos];
-        memcpy(byte_pos_ptr, &outbuf[width*i*m_pixel_size], width * m_pixel_size);
+        memcpy(byte_pos_ptr, &outbuf[size_t(width)*i*m_pixel_size], size_t(width) * m_pixel_size);
     }
 }
 
@@ -333,7 +333,7 @@ void DesktopViewer::AddDuplicateBlock(int src_block_no, int dest_block_no)
         TTASSERT(dest_byte_pos < m_bitmap.size());
         char* src_byte_pos_ptr = &m_bitmap[src_byte_pos];
         char* dest_byte_pos_ptr = &m_bitmap[dest_byte_pos];
-        memcpy(dest_byte_pos_ptr, src_byte_pos_ptr, width * m_pixel_size);
+        memcpy(dest_byte_pos_ptr, src_byte_pos_ptr, size_t(width) * m_pixel_size);
     }
 }
 

--- a/Library/TeamTalkLib/teamtalk/client/StreamPlayers.cpp
+++ b/Library/TeamTalkLib/teamtalk/client/StreamPlayers.cpp
@@ -60,7 +60,7 @@ AudioPlayer::AudioPlayer(int userid, StreamType stream_type, soundsystem::sounds
         input_channels = 2;
     int const input_samples = GetAudioCodecCbSamples(m_codec);
     if (m_resampler)
-        m_resample_buffer.resize(input_samples*input_channels);
+        m_resample_buffer.resize(size_t(input_samples)*input_channels);
 
     SetAudioBufferSize(GetAudioCodecCbMillis(m_codec) * 4);
 }

--- a/Library/TeamTalkLib/teamtalk/client/VoiceLogger.cpp
+++ b/Library/TeamTalkLib/teamtalk/client/VoiceLogger.cpp
@@ -175,7 +175,7 @@ VoiceLog::VoiceLog(int userid, const ACE_TString& filename,
 
     if (cbsamples > 0)
     {
-        m_samples_buf.resize(cbsamples * channels);
+        m_samples_buf.resize(size_t(cbsamples) * channels);
         m_active = true;
     }
     MYTRACE(ACE_TEXT("VoiceLog started: %s\n"), this->GetFileName().c_str());
@@ -363,7 +363,7 @@ void VoiceLog::WriteAudio(int packet_no)
                 for(size_t i=0;i<frame_sizes.size();i++)
                 {
                     ret = m_opus->Decode(&enc_data[sum_dec], frame_sizes[i],
-                                         &m_samples_buf[framesize * channels * i],
+                                         &m_samples_buf[size_t(framesize) * channels * i],
                                          cb_samples);
                     assert(ret > 0);
                     decsamples += ret;
@@ -401,7 +401,7 @@ void VoiceLog::WriteAudio(int packet_no)
                 for(int i=0;i<fpp;i++)
                 {
                     m_opus->Decode(nullptr, 0,
-                                   &m_samples_buf[cb_samples*channels*i],
+                                   &m_samples_buf[size_t(cb_samples)*channels*i],
                                    cb_samples);
                 }
             }

--- a/Library/TeamTalkLib/test/CatchDefault.cpp
+++ b/Library/TeamTalkLib/test/CatchDefault.cpp
@@ -915,7 +915,7 @@ for (size_t i=0;std::cmp_less(i,77000*fmt.channels);++i)
 TEST_CASE("GenerateToneStereoWaveFile")
 {
     media::AudioFormat const fmt(32000, 2);
-    std::vector<short> buf(fmt.samplerate * fmt.channels);
+    std::vector<short> buf(size_t(fmt.samplerate) * fmt.channels);
     media::AudioFrame frm(fmt, buf.data(), 32000);
     WavePCMFile wavfile;
     REQUIRE(wavfile.NewFile(ACE_TEXT("stereo.wav"), fmt));
@@ -2513,7 +2513,7 @@ TEST_CASE("InjectAudioInputGain")
     REQUIRE(chan.audiocodec.nCodec == OPUS_CODEC);
     auto const N_FRAMES = 5;
     int const samples = PCM16_DURATION_SAMPLES(chan.audiocodec.opus.nTxIntervalMSec, chan.audiocodec.opus.nSampleRate) * N_FRAMES;
-    std::vector<short> buffer(samples * chan.audiocodec.opus.nChannels);
+    std::vector<short> buffer(size_t(samples) * chan.audiocodec.opus.nChannels);
     media::AudioFrame frm(media::AudioFormat(chan.audiocodec.opus.nSampleRate, chan.audiocodec.opus.nChannels), buffer.data(), samples);
     int const sampleindex = GenerateTone(frm, 0, 500);
 
@@ -3438,7 +3438,7 @@ static void CreateOpusFile(const MediaFileInfo& mfi, const ACE_TString& oggfilen
     OpusEncFile opusenc;
     REQUIRE(opusenc.Open(oggfilename, mfi.audioFmt.nChannels, mfi.audioFmt.nSampleRate, FRAMESIZE, OPUS_APPLICATION_AUDIO));
 
-    std::vector<short> buf(mfi.audioFmt.nChannels * FRAMESIZE);
+    std::vector<short> buf(size_t(mfi.audioFmt.nChannels) * FRAMESIZE);
     int samples = 0;
     while ((samples = wavfile.ReadSamples(buf.data(), FRAMESIZE)) > 0)
     {
@@ -3478,7 +3478,7 @@ TEST_CASE("OPUSFileEncDec")
                              mfi.audioFmt.nSampleRate, PCM16_SAMPLES_DURATION(FRAMESIZE, mfi.audioFmt.nSampleRate));
             REQUIRE(opusenc.Open(opusencfilename, mfi.audioFmt.nChannels, mfi.audioFmt.nSampleRate, FRAMESIZE, OPUS_APPLICATION_AUDIO));
 
-            std::vector<short> buf(mfi.audioFmt.nChannels * FRAMESIZE);
+            std::vector<short> buf(size_t(mfi.audioFmt.nChannels) * FRAMESIZE);
             int samples = 0;
             while ((samples = wavfile.ReadSamples(buf.data(), FRAMESIZE)) > 0)
             {
@@ -3874,7 +3874,7 @@ TEST_CASE("TTPlayFFmpegOpus")
 
     WavePCMFile wavfile;
     REQUIRE(wavfile.NewFile(ACE_TEXT("giana.wav"), odf.GetSampleRate(), odf.GetChannels()));
-    std::vector<short> buf(odf.GetSampleRate() * odf.GetChannels());
+    std::vector<short> buf(size_t(odf.GetSampleRate()) * odf.GetChannels());
     int samples;
     int framesize = 0;
     while ((samples = odf.Decode(buf.data(), odf.GetSampleRate())) > 0)


### PR DESCRIPTION
Resolved code scanning alerts:

java/xxe (critical) - harden DocumentBuilderFactory against XXE:
- https://github.com/BearWare/TeamTalk5/security/code-scanning/47
- https://github.com/BearWare/TeamTalk5/security/code-scanning/48
- https://github.com/BearWare/TeamTalk5/security/code-scanning/49
- https://github.com/BearWare/TeamTalk5/security/code-scanning/50

java/path-injection (high) - sanitize untrusted display name before building cache file:
- https://github.com/BearWare/TeamTalk5/security/code-scanning/54
- https://github.com/BearWare/TeamTalk5/security/code-scanning/55
- https://github.com/BearWare/TeamTalk5/security/code-scanning/56
- https://github.com/BearWare/TeamTalk5/security/code-scanning/57
- https://github.com/BearWare/TeamTalk5/security/code-scanning/58
- https://github.com/BearWare/TeamTalk5/security/code-scanning/59

cpp/suspicious-add-sizeof (high) - use element count instead of sizeof for array end:
- https://github.com/BearWare/TeamTalk5/security/code-scanning/881

cpp/comparison-with-wider-type (high) - widen loop counter to size_t:
- https://github.com/BearWare/TeamTalk5/security/code-scanning/1

cpp/integer-multiplication-cast-to-long (high) - cast operand to size_t before multiply:
- https://github.com/BearWare/TeamTalk5/security/code-scanning/4
- https://github.com/BearWare/TeamTalk5/security/code-scanning/5
- https://github.com/BearWare/TeamTalk5/security/code-scanning/8
- https://github.com/BearWare/TeamTalk5/security/code-scanning/14
- https://github.com/BearWare/TeamTalk5/security/code-scanning/21
- https://github.com/BearWare/TeamTalk5/security/code-scanning/23
- https://github.com/BearWare/TeamTalk5/security/code-scanning/24
- https://github.com/BearWare/TeamTalk5/security/code-scanning/34
- https://github.com/BearWare/TeamTalk5/security/code-scanning/35
- https://github.com/BearWare/TeamTalk5/security/code-scanning/36
- https://github.com/BearWare/TeamTalk5/security/code-scanning/37
- https://github.com/BearWare/TeamTalk5/security/code-scanning/38
- https://github.com/BearWare/TeamTalk5/security/code-scanning/39
- https://github.com/BearWare/TeamTalk5/security/code-scanning/41
- https://github.com/BearWare/TeamTalk5/security/code-scanning/42
- https://github.com/BearWare/TeamTalk5/security/code-scanning/43
- https://github.com/BearWare/TeamTalk5/security/code-scanning/44
- https://github.com/BearWare/TeamTalk5/security/code-scanning/45
- https://github.com/BearWare/TeamTalk5/security/code-scanning/46
- https://github.com/BearWare/TeamTalk5/security/code-scanning/71
- https://github.com/BearWare/TeamTalk5/security/code-scanning/72
- https://github.com/BearWare/TeamTalk5/security/code-scanning/73
- https://github.com/BearWare/TeamTalk5/security/code-scanning/74
- https://github.com/BearWare/TeamTalk5/security/code-scanning/75
- https://github.com/BearWare/TeamTalk5/security/code-scanning/76
- https://github.com/BearWare/TeamTalk5/security/code-scanning/77
- https://github.com/BearWare/TeamTalk5/security/code-scanning/78
- https://github.com/BearWare/TeamTalk5/security/code-scanning/79
- https://github.com/BearWare/TeamTalk5/security/code-scanning/80
- https://github.com/BearWare/TeamTalk5/security/code-scanning/81
- https://github.com/BearWare/TeamTalk5/security/code-scanning/82
- https://github.com/BearWare/TeamTalk5/security/code-scanning/83
- https://github.com/BearWare/TeamTalk5/security/code-scanning/84
- https://github.com/BearWare/TeamTalk5/security/code-scanning/870
- https://github.com/BearWare/TeamTalk5/security/code-scanning/871