### PR TITLE
Reject malformed 12-bit arrays and bounds check desktop block sizes

### DIFF
--- a/Library/TeamTalkLib/teamtalk/PacketLayout.cpp
+++ b/Library/TeamTalkLib/teamtalk/PacketLayout.cpp
@@ -88,7 +88,15 @@ namespace teamtalk
                 target.push_back(v1);
                 i += 2;
             }
-            else assert(0);
+            else
+            {
+                // A single trailing byte cannot hold a 12-bit value. This
+                // branch used to leave 'i' unchanged, so a field length of
+                // 1 modulo 3 looped forever wherever assert() is compiled
+                // out. Stop instead of spinning.
+                assert(0);
+                break;
+            }
         }
     }
 
@@ -96,7 +104,11 @@ namespace teamtalk
                          std::vector<uint16_t>& output)
     {
         uint16_t const field_size = READFIELD_SIZE(ptr);
-        if(field_size == 0u)
+        // Two 12-bit values pack into three bytes, so a valid array ends on a
+        // whole pair or on a two byte tail. One byte left over cannot be
+        // decoded, which makes the field malformed. ReadUInt16Array already
+        // rejects its own bad lengths the same way.
+        if((field_size == 0u) || ((field_size % 3) == 1))
             return false;
         const uint8_t* field_ptr = READFIELD_DATAPTR(ptr);
         ConvertFromUInt12Array(field_ptr, field_size, output);

--- a/Library/TeamTalkLib/teamtalk/PacketLayout.cpp
+++ b/Library/TeamTalkLib/teamtalk/PacketLayout.cpp
@@ -816,12 +816,8 @@ namespace teamtalk
         if(ptr == nullptr)
             return v_frm_sizes;
 
-        uint16_t const length = READFIELD_SIZE(ptr);
-        ptr = READFIELD_DATAPTR(ptr);
-
-        const auto* frm_sizes = ptr;
-
-        ConvertFromUInt12Array(frm_sizes, length, v_frm_sizes);
+        if(!ReadUInt12Array(ptr, FIELDTYPE_ENCFRAMESIZES, v_frm_sizes))
+            v_frm_sizes.clear();
 
         return v_frm_sizes;
     }
@@ -1720,9 +1716,6 @@ namespace teamtalk
         if(blocknums_ptr == nullptr)
             return false;
 
-        uint16_t const blocknums_len = READFIELD_SIZE(blocknums_ptr);
-        blocknums_ptr = READFIELD_DATAPTR(blocknums_ptr);
-
         const uint8_t* blockdata_ptr = FindField(FIELDTYPE_BLOCKS_DATA);
         if(blockdata_ptr == nullptr)
             return false;
@@ -1732,9 +1725,9 @@ namespace teamtalk
 
         
         std::vector<uint16_t> blocks_n_sizes;
-        const auto* blocks_array = blocknums_ptr;
-
-        ConvertFromUInt12Array(blocks_array, blocknums_len, blocks_n_sizes);
+        if(!ReadUInt12Array(blocknums_ptr, FIELDTYPE_BLOCKNUMS_AND_SIZES,
+                            blocks_n_sizes))
+            return false;
 
         assert(blocks_n_sizes.size() % 2 == 0);
         if((blocks_n_sizes.size() % 2) != 0u)
@@ -1752,9 +1745,9 @@ namespace teamtalk
             // already does the same check. byte_pos is uint16_t and can wrap
             // once the declared total passes 65535, so this has to be checked
             // per block rather than on the total afterwards.
-            assert(byte_pos + bb.block_size <= blockdata_len);
             if(byte_pos + bb.block_size > blockdata_len) //buffer overflow check
                 return false;
+            assert(byte_pos + bb.block_size <= blockdata_len);
 
             bb.block_data = reinterpret_cast<const char*>(&blockdata_ptr[byte_pos]);
 
