### PR TITLE
Add Android status mode controls

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -430,11 +430,11 @@ extends AppCompatActivity
                 TeamTalkConstants.STATUSMODE_AWAY,
                 TeamTalkConstants.STATUSMODE_QUESTION
         };
-        final int[] checkedItem = {0};
+        int checkedItem = 0;
         int currentMode = myself.nStatusMode & TeamTalkConstants.STATUSMODE_MODE;
         for (int i = 0; i < modeValues.length; i++) {
             if (modeValues[i] == currentMode) {
-                checkedItem[0] = i;
+                checkedItem = i;
                 break;
             }
         }
@@ -488,25 +488,21 @@ extends AppCompatActivity
         questionButton.setText(R.string.status_mode_question);
         modeGroup.addView(questionButton);
 
-        modeGroup.check(modeGroup.getChildAt(checkedItem[0]).getId());
-        modeGroup.setOnCheckedChangeListener((group, checkedId) -> {
-            for (int i = 0; i < group.getChildCount(); i++) {
-                if (group.getChildAt(i).getId() == checkedId) {
-                    checkedItem[0] = i;
-                    break;
-                }
-            }
-        });
+        modeGroup.check(modeGroup.getChildAt(checkedItem).getId());
         layout.addView(modeGroup);
 
         new AlertDialog.Builder(this)
                 .setTitle(R.string.action_statusnick)
                 .setView(layout)
-                .setPositiveButton(android.R.string.ok, (dialog, which) ->
+                .setPositiveButton(android.R.string.ok, (dialog, which) -> {
+                    int selectedIndex = modeGroup.indexOfChild(
+                            modeGroup.findViewById(modeGroup.getCheckedRadioButtonId()));
+
                         applyNicknameStatusChange(
                                 nicknameInput.getText().toString(),
-                                modeValues[checkedItem[0]],
-                                statusMessageInput.getText().toString()))
+                                modeValues[selectedIndex],
+                                statusMessageInput.getText().toString());
+                })
                 .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -500,7 +500,7 @@ extends AppCompatActivity
         layout.addView(modeGroup);
 
         new AlertDialog.Builder(this)
