### PR TITLE
Fix screen reader focus bugs in android 15 and up with edg to edg

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/EdgeToEdgeHelper.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/EdgeToEdgeHelper.java
@@ -27,18 +27,16 @@ import android.app.Activity;
 import android.os.Build;
 import android.view.View;
 
+import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 
 public class EdgeToEdgeHelper {
-
     public static void enableEdgeToEdge(Activity activity) {
-        View rootView = activity.findViewById(android.R.id.content);
+        View rootView = (View) activity.findViewById(android.R.id.content).getParent();
         ViewCompat.setOnApplyWindowInsetsListener(rootView, (v, insets) -> {
-            int topInset = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top;
-            int bottomInset = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom;
-
-            v.setPadding(v.getPaddingLeft(), topInset, v.getPaddingRight(), bottomInset);
+            Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
             return insets;
         });
     }


### PR DESCRIPTION
When we introduced edg to edg at first, we didn't handle it properly.
It was custom and incomplete.
Talkback and other screen readers didn't cover the action bars properly, skipped over them and they were placed at the last, incorrect auder.
By switching to the standard edg to edg handling that android provides in all newly created empty templates projects and also properly grabbing the actual content of the activity and set the padding to it, Everything is fixed for everyone. Now action bar, focus, and everything acts as normal
Also, portrate, landskape, and any side by side support is complete because we are handling this like how android suggest, raather than manually handling the insets