### PR TITLE
Reject negative ban list ranges

### DIFF
--- a/Library/TeamTalkJNI/test/dk/bearware/TeamTalkServerTestCase.java
+++ b/Library/TeamTalkJNI/test/dk/bearware/TeamTalkServerTestCase.java
@@ -587,6 +587,29 @@ public class TeamTalkServerTestCase extends TeamTalkTestCaseBase {
     }
 
     @Test
+    public void testListBansInvalidRange() {
+
+        TeamTalkSrv server = newServerInstance();
+        TeamTalkBase client = newClientInstance();
+
+        ServerInterleave interleave = new RunServer(server);
+        connect(server, client);
+        login(server, client, getTestMethodName(), ADMIN_USERNAME, ADMIN_PASSWORD);
+
+        TTMessage msg = new TTMessage();
+        int cmdid = client.doListBans(0, -1, 1);
+        assertTrue(waitCmdError(client, cmdid, DEF_WAIT, msg, interleave), "negative ban index");
+        assertEquals(ClientError.CMDERR_SYNTAX_ERROR, msg.clienterrormsg.nErrorNo, "negative ban index error");
+        assertTrue(waitCmdComplete(client, client.doPing(), DEF_WAIT, interleave), "server responsive after negative ban index");
+
+        cmdid = client.doListBans(0, 0, -1);
+        assertTrue(waitCmdError(client, cmdid, DEF_WAIT, msg, interleave), "negative ban count");
+        assertEquals(ClientError.CMDERR_SYNTAX_ERROR, msg.clienterrormsg.nErrorNo, "negative ban count error");
+        assertTrue(waitCmdSuccess(client, client.doListBans(0, 0, 0), DEF_WAIT, interleave), "zero-length ban list");
+        assertTrue(waitCmdComplete(client, client.doPing(), DEF_WAIT, interleave), "server responsive after invalid ban ranges");
+    }
+
+    @Test
     public void testSystemID() {
         TeamTalkSrv server = newServerInstance("foobar");
 

--- a/Library/TeamTalkLib/teamtalk/server/ServerNode.cpp
+++ b/Library/TeamTalkLib/teamtalk/server/ServerNode.cpp
@@ -3466,9 +3466,6 @@ ErrorMsg ServerNode::UserListServerBans(int userid, int chanid, int index, int c
             return ErrorMsg(TT_CMDERR_NOT_AUTHORIZED);
     }
 
-    if (index < 0 || count < 0)
-        return ErrorMsg(TT_CMDERR_SYNTAX_ERROR);
-
     std::vector<BannedUser> bans;
     if (banchan)
     {

--- a/Library/TeamTalkLib/teamtalk/server/ServerNode.cpp
+++ b/Library/TeamTalkLib/teamtalk/server/ServerNode.cpp
@@ -3466,6 +3466,9 @@ ErrorMsg ServerNode::UserListServerBans(int userid, int chanid, int index, int c
             return ErrorMsg(TT_CMDERR_NOT_AUTHORIZED);
     }
 
+    if (index < 0 || count < 0)
+        return ErrorMsg(TT_CMDERR_SYNTAX_ERROR);
+
     std::vector<BannedUser> bans;
     if (banchan)
     {

--- a/Library/TeamTalkLib/teamtalk/server/ServerUser.cpp
+++ b/Library/TeamTalkLib/teamtalk/server/ServerUser.cpp
@@ -929,6 +929,9 @@ ErrorMsg ServerUser::HandleListServerBans(const mstrings_t& properties)
     GetProperty(properties, TT_INDEX, index);
     GetProperty(properties, TT_COUNT, count);
 
+    if (index < 0 || count < 0)
+        return ErrorMsg(TT_CMDERR_SYNTAX_ERROR);
+
     //ban if admin
     return m_servernode.UserListServerBans(GetUserID(), chanid, index, count);
 }


### PR DESCRIPTION
Hi,

This fixes #3391 by rejecting negative ban-list ranges before the server indexes the ban vector.

The retained crash evidence pointed to a `BannedUser` pointer 232 bytes before the start of the list, and 232 bytes matches `sizeof(BannedUser)`. That is consistent with `nIndex == -1` on an empty ban list. This keeps the existing login, channel and authorization checks first, then returns `TT_CMDERR_SYNTAX_ERROR` for a negative `nIndex` or `nCount`.

I also added an in-process server regression for `doListBans(0, -1, 1)` and `doListBans(0, 0, -1)`. It checks the exact syntax error, confirms `doListBans(0, 0, 0)` still succeeds, and verifies the server remains responsive afterward.

Validation performed:

- Built `TeamTalk5Pro-jni` and `TeamTalk5SrvTest` on Linux.
- Ran `testListBansInvalidRange` 10 times plain and 10 times encrypted.
- Ran `testBanUser` and `testAutoOperatorChannelUpdate` plain and encrypted.
- Ran the in-process server test class excluding one local IPv4/v6 hostname-resolution environment failure: 37/37 passed plain and 37/37 passed encrypted.
- `git diff --check` passed, apart from normal Windows line-ending warnings.

@bear101, could you please review this when you have time?

Thanks for reading!