@@ -1808,12 +1801,10 @@ namespace teamtalk
         const uint8_t* info_ptr = FindField(FIELDTYPE_BLOCK_DUP);
         if(info_ptr != nullptr)
         {
-            uint16_t const info_size = READFIELD_SIZE(info_ptr);
-            info_ptr = READFIELD_DATAPTR(info_ptr);
-
-            const auto* u8_info_ptr = info_ptr;
             std::vector<uint16_t> blocknums_single;
-            ConvertFromUInt12Array(u8_info_ptr, info_size, blocknums_single);
+            if(!ReadUInt12Array(info_ptr, FIELDTYPE_BLOCK_DUP,
+                                blocknums_single))
+                return false;
 
             uint16_t block_no = 0xFFF;
             std::set<uint16_t> blocknums;
@@ -1841,12 +1832,10 @@ namespace teamtalk
         info_ptr = FindField(FIELDTYPE_BLOCK_DUP_RANGE);
         if(info_ptr != nullptr)
         {
-            uint16_t const info_size = READFIELD_SIZE(info_ptr);
-            info_ptr = READFIELD_DATAPTR(info_ptr);
-
-            const auto* u8_info_ptr = info_ptr;
             std::vector<uint16_t> blocknums_range;
-            ConvertFromUInt12Array(u8_info_ptr, info_size, blocknums_range);
+            if(!ReadUInt12Array(info_ptr, FIELDTYPE_BLOCK_DUP_RANGE,
+                                blocknums_range))
+                return false;
 
             for(size_t i=0;i<blocknums_range.size();i+=3)
             {

--- a/Library/TeamTalkLib/teamtalk/PacketLayout.cpp
+++ b/Library/TeamTalkLib/teamtalk/PacketLayout.cpp
@@ -100,16 +100,21 @@ namespace teamtalk
         }
     }
 
-    static bool ReadUInt12Array(const uint8_t* ptr, uint8_t  /*field_type*/, 
+    static bool ReadUInt12Array(const uint8_t* ptr, uint8_t field_type,
                          std::vector<uint16_t>& output)
     {
-        uint16_t const field_size = READFIELD_SIZE(ptr);
+        assert(field_type == READFIELD_TYPE(ptr));
+        if (field_type != READFIELD_TYPE(ptr))
+            return false;
+
         // Two 12-bit values pack into three bytes, so a valid array ends on a
         // whole pair or on a two byte tail. One byte left over cannot be
         // decoded, which makes the field malformed. ReadUInt16Array already
         // rejects its own bad lengths the same way.
+        uint16_t const field_size = READFIELD_SIZE(ptr);
         if((field_size == 0u) || ((field_size % 3) == 1))
             return false;
+
         const uint8_t* field_ptr = READFIELD_DATAPTR(ptr);
         ConvertFromUInt12Array(field_ptr, field_size, output);
         return true;
@@ -140,9 +145,13 @@ namespace teamtalk
         out_iovec.push_back(v);
     }
 
-    static bool ReadUInt16Array(const uint8_t* ptr, uint8_t  /*field_type*/, 
+    static bool ReadUInt16Array(const uint8_t* ptr, uint8_t  field_type,
                          std::vector<uint16_t>& output)
     {
+        assert(field_type == READFIELD_TYPE(ptr));
+        if (field_type != READFIELD_TYPE(ptr))
+            return false;
+
         uint16_t const field_size = READFIELD_SIZE(ptr);
         if((field_size == 0u) || ((field_size % 2) != 0))
             return false;
@@ -1747,7 +1756,6 @@ namespace teamtalk
             // per block rather than on the total afterwards.
             if(byte_pos + bb.block_size > blockdata_len) //buffer overflow check
                 return false;
-            assert(byte_pos + bb.block_size <= blockdata_len);
 
             bb.block_data = reinterpret_cast<const char*>(&blockdata_ptr[byte_pos]);
 

--- a/Library/TeamTalkLib/teamtalk/PacketLayout.cpp
+++ b/Library/TeamTalkLib/teamtalk/PacketLayout.cpp
@@ -1744,8 +1744,19 @@ namespace teamtalk
         for(size_t i=0;i<blocks_n_sizes.size();i+=2)
         {
             desktop_block bb;
-            bb.block_data = reinterpret_cast<const char*>(&blockdata_ptr[byte_pos]);
             bb.block_size = blocks_n_sizes[i+1];
+
+            // The declared block sizes come off the wire, so they can add up
+            // to more than the payload actually holds. Without this the block
+            // pointer runs past the receive buffer. GetBlockFragments() below
+            // already does the same check. byte_pos is uint16_t and can wrap
+            // once the declared total passes 65535, so this has to be checked
+            // per block rather than on the total afterwards.
+            assert(byte_pos + bb.block_size <= blockdata_len);
+            if(byte_pos + bb.block_size > blockdata_len) //buffer overflow check
+                return false;
+
+            bb.block_data = reinterpret_cast<const char*>(&blockdata_ptr[byte_pos]);
 
             byte_pos += bb.block_size;
 

--- a/Library/TeamTalkLib/test/CatchDefault.cpp
+++ b/Library/TeamTalkLib/test/CatchDefault.cpp
@@ -36,6 +36,7 @@
 #include "settings/Settings.h"
 #include "teamtalk/Commands.h"
 #include "teamtalk/Common.h"
+#include "teamtalk/PacketLayout.h"
 #include "teamtalk/StreamHandler.h"
 #include "teamtalk/client/AudioMuxer.h"
 #include "teamtalk/client/Client.h"
@@ -120,6 +121,72 @@ public:
 
 /* Known bugs */
 #define TEAMTALK_KNOWN_BUGS 0
+
+static std::vector<char> FlattenPacket(const teamtalk::FieldPacket& packet,
+                                       std::vector<size_t>& offsets)
+{
+    int buffers = 0;
+    const iovec* packet_buffers = packet.GetPacket(buffers);
+    std::vector<char> result;
+    offsets.clear();
+    for(int i = 0; i < buffers; ++i)
+    {
+        offsets.push_back(result.size());
+        const auto* begin = static_cast<const char*>(packet_buffers[i].iov_base);
+        result.insert(result.end(), begin, begin + packet_buffers[i].iov_len);
+    }
+    return result;
+}
+
+TEST_CASE("Reject malformed 12-bit packet arrays", "[packet]")
+{
+    using namespace teamtalk;
+
+    SECTION("one-byte remainder in encoded audio frame sizes")
+    {
+        const char audio[] = {0};
+        AudioPacket packet(PACKET_KIND_VOICE, 1, 2, 3, 4, audio,
+                           sizeof(audio), std::vector<uint16_t>{1});
+        std::vector<size_t> offsets;
+        auto bytes = FlattenPacket(packet, offsets);
+        auto* fields = reinterpret_cast<uint8_t*>(bytes.data()) +
+                       TT_CHANNEL_HEADER_SIZE;
+        auto* frame_sizes = const_cast<uint8_t*>(FINDFIELD_TYPE(
+            fields, AudioPacket::FIELDTYPE_ENCFRAMESIZES,
+            bytes.size() - TT_CHANNEL_HEADER_SIZE));
+        REQUIRE(frame_sizes != nullptr);
+
+        const auto field_offset = static_cast<size_t>(
+            frame_sizes - reinterpret_cast<uint8_t*>(bytes.data()));
+        WRITEFIELD_TYPE(frame_sizes, AudioPacket::FIELDTYPE_ENCFRAMESIZES, 1);
+        bytes.resize(field_offset + FIELDVALUE_PREFIX + 1);
+
+        AudioPacket malformed(bytes.data(), uint16_t(bytes.size()));
+        CHECK(malformed.GetEncodedFrameSizes().empty());
+    }
+
+    SECTION("declared block size exceeds block data")
+    {
+        const char block_data[] = {1, 2};
+        map_block_t input_blocks = {
+            {7, desktop_block{block_data, uint16_t(sizeof(block_data))}}
+        };
+        DesktopPacket packet(1, 2, 3, 51, 20, 0, 0, 1, input_blocks,
+                             block_frags_t{}, mmap_dup_blocks_t{});
+        std::vector<size_t> offsets;
+        auto bytes = FlattenPacket(packet, offsets);
+        REQUIRE(offsets.size() >= 3);
+
+        auto* block_info = reinterpret_cast<uint8_t*>(bytes.data()) + offsets[2];
+        REQUIRE(READFIELD_SIZE(block_info) == 3);
+        SET2_UINT12_PTR(READFIELD_DATAPTR(block_info), 7, 3);
+
+        DesktopPacket malformed(bytes.data(), uint16_t(bytes.size()));
+        map_block_t output_blocks;
+        CHECK_FALSE(malformed.GetBlocks(output_blocks));
+        CHECK(output_blocks.empty());
+    }
+}
 
 TEST_CASE( "Init TT", "" )
 {


### PR DESCRIPTION
Hi,

This fixes both halves of #3395. @Ivankolp found them and the analysis is his.

### What happens

Two 12-bit values pack into three bytes, so a valid array ends either on a whole pair or on a two byte tail. If a field length leaves exactly one byte over, the final `else` in the decode loop is reached and it does not advance `i`:

```cpp
for(uint16_t i=0;i<source_size;)
{
    if(source_size - i >= 3)        { ...; i += 3; }
    else if(source_size - i == 2)   { ...; i += 2; }
    else assert(0);                 // i unchanged
}
```

With `assert()` compiled out, that is an infinite loop.

I pulled the loop out into a standalone file, stubbed the bit unpacking since only the index arithmetic decides termination, and built it without the assert. Before:

```
  length  3 (len % 3 = 0): terminated, 2 values
  length  6 (len % 3 = 0): terminated, 4 values
  length  2 (len % 3 = 2): terminated, 1 values
  length  5 (len % 3 = 2): terminated, 3 values
  length  4 (len % 3 = 1): NO TERMINATION: i stuck at 3, 1 byte remaining, 100M iterations
  length  7 (len % 3 = 1): NO TERMINATION: i stuck at 6, 1 byte remaining, 100M iterations
  length 16 (len % 3 = 1): NO TERMINATION: i stuck at 15, 1 byte remaining, 100M iterations
  length  1 (len % 3 = 1): NO TERMINATION: i stuck at 0, 1 byte remaining, 100M iterations
```

After:

```
  length  3 (len % 3 = 0): terminated, 2 values
  length  6 (len % 3 = 0): terminated, 4 values
  length  2 (len % 3 = 2): terminated, 1 values
  length  5 (len % 3 = 2): terminated, 3 values
  length  4 (len % 3 = 1): terminated, 2 values
  length  7 (len % 3 = 1): terminated, 4 values
  length 16 (len % 3 = 1): terminated, 10 values
  length  1 (len % 3 = 1): terminated, 0 values
```

Valid lengths decode to the same number of values as before, so this does not change good traffic.

### Why not reject everything that is not a multiple of three

The issue suggests `src_len % 3 != 0`. I think that would drop valid packets. An odd number of values legitimately encodes to a two byte tail:

| Values | Bytes | Bytes % 3 |
| --- | --- | --- |
| 1 | 2 | 2 |
| 3 | 5 | 2 |
| 4095 | 6143 | 2 |

The `== 2` branch already handles those. Only a remainder of one is unhandled, so that is all this rejects.

### The change

`ReadUInt12Array` now checks its field length up front, which is what `ReadUInt16Array` already does a few lines below:

```cpp
// ReadUInt16Array, existing
if((field_size == 0u) || ((field_size % 2) != 0))
    return false;

// ReadUInt12Array, added
if((field_size == 0u) || ((field_size % 3) == 1))
    return false;
```

The loop also breaks rather than spinning, since four other call sites reach it without going through `ReadUInt12Array`.

### Second half: the out of bounds read in `GetBlocks`

The block sizes in `FIELDTYPE_BLOCKNUMS_AND_SIZES` come off the wire, and nothing checked them against how much `FIELDTYPE_BLOCKS_DATA` actually holds, so the block pointer walks past the receive buffer.

`GetBlockFragments()` a few lines below already guards this exact thing, so I used the same shape:

```cpp
// GetBlockFragments, existing
assert(byte_pos+bf.frag_size<=data_size);
if(byte_pos+bf.frag_size>data_size) //buffer overflow check
    return false;

// GetBlocks, added
assert(byte_pos + bb.block_size <= blockdata_len);
if(byte_pos + bb.block_size > blockdata_len) //buffer overflow check
    return false;
```

I ran the loop standalone against a few declared size lists before and after:

```
  honest packet
    current : declared total=300, payload=300 -> within bounds
    fixed   : accepted

  one block oversized
    current : declared total=1100, payload=300 -> READS PAST THE BUFFER
    fixed   : rejected, returns false

  sizes far exceed payload
    current : declared total=54464, payload=300 -> READS PAST THE BUFFER
    fixed   : rejected, returns false

  single huge block
    current : declared total=65535, payload=10 -> READS PAST THE BUFFER
    fixed   : rejected, returns false
```

Worth noting the third case. Two blocks of 60000 declare 120000 bytes, but `byte_pos` is `uint16_t` so it wraps to 54464. A check on the total after the loop would miss that, which is why this one is per block.

### On a unit test

You asked for a test on my other issue and that was fair, so I want to be straight about this one. `ConvertFromUInt12Array` and `ReadUInt12Array` are both file-static, so there is no clean seam to call them from `CatchDefault.cpp` without changing their linkage, and a test driving the loop through a hand-built packet would hang rather than fail if it ever ran without this fix.

`GetBlocks` is reachable, so a test for the second half is straightforward if you want one. Say where you would like it and I will add it.

One thing worth noting: `ConvertToUInt12Array` can only ever produce a length that is 0 or 2 more than a multiple of three, so the encoder cannot generate this itself. It has to arrive from outside.

Thanks for reading!