-                .setTitle(R.string.action_status)
+                .setTitle(R.string.action_statusnick)
                 .setView(layout)
                 .setPositiveButton(android.R.string.ok, (dialog, which) ->
                         applyNicknameStatusChange(

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -31,6 +31,7 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.graphics.Color;
 import android.hardware.Sensor;
@@ -47,6 +48,7 @@ import android.os.Bundle;
 import android.os.CountDownTimer;
 import android.os.PowerManager;
 import android.os.PowerManager.WakeLock;
+import android.text.TextUtils;
 import android.os.Vibrator;
 import android.provider.OpenableColumns;
 import android.text.InputType;
@@ -73,9 +75,12 @@ import android.widget.EditText;
 import android.widget.ExpandableListView;
 import android.widget.ImageButton;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.PopupMenu;
 import android.widget.PopupMenu.OnMenuItemClickListener;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
 import android.widget.SeekBar;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -172,6 +177,7 @@ extends AppCompatActivity
     TabLayout mTabLayout;
 
     public static final String TAG = "bearware";
+    private static final String SERVERLIST_NAME = "serverlist";
 
     private static final String MSG_NOTIFICATION_CHANNEL_ID = "TT_PM";
 
@@ -378,6 +384,8 @@ extends AppCompatActivity
         } else if (itemId == R.id.action_settings) {
             Intent intent = new Intent(MainActivity.this, PreferencesActivity.class);
             startActivity(intent);
+        } else if (itemId == R.id.action_status) {
+            showChangeStatusDialog();
         } else if (itemId == R.id.action_online_users) {
             Intent intent = new Intent(MainActivity.this, OnlineUsersActivity.class);
             startActivity(intent);
@@ -410,6 +418,140 @@ extends AppCompatActivity
             return super.onOptionsItemSelected(item);
         }
         return true;
+    }
+
+    private void showChangeStatusDialog() {
+        User myself = getService().getUsers().get(getClient().getMyUserID());
+        if (myself == null) {
+            Toast.makeText(this, R.string.text_con_cmderr, Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        final int[] modeValues = {
+                TeamTalkConstants.STATUSMODE_AVAILABLE,
+                TeamTalkConstants.STATUSMODE_AWAY,
+                TeamTalkConstants.STATUSMODE_QUESTION
+        };
+        final int[] checkedItem = {0};
+        int currentMode = myself.nStatusMode & TeamTalkConstants.STATUSMODE_MODE;
+        for (int i = 0; i < modeValues.length; i++) {
+            if (modeValues[i] == currentMode) {
+                checkedItem[0] = i;
+                break;
+            }
+        }
+
+        LinearLayout layout = new LinearLayout(this);
+        layout.setOrientation(LinearLayout.VERTICAL);
+        int padding = (int) (getResources().getDisplayMetrics().density * 20);
+        layout.setPadding(padding, padding / 2, padding, 0);
+
+        TextView modeLabel = new TextView(this);
+        modeLabel.setText(R.string.text_status_mode);
+        layout.addView(modeLabel);
+
+        RadioGroup modeGroup = new RadioGroup(this);
+        modeGroup.setOrientation(RadioGroup.VERTICAL);
+
+        RadioButton availableButton = new RadioButton(this);
+        availableButton.setId(View.generateViewId());
+        availableButton.setText(R.string.status_mode_available);
+        modeGroup.addView(availableButton);
+
+        RadioButton awayButton = new RadioButton(this);
+        awayButton.setId(View.generateViewId());
+        awayButton.setText(R.string.status_mode_away);
+        modeGroup.addView(awayButton);
+
+        RadioButton questionButton = new RadioButton(this);
+        questionButton.setId(View.generateViewId());
+        questionButton.setText(R.string.status_mode_question);
+        modeGroup.addView(questionButton);
+
+        modeGroup.check(modeGroup.getChildAt(checkedItem[0]).getId());
+        modeGroup.setOnCheckedChangeListener((group, checkedId) -> {
+            for (int i = 0; i < group.getChildCount(); i++) {
+                if (group.getChildAt(i).getId() == checkedId) {
+                    checkedItem[0] = i;
+                    break;
+                }
+            }
+        });
+        layout.addView(modeGroup);
+
+        TextView messageLabel = new TextView(this);
+        messageLabel.setText(R.string.text_status_message);
+        layout.addView(messageLabel);
+
+        EditText statusMessageInput = new EditText(this);
+        statusMessageInput.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES);
+        statusMessageInput.setSingleLine();
+        statusMessageInput.setText(getCurrentStatusMessage(myself));
+        statusMessageInput.setSelection(statusMessageInput.getText().length());
+        layout.addView(statusMessageInput);
+
+        new AlertDialog.Builder(this)
+                .setTitle(R.string.action_status)
+                .setView(layout)
+                .setPositiveButton(android.R.string.ok, (dialog, which) ->
+                        applyStatusChange(modeValues[checkedItem[0]], statusMessageInput.getText().toString()))
+                .setNegativeButton(android.R.string.cancel, null)
+                .show();
+    }
+
+    private String getCurrentStatusMessage(User myself) {
+        if (myself != null && !TextUtils.isEmpty(myself.szStatusMsg))
+            return myself.szStatusMsg;
+
+        ServerEntry serverEntry = getService().getServerEntry();
+        if (serverEntry != null && !TextUtils.isEmpty(serverEntry.statusmsg))
+            return serverEntry.statusmsg;
+
+        return prefs.get(Preferences.PREF_GENERAL_STATUSMSG, "");
+    }
+
+    private void applyStatusChange(int mode, String statusMessage) {
+        User myself = getService().getUsers().get(getClient().getMyUserID());
+        if (myself == null)
+            return;
+
+        int statusMode = (myself.nStatusMode & ~TeamTalkConstants.STATUSMODE_MODE) | mode;
+        getClient().doChangeStatus(statusMode, statusMessage);
+        updateCurrentServerStatusMessage(statusMessage);
+    }
+
+    private void updateCurrentServerStatusMessage(String statusMessage) {
+        ServerEntry serverEntry = getService().getServerEntry();
+        if (serverEntry == null)
+            return;
+
+        serverEntry.statusmsg = statusMessage;
+        getService().setServerEntry(serverEntry);
+
+        if (serverEntry.servertype == ServerEntry.ServerType.LOCAL)
+            persistLocalServerStatusMessage(serverEntry);
+    }
+
+    private void persistLocalServerStatusMessage(ServerEntry serverEntry) {
+        SharedPreferences pref = getSharedPreferences(SERVERLIST_NAME, MODE_PRIVATE);
+        SharedPreferences.Editor edit = pref.edit();
+        int index = 0;
+        while (!pref.getString(index + ServerEntry.KEY_SERVERNAME, "").isEmpty()) {
+            if (serverEntryMatches(pref, index, serverEntry)) {
+                edit.putString(index + ServerEntry.KEY_STATUSMSG, serverEntry.statusmsg);
+                edit.apply();
+                return;
+            }
+            index++;
+        }
+    }
+
+    private boolean serverEntryMatches(SharedPreferences pref, int index, ServerEntry serverEntry) {
+        return TextUtils.equals(pref.getString(index + ServerEntry.KEY_SERVERNAME, ""), serverEntry.servername) &&
+                TextUtils.equals(pref.getString(index + ServerEntry.KEY_IPADDR, ""), serverEntry.ipaddr) &&
+                pref.getInt(index + ServerEntry.KEY_TCPPORT, 0) == serverEntry.tcpport &&
+                pref.getInt(index + ServerEntry.KEY_UDPPORT, 0) == serverEntry.udpport &&
+                TextUtils.equals(pref.getString(index + ServerEntry.KEY_USERNAME, ""), serverEntry.username);
     }
 
     @Override

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -177,8 +177,6 @@ extends AppCompatActivity
     TabLayout mTabLayout;
 
     public static final String TAG = "bearware";
-    private static final String SERVERLIST_NAME = "serverlist";
-
     private static final String MSG_NOTIFICATION_CHANNEL_ID = "TT_PM";
 
     public final int REQUEST_EDITCHANNEL = 1,
@@ -385,7 +383,7 @@ extends AppCompatActivity
             Intent intent = new Intent(MainActivity.this, PreferencesActivity.class);
             startActivity(intent);
         } else if (itemId == R.id.action_status) {
-            showChangeStatusDialog();
+            showChangeNicknameStatusDialog();
         } else if (itemId == R.id.action_online_users) {
             Intent intent = new Intent(MainActivity.this, OnlineUsersActivity.class);
             startActivity(intent);
@@ -420,7 +418,7 @@ extends AppCompatActivity
         return true;
     }
 
