### PR TITLE
Android client. Added the forgotan Subscription and transmission changes to the chat list

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
@@ -1050,6 +1050,13 @@ public class TeamTalkService extends Service
 
     @Override
     public void onCmdUserUpdate(User user) {
+
+        User olduser = users.get(user.nUserID);
+
+        if (olduser != null) {
+            Utils.subscriptionLogChanged(getBaseContext(), olduser, user) .ifPresent(text -> getChatLogTextMsgs().add( MyTextMessage.createLogMsg( MyTextMessage.MSGTYPE_LOG_INFO, text)));
+        }
+
         users.put(user.nUserID, user);
     }
 
@@ -1175,6 +1182,13 @@ public class TeamTalkService extends Service
 
     @Override
     public void onCmdChannelUpdate(Channel channel) {
+
+        Channel oldchannel = channels.get(channel.nChannelID);
+
+        if (oldchannel != null) {
+            Utils.transmitUsersLogChanged(getBaseContext(), oldchannel, channel, getUsers()) .ifPresent(text -> getChatLogTextMsgs().add( MyTextMessage.createLogMsg( MyTextMessage.MSGTYPE_LOG_INFO, text)));
+        }
+
         channels.put(channel.nChannelID, channel);
 
         if (mychannel != null && mychannel.nChannelID == channel.nChannelID) {

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
@@ -1054,7 +1054,8 @@ public class TeamTalkService extends Service
         User olduser = users.get(user.nUserID);
 
         if (olduser != null) {
-            Utils.subscriptionLogChanged(getBaseContext(), olduser, user) .ifPresent(text -> getChatLogTextMsgs().add( MyTextMessage.createLogMsg( MyTextMessage.MSGTYPE_LOG_INFO, text)));
+            Utils.subscriptionLogChanged(getBaseContext(), olduser, user)
+                .ifPresent(text -> getChatLogTextMsgs().add(MyTextMessage.createLogMsg(MyTextMessage.MSGTYPE_LOG_INFO, text)));
         }
 
         users.put(user.nUserID, user);
@@ -1185,8 +1186,9 @@ public class TeamTalkService extends Service
 
         Channel oldchannel = channels.get(channel.nChannelID);
 
-        if (oldchannel != null) {
-            Utils.transmitUsersLogChanged(getBaseContext(), oldchannel, channel, getUsers()) .ifPresent(text -> getChatLogTextMsgs().add( MyTextMessage.createLogMsg( MyTextMessage.MSGTYPE_LOG_INFO, text)));
+        if (oldchannel != null && mychannel != null && mychannel.nChannelID == channel.nChannelID) {
+            Utils.transmitUsersLogChanged(getBaseContext(), oldchannel, channel, getUsers())
+                .ifPresent(text -> getChatLogTextMsgs().add(MyTextMessage.createLogMsg(MyTextMessage.MSGTYPE_LOG_INFO, text)));
         }
 
         channels.put(channel.nChannelID, channel);

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -2019,6 +2019,9 @@ private EditText newmsg;
         subscriptionChange(user);
 
         users.put(user.nUserID, user);
+        accessibilityAssistant.lockEvents();
+        textmsgAdapter.notifyDataSetChanged();
+        accessibilityAssistant.unlockEvents();
     }
 
     @Override
@@ -2228,6 +2231,9 @@ private EditText newmsg;
 
             setMyChannel(channel);
         }
+    accessibilityAssistant.lockEvents();
+    textmsgAdapter.notifyDataSetChanged();
+    accessibilityAssistant.unlockEvents();
     }
 
     @Override

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -2231,9 +2231,9 @@ private EditText newmsg;
 
             setMyChannel(channel);
         }
-    accessibilityAssistant.lockEvents();
-    textmsgAdapter.notifyDataSetChanged();
-    accessibilityAssistant.unlockEvents();
+        accessibilityAssistant.lockEvents();
+        textmsgAdapter.notifyDataSetChanged();
+        accessibilityAssistant.unlockEvents();
     }
 
     @Override

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/Utils.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/Utils.java
@@ -68,6 +68,7 @@ import java.util.Vector;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 import dk.bearware.AudioCodec;
 import dk.bearware.Channel;
@@ -665,12 +666,23 @@ public class Utils {
         return result.toString();
     }
     
