### PR TITLE
Fix Android instrumented tests for JUnit 5 migration

### DIFF
--- a/Client/TeamTalkAndroid/build.gradle
+++ b/Client/TeamTalkAndroid/build.gradle
@@ -87,6 +87,11 @@ android {
         jniLibs {
             excludes += ['**/libTeamTalk5Pro-jni.so']
         }
+        pickFirsts = [
+                // Ignore duplicate files in junit-platform-commons-1.9.3.jar and junit-jupiter-api-5.9.3.jar
+                'META-INF/LICENSE.md',
+                'META-INF/LICENSE-notice.md'
+        ]
     }
 
     lint {
@@ -118,11 +123,12 @@ dependencies {
     implementation libs.material
     implementation files('../../Library/TeamTalkJNI/libs/TeamTalk5.jar')
 
-    testImplementation libs.junit
+    testImplementation libs.junit.jupiter.api
     testImplementation files('../../Library/TeamTalkJNI/libs/TeamTalk5Test.jar')
 
     androidTestImplementation libs.androidx.test.core
     androidTestImplementation libs.androidx.test.runner
     androidTestImplementation libs.androidx.test.rules
+    androidTestImplementation libs.junit.jupiter.api
     androidTestImplementation files('../../Library/TeamTalkJNI/libs/TeamTalk5Test.jar')
 }

--- a/Client/TeamTalkAndroid/gradle/libs.versions.toml
+++ b/Client/TeamTalkAndroid/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ media = "1.8.0"
 preference = "1.2.1"
 viewpager = "1.1.0"
 material = "1.14.0"
-junit = "4.13.2"
+junitJupiter = "5.9.3"
 testCore = "1.7.0"
 testRunner = "1.7.0"
 testRules = "1.7.0"
@@ -26,7 +26,7 @@ androidx-media = { group = "androidx.media", name = "media", version.ref = "medi
 androidx-preference = { group = "androidx.preference", name = "preference", version.ref = "preference" }
 androidx-viewpager = { group = "androidx.viewpager", name = "viewpager", version.ref = "viewpager" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
-junit = { group = "junit", name = "junit", version.ref = "junit" }
+junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junitJupiter" }
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "testCore" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "testRunner" }
 androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "testRules" }

--- a/Client/TeamTalkAndroid/src/androidTest/java/dk/bearware/TeamTalkAndroidOnlyTest.java
+++ b/Client/TeamTalkAndroid/src/androidTest/java/dk/bearware/TeamTalkAndroidOnlyTest.java
@@ -29,10 +29,12 @@ import androidx.test.rule.GrantPermissionRule;
 
 import org.junit.Rule;
 import org.junit.Test;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.Before;
+import org.junit.After;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.util.Vector;
@@ -58,6 +60,7 @@ public class TeamTalkAndroidOnlyTest extends TeamTalkTestCaseBase {
             Manifest.permission.WAKE_LOCK,
             Manifest.permission.READ_PHONE_STATE);
 
+    @Before
     public void setUp() throws Exception {
         ADMIN_USERNAME = "admin";
         ADMIN_PASSWORD = "admin";
@@ -73,6 +76,11 @@ public class TeamTalkAndroidOnlyTest extends TeamTalkTestCaseBase {
 
         File filepath = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
         STORAGEFOLDER = filepath.toString();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
     }
 
     @Test
@@ -427,7 +435,7 @@ public class TeamTalkAndroidOnlyTest extends TeamTalkTestCaseBase {
             waitForEvent(simclients.elementAt(0), ClientEvent.CLIENTEVENT_NONE, 5000);
 
             for (TeamTalkBase ttclient : clients) {
-                assertFalse("No snd input error", waitForEvent(ttclient, ClientEvent.CLIENTEVENT_INTERNAL_ERROR, 0));
+                assertFalse(waitForEvent(ttclient, ClientEvent.CLIENTEVENT_INTERNAL_ERROR, 0), "No snd input error");
             }
         }
     }


### PR DESCRIPTION
The JUnit 5 migration changed the shared TeamTalkTestCaseBase to Jupiter but left the Android instrumented test broken: assert calls used the JUnit 5 argument order while still importing JUnit 4 Assert, the setUp() lifecycle annotation was dropped, and Jupiter was absent from the androidTest runtime classpath.

- Switch TeamTalkAndroidOnlyTest asserts to org.junit.jupiter.api.Assertions
- Restore lifecycle with @Before setUp()/@After tearDown()
- Fix leftover JUnit 4 argument order on one assertFalse
- Add junit-jupiter-api 5.9.3 to test/androidTest classpath