-    private void showChangeStatusDialog() {
+    private void showChangeNicknameStatusDialog() {
         User myself = getService().getUsers().get(getClient().getMyUserID());
         if (myself == null) {
             Toast.makeText(this, R.string.text_con_cmderr, Toast.LENGTH_SHORT).show();
@@ -445,6 +443,28 @@ extends AppCompatActivity
         layout.setOrientation(LinearLayout.VERTICAL);
         int padding = (int) (getResources().getDisplayMetrics().density * 20);
         layout.setPadding(padding, padding / 2, padding, 0);
+
+        TextView nicknameLabel = new TextView(this);
+        nicknameLabel.setText(R.string.pref_title_nickname);
+        layout.addView(nicknameLabel);
+
+        EditText nicknameInput = new EditText(this);
+        nicknameInput.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES);
+        nicknameInput.setSingleLine();
+        nicknameInput.setText(getCurrentNickname(myself));
+        nicknameInput.setSelection(nicknameInput.getText().length());
+        layout.addView(nicknameInput);
+
+        TextView messageLabel = new TextView(this);
+        messageLabel.setText(R.string.text_status_message);
+        layout.addView(messageLabel);
+
+        EditText statusMessageInput = new EditText(this);
+        statusMessageInput.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES);
+        statusMessageInput.setSingleLine();
+        statusMessageInput.setText(getCurrentStatusMessage(myself));
+        statusMessageInput.setSelection(statusMessageInput.getText().length());
+        layout.addView(statusMessageInput);
 
         TextView modeLabel = new TextView(this);
         modeLabel.setText(R.string.text_status_mode);
@@ -479,79 +499,62 @@ extends AppCompatActivity
         });
         layout.addView(modeGroup);
 
-        TextView messageLabel = new TextView(this);
-        messageLabel.setText(R.string.text_status_message);
-        layout.addView(messageLabel);
-
-        EditText statusMessageInput = new EditText(this);
-        statusMessageInput.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES);
-        statusMessageInput.setSingleLine();
-        statusMessageInput.setText(getCurrentStatusMessage(myself));
-        statusMessageInput.setSelection(statusMessageInput.getText().length());
-        layout.addView(statusMessageInput);
-
         new AlertDialog.Builder(this)
                 .setTitle(R.string.action_status)
                 .setView(layout)
                 .setPositiveButton(android.R.string.ok, (dialog, which) ->
-                        applyStatusChange(modeValues[checkedItem[0]], statusMessageInput.getText().toString()))
+                        applyNicknameStatusChange(
+                                nicknameInput.getText().toString(),
+                                modeValues[checkedItem[0]],
+                                statusMessageInput.getText().toString()))
                 .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }
 