+    public static DocumentBuilderFactory newSecureDocumentBuilderFactory() throws ParserConfigurationException {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        dbf.setXIncludeAware(false);
+        dbf.setExpandEntityReferences(false);
+        return dbf;
+    }
+
     public static Vector<ServerEntry> getXmlServerEntries(String xml) {
         Vector<ServerEntry> servers = new Vector<>();
-        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
         DocumentBuilder dBuilder;
         Document doc;
         try {
+            DocumentBuilderFactory dbFactory = newSecureDocumentBuilderFactory();
             dBuilder = dbFactory.newDocumentBuilder();
             doc = dBuilder.parse(new InputSource(new StringReader(xml)));
         }

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/Utils.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/Utils.java
@@ -68,7 +68,6 @@ import java.util.Vector;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 
 import dk.bearware.AudioCodec;
 import dk.bearware.Channel;
@@ -329,6 +328,73 @@ public class Utils {
         return map;
     }
 
+    public static Optional<String> transmitUsersLogChanged(Context context, Channel oldchan, Channel updchan, Map<Integer, User> users) {
+
+        Set<Integer> allUserIds = new HashSet<>();
+        Map<Integer, Integer> oldTransmitUsers = Utils.transmitUsersToMap(oldchan.transmitUsers);
+        Map<Integer, Integer> newTransmitUsers = Utils.transmitUsersToMap(updchan.transmitUsers);
+
+        allUserIds.addAll(oldTransmitUsers.keySet());
+        allUserIds.addAll(newTransmitUsers.keySet());
+
+        for (int userId : allUserIds) {
+
+            int oldValue = oldTransmitUsers.getOrDefault(userId, StreamType.STREAMTYPE_NONE);
+            int newValue = newTransmitUsers.getOrDefault(userId, StreamType.STREAMTYPE_NONE);
+
+            String name;
+
+            if (userId == 0) continue;
+
+            if (userId == Constants.TT_CLASSROOM_FREEFORALL)
+                name = context.getResources().getString(R.string.text_tts_transmit_name_everyone);
+            else {
+                User u = users.get(userId);
+                if (u != null && u.nChannelID == oldchan.nChannelID)
+                    name = Utils.getDisplayName(context, u);
+                else
+                    continue;
+            }
+
+            int result = Utils.transmitUsersToggled(updchan, oldValue, newValue, StreamType.STREAMTYPE_CHANNELMSG);
+
+            if (result < 0)
+                return Optional.of(name + " " + context.getResources().getString(R.string.text_tts_channel_msg_transmit_off));
+            else if (result > 0)
+                return Optional.of(name + " " + context.getResources().getString(R.string.text_tts_channel_msg_transmit_on));
+
+            result = Utils.transmitUsersToggled(updchan, oldValue, newValue, StreamType.STREAMTYPE_VOICE);
+
+            if (result < 0)
+                return Optional.of(name + " " + context.getResources().getString(R.string.text_tts_voice_transmit_off));
+            else if (result > 0)
+                return Optional.of(name + " " + context.getResources().getString(R.string.text_tts_voice_transmit_on));
+
+            result = Utils.transmitUsersToggled(updchan, oldValue, newValue, StreamType.STREAMTYPE_VIDEOCAPTURE);
+
+            if (result < 0)
+                return Optional.of(name + " " + context.getResources().getString(R.string.text_tts_vid_transmit_off));
+            else if (result > 0)
+                return Optional.of(name + " " + context.getResources().getString(R.string.text_tts_vid_transmit_on));
+
+            result = Utils.transmitUsersToggled(updchan, oldValue, newValue, StreamType.STREAMTYPE_DESKTOP);
+
+            if (result < 0)
+                return Optional.of(name + " " + context.getResources().getString(R.string.text_tts_desk_transmit_off));
+            else if (result > 0)
+                return Optional.of(name + " " + context.getResources().getString(R.string.text_tts_desk_transmit_on));
+
+            result = Utils.transmitUsersToggled(updchan, oldValue, newValue, StreamType.STREAMTYPE_MEDIAFILE);
+
+            if (result < 0)
+                return Optional.of(name + " " + context.getResources().getString(R.string.text_tts_media_transmit_off));
+            else if (result > 0)
+                return Optional.of(name + " " + context.getResources().getString(R.string.text_tts_media_transmit_on));
+        }
+
+        return Optional.empty();
+    }
+
     public static Optional<String> ttsTransmitUsersToggled(Context context, Channel oldchan, Channel updchan, Map<Integer, User> users) {
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
@@ -434,6 +500,90 @@ public class Utils {
                         context.getResources().getString(R.string.text_tts_subscribe_off)));
     }
 
