### PR TITLE
Add Android webcam transmission controls

### DIFF
--- a/Client/TeamTalkAndroid/src/main/AndroidManifest.xml
+++ b/Client/TeamTalkAndroid/src/main/AndroidManifest.xml
@@ -7,6 +7,8 @@
     </queries>
     <!-- RECORD_AUDIO is needed to create an audio recorder -->
     <uses-permission android:name="android.permission.RECORD_AUDIO"></uses-permission>
+    <!-- CAMERA is needed to transmit webcam video -->
+    <uses-permission android:name="android.permission.CAMERA"></uses-permission>
     <!-- MODIFY_AUDIO_SETTINGS is needed to use audio effects such as environmental reverb -->
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"></uses-permission>
     <!-- INTERNET is needed to use a URI-based audio player, depending on the URI -->
@@ -29,8 +31,11 @@
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"></uses-permission>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"></uses-permission>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"></uses-permission>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA"></uses-permission>
     <uses-permission android:name="android.hardware.sensor.proximity"></uses-permission>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.front" android:required="false" />
 
     <application
         android:allowBackup="true"
@@ -97,7 +102,7 @@
 
         <service
             android:name="dk.bearware.backend.TeamTalkService"
-            android:foregroundServiceType="microphone"
+            android:foregroundServiceType="microphone|camera"
             android:enabled="true"
             android:exported="false"
             android:stopWithTask="true" />

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/backend/TeamTalkService.java
@@ -81,6 +81,7 @@ import dk.bearware.Channel;
 import dk.bearware.ClientErrorMsg;
 import dk.bearware.ClientEvent;
 import dk.bearware.ClientFlag;
+import dk.bearware.Codec;
 import dk.bearware.EncryptionContext;
 import dk.bearware.FileTransfer;
 import dk.bearware.FileTransferStatus;
@@ -99,6 +100,9 @@ import dk.bearware.TextMsgType;
 import dk.bearware.User;
 import dk.bearware.UserAccount;
 import dk.bearware.UserRight;
+import dk.bearware.VideoCaptureDevice;
+import dk.bearware.VideoCodec;
+import dk.bearware.VideoFormat;
 import dk.bearware.WebRTCConstants;
 import dk.bearware.data.AppInfo;
 import dk.bearware.data.License;
@@ -172,6 +176,9 @@ public class TeamTalkService extends Service
     Handler reconnectHandler = new Handler();
     Runnable reconnectTimer = this::reconnect;
     private Runnable reconnectBluetoothScoAfterCall;
+    private String selectedVideoCaptureDeviceId = "";
+    private VideoFormat selectedVideoCaptureFormat;
+    private int selectedVideoCaptureBitrate = 256;
 
     TeamTalkBase ttclient;
     ServerEntry ttserver;
@@ -195,8 +202,10 @@ public class TeamTalkService extends Service
 
         syncToUserCache();
 
-        if(ttclient != null)
+        if(ttclient != null) {
+            stopVideoCaptureTransmission();
             ttclient.disconnect();
+        }
 
         displayNotification(false);
         joinchannel = null;
@@ -370,8 +379,10 @@ public class TeamTalkService extends Service
         disablePhoneCallReaction();
         unwatchBluetoothHeadset();
 
-        if (ttclient != null)
+        if (ttclient != null) {
+            stopVideoCaptureTransmission(false);
             ttclient.closeTeamTalk();
+        }
 
         super.onDestroy();
         mediaSession.release();
@@ -383,6 +394,17 @@ public class TeamTalkService extends Service
         return (mychannel != null) ?
             String.format("%s / %s", ttserver.servername, mychannel.szName) :
             ttserver.servername;
+    }
+
+    private int getTeamTalkForegroundServiceType() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return 0;
+        }
+        int type = ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE;
+        if (isVideoCaptureTransmissionEnabled() || isVideoCaptureDeviceReady()) {
+            type |= ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA;
+        }
+        return type;
     }
 
     @SuppressLint("NewApi")
@@ -410,12 +432,12 @@ public class TeamTalkService extends Service
                     .setContentText(getNotificationText())
                     .setShowWhen(false)
                     .build();
-                ServiceCompat.startForeground(this, UI_WIDGET_ID, widget, ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST);
+                ServiceCompat.startForeground(this, UI_WIDGET_ID, widget, getTeamTalkForegroundServiceType());
             } else {
                 widget = new NotificationCompat.Builder(this, widget)
                     .setContentText(getNotificationText())
                     .build();
-                notificationManager.notify(UI_WIDGET_ID, widget);
+                ServiceCompat.startForeground(this, UI_WIDGET_ID, widget, getTeamTalkForegroundServiceType());
             }
         } else if (widget != null) {
             ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE);