-    private String getCurrentStatusMessage(User myself) {
-        if (myself != null && !TextUtils.isEmpty(myself.szStatusMsg))
-            return myself.szStatusMsg;
+    private String getCurrentNickname(User myself) {
+        ServerEntry serverEntry = getService().getServerEntry();
+        if (serverEntry != null && !TextUtils.isEmpty(serverEntry.nickname))
+            return serverEntry.nickname;
 
+        if (myself != null && !TextUtils.isEmpty(myself.szNickname))
+            return myself.szNickname;
+
+        return prefs.get(Preferences.PREF_GENERAL_NICKNAME, "");
+    }
+
+    private String getCurrentStatusMessage(User myself) {
         ServerEntry serverEntry = getService().getServerEntry();
         if (serverEntry != null && !TextUtils.isEmpty(serverEntry.statusmsg))
             return serverEntry.statusmsg;
 
+        if (myself != null && !TextUtils.isEmpty(myself.szStatusMsg))
+            return myself.szStatusMsg;
+
         return prefs.get(Preferences.PREF_GENERAL_STATUSMSG, "");
     }
 
-    private void applyStatusChange(int mode, String statusMessage) {
+    private void applyNicknameStatusChange(String nickname, int mode, String statusMessage) {
         User myself = getService().getUsers().get(getClient().getMyUserID());
         if (myself == null)
             return;
 
+        updateCurrentServerEntry(nickname, statusMessage);
+
+        if (!TextUtils.equals(nickname, myself.szNickname))
+            getClient().doChangeNickname(nickname);
+
         int statusMode = (myself.nStatusMode & ~TeamTalkConstants.STATUSMODE_MODE) | mode;
         getClient().doChangeStatus(statusMode, statusMessage);
-        updateCurrentServerStatusMessage(statusMessage);
     }
 
-    private void updateCurrentServerStatusMessage(String statusMessage) {
+    private void updateCurrentServerEntry(String nickname, String statusMessage) {
         ServerEntry serverEntry = getService().getServerEntry();
         if (serverEntry == null)
             return;
 
+        serverEntry.nickname = nickname;
         serverEntry.statusmsg = statusMessage;
         getService().setServerEntry(serverEntry);
-
-        if (serverEntry.servertype == ServerEntry.ServerType.LOCAL)
-            persistLocalServerStatusMessage(serverEntry);
-    }
-
-    private void persistLocalServerStatusMessage(ServerEntry serverEntry) {
-        SharedPreferences pref = getSharedPreferences(SERVERLIST_NAME, MODE_PRIVATE);
-        SharedPreferences.Editor edit = pref.edit();
-        int index = 0;
-        while (!pref.getString(index + ServerEntry.KEY_SERVERNAME, "").isEmpty()) {
-            if (serverEntryMatches(pref, index, serverEntry)) {
-                edit.putString(index + ServerEntry.KEY_STATUSMSG, serverEntry.statusmsg);
-                edit.apply();
-                return;
-            }
-            index++;
-        }
-    }
-
-    private boolean serverEntryMatches(SharedPreferences pref, int index, ServerEntry serverEntry) {
-        return TextUtils.equals(pref.getString(index + ServerEntry.KEY_SERVERNAME, ""), serverEntry.servername) &&
-                TextUtils.equals(pref.getString(index + ServerEntry.KEY_IPADDR, ""), serverEntry.ipaddr) &&
-                pref.getInt(index + ServerEntry.KEY_TCPPORT, 0) == serverEntry.tcpport &&
-                pref.getInt(index + ServerEntry.KEY_UDPPORT, 0) == serverEntry.udpport &&
-                TextUtils.equals(pref.getString(index + ServerEntry.KEY_USERNAME, ""), serverEntry.username);
     }
 
     @Override

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -382,7 +382,7 @@ extends AppCompatActivity
         } else if (itemId == R.id.action_settings) {
             Intent intent = new Intent(MainActivity.this, PreferencesActivity.class);
             startActivity(intent);
-        } else if (itemId == R.id.action_status) {
+        } else if (itemId == R.id.action_statusnick) {
             showChangeNicknameStatusDialog();
         } else if (itemId == R.id.action_online_users) {
             Intent intent = new Intent(MainActivity.this, OnlineUsersActivity.class);
@@ -515,22 +515,14 @@ extends AppCompatActivity
         ServerEntry serverEntry = getService().getServerEntry();
         if (serverEntry != null && !TextUtils.isEmpty(serverEntry.nickname))
             return serverEntry.nickname;
-
-        if (myself != null && !TextUtils.isEmpty(myself.szNickname))
-            return myself.szNickname;
-
-        return prefs.get(Preferences.PREF_GENERAL_NICKNAME, "");
+        return "";
     }
 
     private String getCurrentStatusMessage(User myself) {
         ServerEntry serverEntry = getService().getServerEntry();
         if (serverEntry != null && !TextUtils.isEmpty(serverEntry.statusmsg))
             return serverEntry.statusmsg;
-
-        if (myself != null && !TextUtils.isEmpty(myself.szStatusMsg))
-            return myself.szStatusMsg;
-
-        return prefs.get(Preferences.PREF_GENERAL_STATUSMSG, "");
+        return "";
     }
 
     private void applyNicknameStatusChange(String nickname, int mode, String statusMessage) {

--- a/Client/TeamTalkAndroid/src/main/res/menu/main.xml
+++ b/Client/TeamTalkAndroid/src/main/res/menu/main.xml
@@ -12,7 +12,7 @@
         android:id="@+id/action_statusnick"
         android:orderInCategory="101"
         app:showAsAction="never"
-        android:title="@string/action_status"/>
+        android:title="@string/action_statusnick"/>
 
     <item
         android:id="@+id/action_newchannel"

--- a/Client/TeamTalkAndroid/src/main/res/menu/main.xml
+++ b/Client/TeamTalkAndroid/src/main/res/menu/main.xml
@@ -9,7 +9,7 @@
         android:title="@string/action_settings"/>
 
     <item
-        android:id="@+id/action_status"
+        android:id="@+id/action_statusnick"
         android:orderInCategory="101"
         app:showAsAction="never"
         android:title="@string/action_status"/>

--- a/Client/TeamTalkAndroid/src/main/res/menu/main.xml
+++ b/Client/TeamTalkAndroid/src/main/res/menu/main.xml
@@ -9,6 +9,12 @@
         android:title="@string/action_settings"/>
 
     <item
+        android:id="@+id/action_status"
+        android:orderInCategory="101"
+        app:showAsAction="never"
+        android:title="@string/action_status"/>
+
+    <item
         android:id="@+id/action_newchannel"
         app:showAsAction="ifRoom|withText"
         android:title="@string/action_new_channel"/>

--- a/Client/TeamTalkAndroid/src/main/res/values/strings.xml
+++ b/Client/TeamTalkAndroid/src/main/res/values/strings.xml
@@ -225,6 +225,7 @@
     <string name="action_upload">Upload File</string>
     <string name="action_broadcast">Broadcast Message</string>
     <string name="action_stream">Stream a media file</string>
+    <string name="action_status">Change Status</string>
     <string name="button_select_media_file">Browse</string>
     <string name="button_stream_media_file">Stream</string>
     <string name="button_msg">Message</string>
@@ -488,6 +489,11 @@
     <string name="action_revoke_operator">Revoke Operator</string>
     <string name="text_operator_password">Enter channel operator password</string>
     <string name="text_broadcast_message">Enter broadcast message</string>
+    <string name="text_status_message">Status message</string>
+    <string name="text_status_mode">Status mode</string>
+    <string name="status_mode_available">Available</string>
+    <string name="status_mode_away">Away</string>
+    <string name="status_mode_question">Question</string>
     <string name="online_users">Online Users</string>
 
 

--- a/Client/TeamTalkAndroid/src/main/res/values/strings.xml
+++ b/Client/TeamTalkAndroid/src/main/res/values/strings.xml
@@ -225,7 +225,7 @@
     <string name="action_upload">Upload File</string>
     <string name="action_broadcast">Broadcast Message</string>
     <string name="action_stream">Stream a media file</string>
-    <string name="action_status">Change Nickname and Status</string>
+    <string name="action_statusnick">Change Nickname and Status</string>
     <string name="button_select_media_file">Browse</string>
     <string name="button_stream_media_file">Stream</string>
     <string name="button_msg">Message</string>

--- a/Client/TeamTalkAndroid/src/main/res/values/strings.xml
+++ b/Client/TeamTalkAndroid/src/main/res/values/strings.xml
@@ -225,7 +225,7 @@
     <string name="action_upload">Upload File</string>
     <string name="action_broadcast">Broadcast Message</string>
     <string name="action_stream">Stream a media file</string>
-    <string name="action_status">Change Status</string>
+    <string name="action_status">Change Nickname and Status</string>
     <string name="button_select_media_file">Browse</string>
     <string name="button_stream_media_file">Stream</string>
     <string name="button_msg">Message</string>


### PR DESCRIPTION
This adds status mode controls to the Android client after connecting to a server.

Changes included:
- add a Change Status action to the main menu
- add Available, Away, and Question status mode selection
- allow editing the current status message from the same dialog
- keep the current server entry status message in sync when it is changed

Local verification:
- `gradlew.bat assembleDebug` completed successfully for `Client/TeamTalkAndroid`