+    public static Optional<String> subscriptionLogChanged(Context context, User oldUser, User newUser) {
+        Optional<Boolean> isOn;
+
+        if ((isOn = subscriptionChanged(oldUser, newUser, Subscription.SUBSCRIBE_USER_MSG)).isPresent()) {
+            return Optional.of(ttsGenerateSubscriptionText(context,
+                    R.string.text_tts_subscription_user_msg_changed,
+                    newUser, isOn.get()));
+        }
+
+        if ((isOn = subscriptionChanged(oldUser, newUser, Subscription.SUBSCRIBE_CHANNEL_MSG)).isPresent()) {
+            return Optional.of(ttsGenerateSubscriptionText(context,
+                    R.string.text_tts_subscription_channel_msg_changed,
+                    newUser, isOn.get()));
+        }
+
+        if ((isOn = subscriptionChanged(oldUser, newUser, Subscription.SUBSCRIBE_BROADCAST_MSG)).isPresent()) {
+            return Optional.of(ttsGenerateSubscriptionText(context,
+                    R.string.text_tts_subscription_broadcast_msg_changed,
+                    newUser, isOn.get()));
+        }
+
+        if ((isOn = subscriptionChanged(oldUser, newUser, Subscription.SUBSCRIBE_VOICE)).isPresent()) {
+            return Optional.of(ttsGenerateSubscriptionText(context,
+                    R.string.text_tts_subscription_voice_changed,
+                    newUser, isOn.get()));
+        }
+
+        if ((isOn = subscriptionChanged(oldUser, newUser, Subscription.SUBSCRIBE_VIDEOCAPTURE)).isPresent()) {
+            return Optional.of(ttsGenerateSubscriptionText(context,
+                    R.string.text_tts_subscription_vid_changed,
+                    newUser, isOn.get()));
+        }
+
+        if ((isOn = subscriptionChanged(oldUser, newUser, Subscription.SUBSCRIBE_DESKTOP)).isPresent()) {
+            return Optional.of(ttsGenerateSubscriptionText(context,
+                    R.string.text_tts_subscription_desk_changed,
+                    newUser, isOn.get()));
+        }
+
+        if ((isOn = subscriptionChanged(oldUser, newUser, Subscription.SUBSCRIBE_MEDIAFILE)).isPresent()) {
+            return Optional.of(ttsGenerateSubscriptionText(context,
+                    R.string.text_tts_subscription_media_changed,
+                    newUser, isOn.get()));
+        }
+
+        if ((isOn = subscriptionChanged(oldUser, newUser, Subscription.SUBSCRIBE_INTERCEPT_USER_MSG)).isPresent()) {
+            return Optional.of(ttsGenerateSubscriptionText(context,
+                    R.string.text_tts_subscription_intercept_user_msg_changed,
+                    newUser, isOn.get()));
+        }
+
+        if ((isOn = subscriptionChanged(oldUser, newUser, Subscription.SUBSCRIBE_INTERCEPT_CHANNEL_MSG)).isPresent()) {
+            return Optional.of(ttsGenerateSubscriptionText(context,
+                    R.string.text_tts_subscription_intercept_channel_msg_changed,
+                    newUser, isOn.get()));
+        }
+
+        if ((isOn = subscriptionChanged(oldUser, newUser, Subscription.SUBSCRIBE_INTERCEPT_VOICE)).isPresent()) {
+            return Optional.of(ttsGenerateSubscriptionText(context,
+                    R.string.text_tts_subscription_intercept_voice_changed,
+                    newUser, isOn.get()));
+        }
+
+        if ((isOn = subscriptionChanged(oldUser, newUser, Subscription.SUBSCRIBE_INTERCEPT_VIDEOCAPTURE)).isPresent()) {
+            return Optional.of(ttsGenerateSubscriptionText(context,
+                    R.string.text_tts_subscription_intercept_vid_changed,
+                    newUser, isOn.get()));
+        }
+
+        if ((isOn = subscriptionChanged(oldUser, newUser, Subscription.SUBSCRIBE_INTERCEPT_DESKTOP)).isPresent()) {
+            return Optional.of(ttsGenerateSubscriptionText(context,
+                    R.string.text_tts_subscription_intercept_desk_changed,
+                    newUser, isOn.get()));
+        }
+
+        if ((isOn = subscriptionChanged(oldUser, newUser, Subscription.SUBSCRIBE_INTERCEPT_MEDIAFILE)).isPresent()) {
+            return Optional.of(ttsGenerateSubscriptionText(context,
+                    R.string.text_tts_subscription_intercept_media_changed,
+                    newUser, isOn.get()));
+        }
+
+        return Optional.empty();
+    }
+
     public static Optional<String> ttsSubscriptionChanged(Context context, User oldUser, User newUser) {
         Optional<Boolean> isOn;
         if (ttsScriptionPreferenceEnabled(context, Subscription.SUBSCRIBE_USER_MSG) &&
@@ -515,23 +665,12 @@ public class Utils {
         return result.toString();
     }
     
-    public static DocumentBuilderFactory newSecureDocumentBuilderFactory() throws ParserConfigurationException {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-        dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-        dbf.setXIncludeAware(false);
-        dbf.setExpandEntityReferences(false);
-        return dbf;
-    }
-
     public static Vector<ServerEntry> getXmlServerEntries(String xml) {
         Vector<ServerEntry> servers = new Vector<>();
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
         DocumentBuilder dBuilder;
         Document doc;
         try {
-            DocumentBuilderFactory dbFactory = newSecureDocumentBuilderFactory();
             dBuilder = dbFactory.newDocumentBuilder();
             doc = dBuilder.parse(new InputSource(new StringReader(xml)));
         }


### PR DESCRIPTION
When I was implementing these announcements in 5.18, because you took so long to review and merge my pull request, I forgot to complete it and add the chatlogs for them as whell like I did for the other things. But now has been fadded