### PR TITLE
keyboard navigation accessibility fix. Stop using Qt's Fusion style for dark Color

### DIFF
--- a/Client/qtTeamTalk/main.cpp
+++ b/Client/qtTeamTalk/main.cpp
@@ -25,7 +25,6 @@
 #include <QFileOpenEvent>
 #include <QPalette>
 #include <QSettings>
-#include <QStyleFactory>
 #include <QUrl>
 #include <QtPlugin>
 
@@ -51,7 +50,6 @@ public:
         QSettings settings("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize", QSettings::NativeFormat);
         if (settings.value("AppsUseLightTheme", -1).toUInt() == 0)
         {
-            setStyle(QStyleFactory::create("Fusion"));
             QPalette darkPalette;
             QColor darkColor = QColor(45, 45, 45);
             QColor disabledColor = QColor(127, 127, 127);


### PR DESCRIPTION
I was fasing an accessibility navigation bug for months, And I couldn't find the reason.
Last night, I stayed awake the entire night and made and debugged a sample qt test application, and finally I got the bug cause.
when Qt's Fusion style is active and being used, every disabled menu items in menus/context menus ( disabled grade out QActions) would not receave focus and skipped for screen readers during keyboard navigation with up and down arrow keys.
Currently, If We set windows Color to light from windows settings and open teamtalk, this bug will be solved and every item would receave focus properly during keyboard navigation
when windows Color is set to dark in windows settings, Qt's Fusion style will be activated for teamtalk, And cause this accessibility bug.
So, Fixed it by stop using Qt's Fusion style on dark Color
This bug is for Qt's Fusion style, and I've reported it to Qt, so they will fix it, so that layter Qt's Fusion style won't cause this annoying bug anymore, So that anyone doesn't have to try to hunt the bug for months.