@@ -623,6 +645,109 @@ public class TeamTalkService extends Service
         return (ttclient.getFlags() & (ClientFlag.CLIENT_SNDINPUT_VOICEACTIVATED | ClientFlag.CLIENT_SNDINPUT_VOICEACTIVE)) != 0;
     }
 
+    public Vector<VideoCaptureDevice> getVideoCaptureDevices() {
+        Vector<VideoCaptureDevice> devices = new Vector<>();
+        TeamTalkBase.getVideoCaptureDevices(devices);
+        return devices;
+    }
+
+    public boolean isVideoCaptureTransmissionEnabled() {
+        return (ttclient.getFlags() & ClientFlag.CLIENT_TX_VIDEOCAPTURE) != 0;
+    }
+
+    public boolean isVideoCaptureDeviceReady() {
+        return (ttclient.getFlags() & ClientFlag.CLIENT_VIDEOCAPTURE_READY) != 0;
+    }
+
+    public boolean startVideoCaptureTransmission(String deviceId, VideoFormat format, int bitrateKbps) {
+        if (TextUtils.isEmpty(deviceId) || format == null) {
+            return false;
+        }
+
+        UserAccount account = new UserAccount();
+        if (ttclient.getMyUserAccount(account) &&
+                (account.uUserRights & UserRight.USERRIGHT_TRANSMIT_VIDEOCAPTURE) == 0) {
+            return false;
+        }
+
+        selectedVideoCaptureDeviceId = deviceId;
+        selectedVideoCaptureFormat = copyVideoFormat(format);
+        selectedVideoCaptureBitrate = Math.max(32, bitrateKbps);
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+        prefs.edit()
+                .putString(Preferences.PREF_VIDEOCAPTURE_DEVICE_ID, selectedVideoCaptureDeviceId)
+                .putString(Preferences.PREF_VIDEOCAPTURE_FORMAT, encodeVideoFormat(selectedVideoCaptureFormat))
+                .putInt(Preferences.PREF_VIDEOCAPTURE_BITRATE, selectedVideoCaptureBitrate)
+                .apply();
+
+        if (isVideoCaptureTransmissionEnabled()) {
+            ttclient.stopVideoCaptureTransmission();
+        }
+        if (isVideoCaptureDeviceReady()) {
+            ttclient.closeVideoCaptureDevice();
+        }
+
+        if (!ttclient.initVideoCaptureDevice(selectedVideoCaptureDeviceId, selectedVideoCaptureFormat)) {
+            return false;
+        }
+
+        VideoCodec codec = new VideoCodec();
+        codec.nCodec = Codec.WEBM_VP8_CODEC;
+        codec.webm_vp8.nRcTargetBitrate = selectedVideoCaptureBitrate;
+        if (!ttclient.startVideoCaptureTransmission(codec)) {
+            ttclient.closeVideoCaptureDevice();
+            return false;
+        }
+
+        displayNotification(true);
+        return true;
+    }
+
+    public void stopVideoCaptureTransmission() {
+        stopVideoCaptureTransmission(true);
+    }
+
+    private void stopVideoCaptureTransmission(boolean updateNotification) {
+        if (ttclient == null) {
+            return;
+        }
+        if (isVideoCaptureTransmissionEnabled()) {
+            ttclient.stopVideoCaptureTransmission();
+        }
+        if (isVideoCaptureDeviceReady()) {
+            ttclient.closeVideoCaptureDevice();
+        }
+        if (updateNotification && widget != null) {
+            displayNotification(true);
+        }
+    }
+
+    private VideoFormat copyVideoFormat(VideoFormat source) {
+        VideoFormat copy = new VideoFormat();
+        copy.nWidth = source.nWidth;
+        copy.nHeight = source.nHeight;
+        copy.nFPS_Numerator = source.nFPS_Numerator;
+        copy.nFPS_Denominator = source.nFPS_Denominator;
+        copy.picFourCC = source.picFourCC;
+        return copy;
+    }
+
+    public static String encodeVideoFormat(VideoFormat format) {
+        if (format == null) {
+            return "";
+        }
+        return format.nWidth + "x" + format.nHeight + "@" +
+                format.nFPS_Numerator + "/" + format.nFPS_Denominator + ":" + format.picFourCC;
+    }
+
+    public static int getVideoFormatFps(VideoFormat format) {
+        if (format == null || format.nFPS_Denominator == 0) {
+            return 0;
+        }
+        return Math.max(1, Math.round(format.nFPS_Numerator / (float) format.nFPS_Denominator));
+    }
+
     public void setMute(boolean state) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
 
@@ -694,6 +819,7 @@ public class TeamTalkService extends Service
 
         syncToUserCache();
 
+        stopVideoCaptureTransmission();
         ttclient.disconnect();
 
         if (!setupEncryption())
