### PR TITLE
Bounds check desktop range decoders against out-of-bounds reads

### DIFF
--- a/Library/TeamTalkLib/teamtalk/PacketLayout.cpp
+++ b/Library/TeamTalkLib/teamtalk/PacketLayout.cpp
@@ -1831,6 +1831,7 @@ namespace teamtalk
             // step. GetBlocks() guards its own array the same way.
             if((blocknums_range.size() % 3) != 0u)
                 return false;
+            assert(blocknums_range.size() % 3 == 0);
 
             for(size_t i=0;i<blocknums_range.size();i+=3)
             {
@@ -2003,9 +2004,9 @@ namespace teamtalk
         // length but still yields field_size/2 values, which can be odd, so the
         // count has to be checked at run time and not only with assert(), which
         // is compiled out of a release server.
-        assert(packetnums.size() % 2 == 0);
         if((packetnums.size() % 2) != 0u)
-            return true;
+            return false;
+        assert(packetnums.size() % 2 == 0);
         //insert ranges
         for(size_t i=0;i<packetnums.size();i+=2)
         {

--- a/Library/TeamTalkLib/teamtalk/PacketLayout.cpp
+++ b/Library/TeamTalkLib/teamtalk/PacketLayout.cpp
@@ -1825,6 +1825,13 @@ namespace teamtalk
             std::vector<uint16_t> blocknums_range;
             ConvertFromUInt12Array(u8_info_ptr, info_size, blocknums_range);
 
+            // Each range entry is three values: a source block and a low/high
+            // pair. The values come off the wire, so the count can be anything;
+            // without this the loop below reads past the vector on the last
+            // step. GetBlocks() guards its own array the same way.
+            if((blocknums_range.size() % 3) != 0u)
+                return false;
+
             for(size_t i=0;i<blocknums_range.size();i+=3)
             {
                 std::set<uint16_t> blocknums;
@@ -1992,7 +1999,13 @@ namespace teamtalk
         packetnums.clear();
 
         ReadUInt16Array(ptr, FIELDTYPE_PACKETRANGE_ACK, packetnums);
+        // Each range is a low/high pair. ReadUInt16Array requires an even byte
+        // length but still yields field_size/2 values, which can be odd, so the
+        // count has to be checked at run time and not only with assert(), which
+        // is compiled out of a release server.
         assert(packetnums.size() % 2 == 0);
+        if((packetnums.size() % 2) != 0u)
+            return true;
         //insert ranges
         for(size_t i=0;i<packetnums.size();i+=2)
         {

--- a/Library/TeamTalkLib/test/CatchDefault.cpp
+++ b/Library/TeamTalkLib/test/CatchDefault.cpp
@@ -36,6 +36,7 @@
 #include "settings/Settings.h"
 #include "teamtalk/Commands.h"
 #include "teamtalk/Common.h"
+#include "teamtalk/PacketLayout.h"
 #include "teamtalk/StreamHandler.h"
 #include "teamtalk/client/AudioMuxer.h"
 #include "teamtalk/client/Client.h"
@@ -120,6 +121,71 @@ public:
 
 /* Known bugs */
 #define TEAMTALK_KNOWN_BUGS 0
+
+static std::vector<char> FlattenPacket(const teamtalk::FieldPacket& packet,
+                                       std::vector<size_t>& offsets)
+{
+    int buffers = 0;
+    const iovec* packet_buffers = packet.GetPacket(buffers);
+    std::vector<char> result;
+    offsets.clear();
+    for(int i = 0; i < buffers; ++i)
+    {
+        offsets.push_back(result.size());
+        const auto* begin = static_cast<const char*>(packet_buffers[i].iov_base);
+        result.insert(result.end(), begin, begin + packet_buffers[i].iov_len);
+    }
+    return result;
+}
+
+TEST_CASE("Reject incomplete desktop packet ranges", "[packet]")
+{
+    using namespace teamtalk;
+
+    SECTION("duplicate block range missing its high value")
+    {
+        mmap_dup_blocks_t input_ranges;
+        input_ranges.emplace(4, std::set<uint16_t>{5, 6});
+        DesktopPacket packet(1, 2, 3, 51, 20, 0, 0, 1, map_block_t{},
+                             block_frags_t{}, input_ranges);
+        std::vector<size_t> offsets;
+        auto bytes = FlattenPacket(packet, offsets);
+        REQUIRE(offsets.size() >= 3);
+
+        auto* range_field = reinterpret_cast<uint8_t*>(bytes.data()) +
+                            offsets.back();
+        const auto range_type = READFIELD_TYPE(range_field);
+        REQUIRE(READFIELD_SIZE(range_field) == 5);
+        WRITEFIELD_TYPE(range_field, range_type, 3);
+        bytes.resize(offsets.back() + FIELDVALUE_PREFIX + 3);
+
+        DesktopPacket malformed(bytes.data(), uint16_t(bytes.size()));
+        map_dup_blocks_t output_ranges;
+        CHECK_FALSE(malformed.GetDuplicateBlocks(output_ranges));
+        CHECK(output_ranges.empty());
+    }
+
+    SECTION("acknowledgement range missing its high value")
+    {
+        DesktopAckPacket packet(1, 2, 3, 4, 5, std::set<uint16_t>{},
+                                packet_range_t{{6, 7}});
+        std::vector<size_t> offsets;
+        auto bytes = FlattenPacket(packet, offsets);
+        REQUIRE(offsets.size() >= 3);
+
+        auto* range_field = reinterpret_cast<uint8_t*>(bytes.data()) +
+                            offsets.back();
+        const auto range_type = READFIELD_TYPE(range_field);
+        REQUIRE(READFIELD_SIZE(range_field) == 4);
+        WRITEFIELD_TYPE(range_field, range_type, 2);
+        bytes.resize(offsets.back() + FIELDVALUE_PREFIX + 2);
+
+        DesktopAckPacket malformed(bytes.data(), uint16_t(bytes.size()));
+        std::set<uint16_t> packets;
+        CHECK_FALSE(malformed.GetPacketsAcked(packets));
+        CHECK(packets.empty());
+    }
+}
 
 TEST_CASE( "Init TT", "" )
 {

--- a/Library/TeamTalkLib/test/CatchDefault.cpp
+++ b/Library/TeamTalkLib/test/CatchDefault.cpp
@@ -173,6 +173,10 @@ TEST_CASE("Reject malformed 12-bit packet arrays", "[packet]")
         };
         DesktopPacket packet(1, 2, 3, 51, 20, 0, 0, 1, input_blocks,
                              block_frags_t{}, mmap_dup_blocks_t{});
+        std::vector<size_t> offsets;
+        auto bytes = FlattenPacket(packet, offsets);
+        REQUIRE(offsets.size() >= 3);
+
         auto* block_info = reinterpret_cast<uint8_t*>(bytes.data()) + offsets[2];
         REQUIRE(READFIELD_SIZE(block_info) == 3);
         SET2_UINT12_PTR(READFIELD_DATAPTR(block_info), 7, 3);


### PR DESCRIPTION
Hi,

While looking at the desktop parsing code around #3386 I found two more spots in `PacketLayout.cpp` where a value read off the wire is used to walk a vector without checking its length first. Both are out of bounds reads reachable on the server from a client, so I wanted to fix them the same way `GetBlocks` already handles its own array.

Same threat model as #3386: an authenticated client sending a crafted packet, not a pre-auth remote.

**1. `GetDuplicateBlocks`, the `BLOCK_DUP_RANGE` branch**

It reads three values per range entry:

```cpp
for(size_t i=0;i<blocknums_range.size();i+=3)
{
    for(uint16_t block_no=blocknums_range[i+1];
        block_no<=blocknums_range[i+2];block_no++)
        ...
    ... blocknums_range[i] ...
}
```

There was no check that the decoded length is a multiple of three. A three byte range field decodes to two values, so the first iteration reads `[2]` past the vector. `GetBlocks` guards its own array with `% 2 == 0`; this branch had nothing.

Reached on the server from `DesktopCache::UpdateCurrentDesktopWindow`, the same function as the assertion in #3386.

**2. `GetPacketsAcked`, the `PACKETRANGE_ACK` branch**

It reads two values per range:

```cpp
ReadUInt16Array(ptr, FIELDTYPE_PACKETRANGE_ACK, packetnums);
assert(packetnums.size() % 2 == 0);
for(size_t i=0;i<packetnums.size();i+=2)
{
    ... packetnums[i+1] ...
}
```

The parity check is an `assert`, so it is gone in a release build. `ReadUInt16Array` requires an even byte length but still returns `field_size/2` values, which can be odd (a six byte field gives three values), so an odd count reads `[i+1]` past the vector on the last step.

Reached on the server from `ReceivedDesktopAckPacket` (`PACKET_KIND_DESKTOP_ACK`).

**How I confirmed it**

I could not build the full library locally, so I pulled the two loops out exactly as written and drove them with `vector::at()`, which throws precisely where `operator[]` would read past the end:

```
GetDuplicateBlocks range branch
  3-byte field  -> 2 values (size%3=2): OUT-OF-BOUNDS READ
  6-byte field  -> 4 values (size%3=1): OUT-OF-BOUNDS READ
  well-formed   -> 3 values (size%3=0): ok
  well-formed   -> 6 values (size%3=0): ok

GetPacketsAcked range branch
  6-byte field -> 3 values (size 3): OUT-OF-BOUNDS READ
  4-byte field -> 2 values (size 2): ok
  8-byte field -> 4 values (size 4): ok
```

**The fix**

One guard each, both mirroring what `GetBlocks` already does:

```cpp
// GetDuplicateBlocks
if((blocknums_range.size() % 3) != 0u)
    return false;

// GetPacketsAcked
if((packetnums.size() % 2) != 0u)
    return true;
```

**On a unit test**

These functions are file-static in reach, so the only way to exercise them is a hand-crafted malformed packet, and the normal packet builder never produces one. I did not want to hand-corrupt bytes into a test I cannot run against the current code to confirm it actually reaches the bug, since that would prove nothing. The extracted-loop output above is what demonstrates the read. If you would like an in-tree test, tell me where you would want it and I will add one against a crafted packet.

Thanks for reading!
