### PR TITLE
Fix missing title on sliders in iTeamTalk preferences

### DIFF
--- a/Client/iTeamTalk/iTeamTalk/Views/PreferencesView.swift
+++ b/Client/iTeamTalk/iTeamTalk/Views/PreferencesView.swift
@@ -181,7 +181,7 @@ struct PreferencesView: View {
 
     private var soundSection: some View {
         Section("Sound System") {
-            /*sliderWithSubtitle(
+            sliderWithSubtitle(
                 title: "Master Volume",
                 subtitle: Text(verbatim: model.percentSubtitle(model.masterVolumePercent)),
                 value: Binding(get: { model.masterVolumePercent }, set: { model.masterVolumeChanged($0) }),
@@ -212,23 +212,7 @@ struct PreferencesView: View {
                 range: 0...Double(VOICEACT_DISABLED),
                 step: 1,
                 displayValue: { model.voiceActivationValueText($0) }
-            )*/
-            Slider(value: Binding(get: { model.masterVolumePercent}, set: { model.masterVolumeChanged($0)}), in: 0...100, step: 10) {
-                Text("Master volume")
-            }
-            Slider(value: Binding(get: { model.mediaFileVolumePercent}, set: { model.mediafileVolumeChanged($0)}), in: 0...100, step: 1) {
-                Text("media volume")
-            }
-            Slider(value: Binding(get: { model.microphoneGainPercent}, set: { model.microphoneGainChanged($0)}), in: 0...100, step: 10) {
-                Text("Microphone gain")
-            }
-            Slider(value: Binding(get: { model.voiceActivationLevel}, set: { model.voiceactlevelChanged($0)}), in: 0...Double(VOICEACT_DISABLED), step: 1) {
-                Text("Voice activation level")
-            } minimumValueLabel: {
-                Text(model.voiceActivationSubtitle(model.voiceActivationLevel))
-            } maximumValueLabel: {
-                Text(model.voiceActivationSubtitle(model.voiceActivationLevel))
-            }
+            )
             NavigationLink {
                 SoundDevicesView()
             } label: {
@@ -269,7 +253,7 @@ struct PreferencesView: View {
                         .foregroundStyle(.secondary)
                 }
             }
-            /*sliderWithSubtitle(
+            sliderWithSubtitle(
                 title: "Speech Rate",
                 subtitle: Text(verbatim: String(format: String(localized: "The rate of the speaking voice is %.1f", comment: "preferences"), Float(model.ttsRate))),
                 value: Binding(get: { model.ttsRate }, set: { model.ttsrateChanged($0) }),
@@ -284,13 +268,7 @@ struct PreferencesView: View {
                 range: 0...1,
                 step: 0.1,
                 displayValue: { String(format: "%.1f", $0) }
-            )*/
-            Slider(value: Binding(get: { model.ttsRate}, set: { model.ttsrateChanged($0)}), in: Double(AVSpeechUtteranceMinimumSpeechRate)...Double(AVSpeechUtteranceMaximumSpeechRate), step: 0.1) {
-                Text("Speech rate")
-            }
-            Slider(value: Binding(get: { model.ttsVolume}, set: { model.ttsvolChanged($0)}), in: 0...1, step: 0.1) {
-                Text("Speech volume")
-            }
+            )
             NavigationLink {
                 TextToSpeechEventsView()
             } label: {


### PR DESCRIPTION
The sliders were changes from v5.23 Build 1 to Build 2. The squash commit unfortunately remove the diff.