### PR TITLE
Fix chat jumping bug by switching to smart scrolling

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -1078,7 +1078,7 @@ private EditText newmsg;
                 return false;
             });
             ListView chatlog = rootView.findViewById(R.id.channel_im_listview);
-            chatlog.setTranscriptMode(ListView.TRANSCRIPT_MODE_ALWAYS_SCROLL);
+            chatlog.setTranscriptMode(ListView.TRANSCRIPT_MODE_NORMAL);
             chatlog.setAdapter(mainActivity.getTextMessagesAdapter());
 
             Button sendBtn = rootView.findViewById(R.id.channel_im_sendbtn);

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/TextMessageActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/TextMessageActivity.java
@@ -143,7 +143,7 @@ extends AppCompatActivity implements TeamTalkConnectionListener, ClientEventList
                                          ttclient.getMyUserID());
         
         ListView lv = findViewById(R.id.user_im_listview);
-        lv.setTranscriptMode(ListView.TRANSCRIPT_MODE_ALWAYS_SCROLL);
+        lv.setTranscriptMode(ListView.TRANSCRIPT_MODE_NORMAL);
         lv.setAdapter(adapter);
         adapter.notifyDataSetChanged();
         


### PR DESCRIPTION
Previously, the chat would always scroll to the bottom even if the user was reading old messages. It is now smart: if the user is at the bottom of the list, it scrolls automatically for a smooth conversation. If the user has scrolled back to read the old history, the view will not jump, ensuring they don't lose their focus.