@@ -906,6 +1032,7 @@ public class TeamTalkService extends Service
     public void onConnectionLost() {
         
         Log.i(TAG, "Connection lost to " + ttserver.ipaddr + ":" + ttserver.tcpport);
+        stopVideoCaptureTransmission();
         
         activecmds.clear();
         

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/Permissions.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/Permissions.java
@@ -45,6 +45,7 @@ import dk.bearware.gui.R;
 public enum Permissions {
 
     RECORD_AUDIO(Manifest.permission.RECORD_AUDIO, R.string.permission_audioinput),
+    CAMERA(Manifest.permission.CAMERA, R.string.permission_camera),
     MODIFY_AUDIO_SETTINGS(Manifest.permission.MODIFY_AUDIO_SETTINGS, R.string.permission_audiomodify),
     INTERNET(Manifest.permission.INTERNET, R.string.permission_internet),
     VIBRATE(Manifest.permission.VIBRATE, R.string.permission_vibrate),

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/Preferences.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/Preferences.java
@@ -54,4 +54,8 @@ public class Preferences {
             PREF_SUB_VIDCAP = "sub_video_checkbox",
             PREF_SUB_DESKTOP = "sub_desktop_checkbox",
             PREF_SUB_MEDIAFILE = "sub_mediafile_checkbox";
+    public static final String
+            PREF_VIDEOCAPTURE_DEVICE_ID = "videocapture_device_id",
+            PREF_VIDEOCAPTURE_FORMAT = "videocapture_format",
+            PREF_VIDEOCAPTURE_BITRATE = "videocapture_bitrate";
 }

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -67,6 +67,7 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
 import android.widget.AdapterView.OnItemLongClickListener;
+import android.widget.ArrayAdapter;
 import android.widget.BaseAdapter;
 import android.widget.Button;
 import android.widget.EditText;
@@ -77,6 +78,7 @@ import android.widget.ListView;
 import android.widget.PopupMenu;
 import android.widget.PopupMenu.OnMenuItemClickListener;
 import android.widget.SeekBar;
+import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -120,6 +122,8 @@ import dk.bearware.User;
 import dk.bearware.UserAccount;
 import dk.bearware.UserRight;
 import dk.bearware.UserState;
+import dk.bearware.VideoCaptureDevice;
+import dk.bearware.VideoFormat;
 import dk.bearware.backend.OnVoiceTransmissionToggleListener;
 import dk.bearware.backend.TeamTalkConnection;
 import dk.bearware.backend.TeamTalkConnectionListener;
@@ -194,6 +198,16 @@ extends AppCompatActivity
     FileListAdapter filesAdapter;
     TextMessageAdapter textmsgAdapter;
     MediaAdapter mediaAdapter;
+    Spinner webcamDeviceSpinner;
+    Spinner webcamFormatSpinner;
+    Spinner webcamBitrateSpinner;
+    Button webcamToggleButton;
+    TextView webcamStatusText;
+    boolean updatingWebcamControls;
+    boolean pendingWebcamStartAfterPermission;
+    final ArrayList<VideoCaptureDevice> webcamDevices = new ArrayList<>();
+    final ArrayList<VideoFormat> webcamFormats = new ArrayList<>();
+    final int[] webcamBitratesKbps = {128, 256, 384, 512, 768, 1024};
     TTSWrapper ttsWrapper = null;
     AccessibilityAssistant accessibilityAssistant;
     AudioManager audioManager;
@@ -1058,8 +1072,210 @@ private EditText newmsg;
 
             ExpandableListView mediaview = rootView.findViewById(R.id.media_elist_view);
             mediaview.setAdapter(mainActivity.getMediaAdapter());
+            mainActivity.setupVideoCaptureControls(rootView);
             return rootView;
         }
+    }
+
+    private void setupVideoCaptureControls(View rootView) {
+        webcamStatusText = rootView.findViewById(R.id.webcam_status_text);
+        webcamDeviceSpinner = rootView.findViewById(R.id.webcam_device_spinner);
+        webcamFormatSpinner = rootView.findViewById(R.id.webcam_format_spinner);
+        webcamBitrateSpinner = rootView.findViewById(R.id.webcam_bitrate_spinner);
+        webcamToggleButton = rootView.findViewById(R.id.webcam_toggle_button);
+
+        ArrayList<String> bitrateLabels = new ArrayList<>();
+        for (int bitrate : webcamBitratesKbps) {
+            bitrateLabels.add(bitrate + " kbps");
+        }
+        ArrayAdapter<String> bitrateAdapter = new ArrayAdapter<>(
+                this, android.R.layout.simple_spinner_item, bitrateLabels);
+        bitrateAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        webcamBitrateSpinner.setAdapter(bitrateAdapter);
+
+        webcamDeviceSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                if (!updatingWebcamControls) {
+                    updateVideoCaptureFormatChoices(null);
+                }
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+            }
+        });
+        webcamToggleButton.setOnClickListener(v -> toggleVideoCaptureTransmission());
+
+        refreshVideoCaptureControls();
+        updateVideoCaptureState();
+    }
+
+    private void refreshVideoCaptureControls() {
+        if (webcamDeviceSpinner == null || getService() == null) {
+            return;
+        }
+
+        updatingWebcamControls = true;
+        webcamDevices.clear();
+        webcamDevices.addAll(getService().getVideoCaptureDevices());
+
+        ArrayList<String> deviceLabels = new ArrayList<>();
+        String savedDeviceId = prefs.get(Preferences.PREF_VIDEOCAPTURE_DEVICE_ID, "");
+        int selectedDevice = 0;
+        for (int i = 0; i < webcamDevices.size(); i++) {
+            VideoCaptureDevice device = webcamDevices.get(i);
+            String label = (device.szDeviceName == null || device.szDeviceName.isEmpty()) ?
+                    getString(R.string.webcam_camera) + " " + (i + 1) :
+                    device.szDeviceName;
+            deviceLabels.add(label);
+            if (!savedDeviceId.isEmpty() && savedDeviceId.equals(device.szDeviceID)) {
+                selectedDevice = i;
+            }
+        }
+        if (deviceLabels.isEmpty()) {
+            deviceLabels.add(getString(R.string.webcam_no_cameras));
+        }
+        ArrayAdapter<String> deviceAdapter = new ArrayAdapter<>(
+                this, android.R.layout.simple_spinner_item, deviceLabels);
+        deviceAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        webcamDeviceSpinner.setAdapter(deviceAdapter);
+        webcamDeviceSpinner.setSelection(Math.min(selectedDevice, deviceLabels.size() - 1));
+
+        selectSavedVideoBitrate();
+        updateVideoCaptureFormatChoices(prefs.get(Preferences.PREF_VIDEOCAPTURE_FORMAT, ""));
+        updatingWebcamControls = false;
+        updateVideoCaptureState();
+    }
+
+    private void updateVideoCaptureFormatChoices(String selectedFormat) {
+        if (webcamFormatSpinner == null) {
+            return;
+        }
+        webcamFormats.clear();
+        ArrayList<String> formatLabels = new ArrayList<>();
+        int deviceIndex = webcamDeviceSpinner == null ? -1 : webcamDeviceSpinner.getSelectedItemPosition();
+        if (deviceIndex >= 0 && deviceIndex < webcamDevices.size()) {
+            VideoCaptureDevice device = webcamDevices.get(deviceIndex);
+            if (device.videoFormats != null) {
+                for (VideoFormat format : device.videoFormats) {
+                    if (format == null || format.nWidth <= 0 || format.nHeight <= 0) {
+                        continue;
+                    }
+                    webcamFormats.add(format);
+                    int fps = TeamTalkService.getVideoFormatFps(format);
+                    formatLabels.add(format.nWidth + " x " + format.nHeight +
+                            (fps > 0 ? " @ " + fps + " fps" : ""));
+                }
+            }
+        }
+
+        int selectedIndex = chooseVideoFormatIndex(selectedFormat);
+        if (formatLabels.isEmpty()) {
+            formatLabels.add(getString(R.string.webcam_no_formats));
+        }
+        ArrayAdapter<String> formatAdapter = new ArrayAdapter<>(
+                this, android.R.layout.simple_spinner_item, formatLabels);
+        formatAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        webcamFormatSpinner.setAdapter(formatAdapter);
+        webcamFormatSpinner.setSelection(Math.min(selectedIndex, formatLabels.size() - 1));
+        updateVideoCaptureState();
+    }
+
+    private int chooseVideoFormatIndex(String selectedFormat) {
+        int fallbackIndex = 0;
+        int fallbackPixels = Integer.MAX_VALUE;
+        for (int i = 0; i < webcamFormats.size(); i++) {
+            VideoFormat format = webcamFormats.get(i);
+            if (!selectedFormat.isEmpty() &&
+                    TeamTalkService.encodeVideoFormat(format).equals(selectedFormat)) {
+                return i;
+            }
+            int pixels = format.nWidth * format.nHeight;
+            if (pixels >= 320 * 240 && pixels <= 640 * 480 && pixels < fallbackPixels) {
+                fallbackPixels = pixels;
+                fallbackIndex = i;
+            }
+        }
+        return fallbackIndex;
+    }
+
+    private void selectSavedVideoBitrate() {
+        int savedBitrate = prefs.get(Preferences.PREF_VIDEOCAPTURE_BITRATE, 256);
+        int selected = 1;
+        for (int i = 0; i < webcamBitratesKbps.length; i++) {
+            if (webcamBitratesKbps[i] == savedBitrate) {
+                selected = i;
+                break;
+            }
+        }
+        webcamBitrateSpinner.setSelection(selected);
+    }
+
+    private void toggleVideoCaptureTransmission() {
+        if (getService().isVideoCaptureTransmissionEnabled()) {
+            getService().stopVideoCaptureTransmission();
+            Toast.makeText(this, R.string.webcam_stopped, Toast.LENGTH_SHORT).show();
+            updateVideoCaptureState();
+            return;
+        }
+
+        pendingWebcamStartAfterPermission = true;
+        if (Permissions.CAMERA.request(this)) {
+            pendingWebcamStartAfterPermission = false;
+            startSelectedVideoCaptureTransmission();
+        }
+    }
+
+    private void startSelectedVideoCaptureTransmission() {
+        UserAccount account = new UserAccount();
+        if (getClient().getMyUserAccount(account) &&
+                (account.uUserRights & UserRight.USERRIGHT_TRANSMIT_VIDEOCAPTURE) == 0) {
+            Toast.makeText(this, R.string.webcam_transmit_right_missing, Toast.LENGTH_LONG).show();
+            return;
+        }
+
+        int deviceIndex = webcamDeviceSpinner.getSelectedItemPosition();
+        int formatIndex = webcamFormatSpinner.getSelectedItemPosition();
+        int bitrateIndex = webcamBitrateSpinner.getSelectedItemPosition();
+        if (deviceIndex < 0 || deviceIndex >= webcamDevices.size() ||
+                formatIndex < 0 || formatIndex >= webcamFormats.size()) {
+            Toast.makeText(this, R.string.webcam_start_failed, Toast.LENGTH_LONG).show();
+            return;
+        }
+
+        VideoCaptureDevice device = webcamDevices.get(deviceIndex);
+        VideoFormat format = webcamFormats.get(formatIndex);
+        int bitrate = webcamBitratesKbps[Math.max(0, Math.min(bitrateIndex, webcamBitratesKbps.length - 1))];
+        boolean started = getService().startVideoCaptureTransmission(device.szDeviceID, format, bitrate);
+        if (!started) {
+            Toast.makeText(this, R.string.webcam_start_failed, Toast.LENGTH_LONG).show();
+        }
+        updateVideoCaptureState();
+    }
+
+    private void updateVideoCaptureState() {
+        if (webcamToggleButton == null) {
+            return;
+        }
+        if (getService() == null) {
+            webcamToggleButton.setEnabled(false);
+            webcamDeviceSpinner.setEnabled(false);
+            webcamFormatSpinner.setEnabled(false);
+            webcamBitrateSpinner.setEnabled(false);
+            webcamStatusText.setText(R.string.webcam_status_off);
+            return;
+        }
+        boolean transmitting = getService().isVideoCaptureTransmissionEnabled();
+        boolean hasCamera = !webcamDevices.isEmpty();
+        boolean hasFormat = !webcamFormats.isEmpty();
+        webcamToggleButton.setText(transmitting ? R.string.webcam_stop : R.string.webcam_start);
+        webcamToggleButton.setEnabled(transmitting || (hasCamera && hasFormat));
+        webcamDeviceSpinner.setEnabled(!transmitting && hasCamera);
+        webcamFormatSpinner.setEnabled(!transmitting && hasFormat);
+        webcamBitrateSpinner.setEnabled(!transmitting);
+        webcamStatusText.setText(transmitting ? R.string.webcam_status_transmitting :
+                (hasCamera && hasFormat ? R.string.webcam_status_ready : R.string.webcam_status_off));
     }
 
     public static class FilesSectionFragment extends ListFragment {
@@ -1927,6 +2143,15 @@ private EditText newmsg;
                 if ((Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) || areMediaPermissionsComplete())
                     fileSelectionStart();
                 break;
+            case CAMERA:
+                if (webcamDevices.isEmpty()) {
+                    refreshVideoCaptureControls();
+                }
+                if (pendingWebcamStartAfterPermission) {
+                    pendingWebcamStartAfterPermission = false;
+                    startSelectedVideoCaptureTransmission();
+                }
+                break;
             case WAKE_LOCK:
                 wakeLock.acquire();
                 break;
@@ -1953,6 +2178,7 @@ private EditText newmsg;
     @Override
     public void onCmdMyselfLoggedIn(int my_userid, UserAccount useraccount) {
         textmsgAdapter.setMyUserID(my_userid);
+        refreshVideoCaptureControls();
     }
 
     @Override
@@ -2263,6 +2489,7 @@ private EditText newmsg;
 
     @Override
     public void onConnectionLost() {
+        updateVideoCaptureState();
         if(sounds.get(SOUND_SERVERLOST) != 0) {
             audioIcons.play(sounds.get(SOUND_SERVERLOST), 1.0f, 1.0f, 0, 0, 1.0f);
         }
@@ -2271,6 +2498,10 @@ private EditText newmsg;
     @Override
     public void onUserStateChange(User user) {
         users.put(user.nUserID, user);
+
+        if (user.nUserID == getClient().getMyUserID()) {
+            updateVideoCaptureState();
+        }
         
         if (curchannel != null && user.nChannelID == curchannel.nChannelID) {
             accessibilityAssistant.lockEvents();

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -309,6 +309,7 @@ extends AppCompatActivity
         mTabLayout.setupWithViewPager(mViewPager);
 
         setupButtons();
+        setupVideoCaptureControls();
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             final MediaPlayer mMediaPlayer;
@@ -1072,17 +1073,16 @@ private EditText newmsg;
 
             ExpandableListView mediaview = rootView.findViewById(R.id.media_elist_view);
             mediaview.setAdapter(mainActivity.getMediaAdapter());
-            mainActivity.setupVideoCaptureControls(rootView);
             return rootView;
         }
     }
 
-    private void setupVideoCaptureControls(View rootView) {
-        webcamStatusText = rootView.findViewById(R.id.webcam_status_text);
-        webcamDeviceSpinner = rootView.findViewById(R.id.webcam_device_spinner);
-        webcamFormatSpinner = rootView.findViewById(R.id.webcam_format_spinner);
-        webcamBitrateSpinner = rootView.findViewById(R.id.webcam_bitrate_spinner);
-        webcamToggleButton = rootView.findViewById(R.id.webcam_toggle_button);
+    private void setupVideoCaptureControls() {
+        webcamStatusText = findViewById(R.id.webcam_status_text);
+        webcamDeviceSpinner = findViewById(R.id.webcam_device_spinner);
+        webcamFormatSpinner = findViewById(R.id.webcam_format_spinner);
+        webcamBitrateSpinner = findViewById(R.id.webcam_bitrate_spinner);
+        webcamToggleButton = findViewById(R.id.webcam_toggle_button);
 
         ArrayList<String> bitrateLabels = new ArrayList<>();
         for (int bitrate : webcamBitratesKbps) {

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -204,7 +204,9 @@ extends AppCompatActivity
     Button webcamToggleButton;
     TextView webcamStatusText;
     boolean updatingWebcamControls;
+    boolean webcamControlsLoading;
     boolean pendingWebcamStartAfterPermission;
+    int webcamRefreshToken;
     final ArrayList<VideoCaptureDevice> webcamDevices = new ArrayList<>();
     final ArrayList<VideoFormat> webcamFormats = new ArrayList<>();
     final int[] webcamBitratesKbps = {128, 256, 384, 512, 768, 1024};
@@ -1116,36 +1118,53 @@ private EditText newmsg;
             return;
         }
 
-        updatingWebcamControls = true;
-        webcamDevices.clear();
-        webcamDevices.addAll(getService().getVideoCaptureDevices());
-
-        ArrayList<String> deviceLabels = new ArrayList<>();
-        String savedDeviceId = prefs.get(Preferences.PREF_VIDEOCAPTURE_DEVICE_ID, "");
-        int selectedDevice = 0;
-        for (int i = 0; i < webcamDevices.size(); i++) {
-            VideoCaptureDevice device = webcamDevices.get(i);
-            String label = (device.szDeviceName == null || device.szDeviceName.isEmpty()) ?
-                    getString(R.string.webcam_camera) + " " + (i + 1) :
-                    device.szDeviceName;
-            deviceLabels.add(label);
-            if (!savedDeviceId.isEmpty() && savedDeviceId.equals(device.szDeviceID)) {
-                selectedDevice = i;
-            }
-        }
-        if (deviceLabels.isEmpty()) {
-            deviceLabels.add(getString(R.string.webcam_no_cameras));
-        }
-        ArrayAdapter<String> deviceAdapter = new ArrayAdapter<>(
-                this, android.R.layout.simple_spinner_item, deviceLabels);
-        deviceAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        webcamDeviceSpinner.setAdapter(deviceAdapter);
-        webcamDeviceSpinner.setSelection(Math.min(selectedDevice, deviceLabels.size() - 1));
-
-        selectSavedVideoBitrate();
-        updateVideoCaptureFormatChoices(prefs.get(Preferences.PREF_VIDEOCAPTURE_FORMAT, ""));
-        updatingWebcamControls = false;
+        final int refreshToken = ++webcamRefreshToken;
+        webcamControlsLoading = true;
         updateVideoCaptureState();
+
+        new Thread(() -> {
+            Vector<VideoCaptureDevice> devices = getService() != null ?
+                    getService().getVideoCaptureDevices() :
+                    new Vector<>();
+
+            runOnUiThread(() -> {
+                if (isFinishing() || isDestroyed() || refreshToken != webcamRefreshToken || webcamDeviceSpinner == null) {
+                    return;
+                }
+
+                updatingWebcamControls = true;
+                webcamDevices.clear();
+                webcamDevices.addAll(devices);
+
+                ArrayList<String> deviceLabels = new ArrayList<>();
+                String savedDeviceId = prefs.get(Preferences.PREF_VIDEOCAPTURE_DEVICE_ID, "");
+                int selectedDevice = 0;
+                for (int i = 0; i < webcamDevices.size(); i++) {
+                    VideoCaptureDevice device = webcamDevices.get(i);
+                    String label = (device.szDeviceName == null || device.szDeviceName.isEmpty()) ?
+                            getString(R.string.webcam_camera) + " " + (i + 1) :
+                            device.szDeviceName;
+                    deviceLabels.add(label);
+                    if (!savedDeviceId.isEmpty() && savedDeviceId.equals(device.szDeviceID)) {
+                        selectedDevice = i;
+                    }
+                }
+                if (deviceLabels.isEmpty()) {
+                    deviceLabels.add(getString(R.string.webcam_no_cameras));
+                }
+                ArrayAdapter<String> deviceAdapter = new ArrayAdapter<>(
+                        this, android.R.layout.simple_spinner_item, deviceLabels);
+                deviceAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+                webcamDeviceSpinner.setAdapter(deviceAdapter);
+                webcamDeviceSpinner.setSelection(Math.min(selectedDevice, deviceLabels.size() - 1));
+
+                selectSavedVideoBitrate();
+                updateVideoCaptureFormatChoices(prefs.get(Preferences.PREF_VIDEOCAPTURE_FORMAT, ""));
+                webcamControlsLoading = false;
+                updatingWebcamControls = false;
+                updateVideoCaptureState();
+            });
+        }, "tt-webcam-refresh").start();
     }
 
     private void updateVideoCaptureFormatChoices(String selectedFormat) {
@@ -1258,7 +1277,7 @@ private EditText newmsg;
         if (webcamToggleButton == null) {
             return;
         }
-        if (getService() == null) {
+        if (getService() == null || webcamControlsLoading) {
             webcamToggleButton.setEnabled(false);
             webcamDeviceSpinner.setEnabled(false);
             webcamFormatSpinner.setEnabled(false);
@@ -2178,7 +2197,7 @@ private EditText newmsg;
     @Override
     public void onCmdMyselfLoggedIn(int my_userid, UserAccount useraccount) {
         textmsgAdapter.setMyUserID(my_userid);
-        refreshVideoCaptureControls();
+        runOnUiThread(this::refreshVideoCaptureControls);
     }
 
     @Override

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -1108,8 +1108,6 @@ private EditText newmsg;
             }
         });
         webcamToggleButton.setOnClickListener(v -> toggleVideoCaptureTransmission());
-
-        refreshVideoCaptureControls();
         updateVideoCaptureState();
     }
 
@@ -1232,6 +1230,11 @@ private EditText newmsg;
     }
 
     private void toggleVideoCaptureTransmission() {
+        if (webcamDevices.isEmpty() || webcamFormats.isEmpty()) {
+            refreshVideoCaptureControls();
+            return;
+        }
+
         if (getService().isVideoCaptureTransmissionEnabled()) {
             getService().stopVideoCaptureTransmission();
             Toast.makeText(this, R.string.webcam_stopped, Toast.LENGTH_SHORT).show();
@@ -1289,7 +1292,7 @@ private EditText newmsg;
         boolean hasCamera = !webcamDevices.isEmpty();
         boolean hasFormat = !webcamFormats.isEmpty();
         webcamToggleButton.setText(transmitting ? R.string.webcam_stop : R.string.webcam_start);
-        webcamToggleButton.setEnabled(transmitting || (hasCamera && hasFormat));
+        webcamToggleButton.setEnabled(transmitting || !webcamControlsLoading);
         webcamDeviceSpinner.setEnabled(!transmitting && hasCamera);
         webcamFormatSpinner.setEnabled(!transmitting && hasFormat);
         webcamBitrateSpinner.setEnabled(!transmitting);
@@ -2197,7 +2200,6 @@ private EditText newmsg;
     @Override
     public void onCmdMyselfLoggedIn(int my_userid, UserAccount useraccount) {
         textmsgAdapter.setMyUserID(my_userid);
-        runOnUiThread(this::refreshVideoCaptureControls);
     }
 
     @Override

--- a/Client/TeamTalkAndroid/src/main/res/layout/activity_main.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/activity_main.xml
@@ -132,6 +132,48 @@
 	            android:src="@drawable/mic_green" />
 
 	    </GridLayout>
+
+        <LinearLayout
+            android:id="@+id/webcam_controls"
+            android:layout_width="180dp"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_toStartOf="@+id/transmit_voice"
+            android:layout_marginEnd="8dp"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/webcam_status_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/webcam_status_off"
+                android:textAppearance="?android:attr/textAppearanceSmall" />
+
+            <Spinner
+                android:id="@+id/webcam_device_spinner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/webcam_camera" />
+
+            <Spinner
+                android:id="@+id/webcam_format_spinner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/webcam_quality" />
+
+            <Spinner
+                android:id="@+id/webcam_bitrate_spinner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/webcam_bitrate" />
+
+            <Button
+                android:id="@+id/webcam_toggle_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/webcam_start" />
+
+        </LinearLayout>
 	    
 	    <Button
 	        android:id="@+id/transmit_voice"

--- a/Client/TeamTalkAndroid/src/main/res/layout/fragment_main_media.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/fragment_main_media.xml
@@ -4,51 +4,10 @@
     android:layout_height="match_parent"
     android:orientation="vertical" >
 
-    <LinearLayout
-        android:id="@+id/webcam_controls"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:padding="8dp">
-
-        <TextView
-            android:id="@+id/webcam_status_text"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/webcam_status_off"
-            android:textAppearance="?android:attr/textAppearanceSmall" />
-
-        <Spinner
-            android:id="@+id/webcam_device_spinner"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:contentDescription="@string/webcam_camera" />
-
-        <Spinner
-            android:id="@+id/webcam_format_spinner"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:contentDescription="@string/webcam_quality" />
-
-        <Spinner
-            android:id="@+id/webcam_bitrate_spinner"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:contentDescription="@string/webcam_bitrate" />
-
-        <Button
-            android:id="@+id/webcam_toggle_button"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/webcam_start" />
-
-    </LinearLayout>
-
     <ExpandableListView
         android:id="@+id/media_elist_view"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1" >
+        android:layout_height="match_parent" >
     </ExpandableListView>
 
 

--- a/Client/TeamTalkAndroid/src/main/res/layout/fragment_main_media.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/fragment_main_media.xml
@@ -4,10 +4,51 @@
     android:layout_height="match_parent"
     android:orientation="vertical" >
 
+    <LinearLayout
+        android:id="@+id/webcam_controls"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="8dp">
+
+        <TextView
+            android:id="@+id/webcam_status_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/webcam_status_off"
+            android:textAppearance="?android:attr/textAppearanceSmall" />
+
+        <Spinner
+            android:id="@+id/webcam_device_spinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/webcam_camera" />
+
+        <Spinner
+            android:id="@+id/webcam_format_spinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/webcam_quality" />
+
+        <Spinner
+            android:id="@+id/webcam_bitrate_spinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/webcam_bitrate" />
+
+        <Button
+            android:id="@+id/webcam_toggle_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/webcam_start" />
+
+    </LinearLayout>
+
     <ExpandableListView
         android:id="@+id/media_elist_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" >
+        android:layout_height="0dp"
+        android:layout_weight="1" >
     </ExpandableListView>
 
 

--- a/Client/TeamTalkAndroid/src/main/res/values/strings.xml
+++ b/Client/TeamTalkAndroid/src/main/res/values/strings.xml
@@ -417,8 +417,22 @@
     <string name="text_desktop_session">Desktop session</string>
     <string name="text_webcam_session">Webcam session</string>
     <string name="text_mediafile_session">Media file session</string>
+    <string name="webcam_bitrate">Webcam bitrate</string>
+    <string name="webcam_camera">Webcam camera</string>
+    <string name="webcam_no_cameras">No cameras found</string>
+    <string name="webcam_no_formats">No camera formats found</string>
+    <string name="webcam_quality">Webcam quality</string>
+    <string name="webcam_start">Start webcam</string>
+    <string name="webcam_start_failed">Failed to start webcam transmission</string>
+    <string name="webcam_status_off">Webcam is off</string>
+    <string name="webcam_status_ready">Select webcam settings and start transmission</string>
+    <string name="webcam_status_transmitting">Webcam is transmitting</string>
+    <string name="webcam_stop">Stop webcam</string>
+    <string name="webcam_stopped">Webcam transmission stopped</string>
+    <string name="webcam_transmit_right_missing">This account cannot transmit webcam video on this server</string>
 
     <string name="permission_audioinput">Audio recording and playback will be unavailable</string>
+    <string name="permission_camera">Webcam transmission will be unavailable</string>
     <string name="permission_audiomodify">Audio recording and playback will be unavailable</string>
     <string name="permission_filerx">Download files will be unavailable</string>
     <string name="permission_filetx">Upload and importing files will be unavailable</string>


### PR DESCRIPTION
This adds Android webcam transmission controls to the official client.

Changes included:
- add camera permissions and optional camera feature declarations
- add foreground service camera support for webcam transmission
- add webcam controls in the Media Streams tab
- add camera, format, and bitrate selection
- add start and stop webcam transmission through the TeamTalk SDK
- persist the selected webcam settings between sessions

Local verification:
- `gradlew.bat assembleDebug` completed successfully for `Client/TeamTalkAndroid`