### PR TITLE
Add channel types to TeamTalk files

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -13,6 +13,7 @@ Default Qt Client
 - Updated Qt to 6.11.1 on Windows and macOS
 - Ubuntu 22 is no longer supported
 - Fixed crash issue when invoking context menu in Server List dialog
+- Channel types can now be specified in .tt files
 Android Client
 - Ability to pause and resume media file streams
 - Announce who is administrator

--- a/Client/qtTeamTalk/CMakeLists.txt
+++ b/Client/qtTeamTalk/CMakeLists.txt
@@ -77,7 +77,7 @@ if (Qt5_FOUND OR Qt6_FOUND)
 
   set (QTTEAMTALK_SOURCES
     mainwindow.h preferencesdlg.h uservideowidget.h
-    channelstree.h channeldlg.h userinfodlg.h bannedusersdlg.h
+    channelstree.h channeldlg.h channeltypedlg.h userinfodlg.h bannedusersdlg.h
     useraccountsdlg.h videogridwidget.h uservideodlg.h
     serverpropertiesdlg.h keycompdlg.h serverlistdlg.h common.h
     textmessagedlg.h chattextedit.h filesmodel.h filetransferdlg.h
@@ -99,7 +99,7 @@ if (Qt5_FOUND OR Qt6_FOUND)
     chattextlist.h chattemplatesdlg.h
 
     main.cpp mainwindow.cpp preferencesdlg.cpp uservideowidget.cpp
-    channelstree.cpp channeldlg.cpp userinfodlg.cpp
+    channelstree.cpp channeldlg.cpp channeltypedlg.cpp userinfodlg.cpp
     bannedusersdlg.cpp useraccountsdlg.cpp videogridwidget.cpp
     uservideodlg.cpp serverpropertiesdlg.cpp keycompdlg.cpp
     serverlistdlg.cpp common.cpp textmessagedlg.cpp chattextedit.cpp

--- a/Client/qtTeamTalk/channeltypedlg.cpp
+++ b/Client/qtTeamTalk/channeltypedlg.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026, Bjørn D. Rasmussen, BearWare.dk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "channeltypedlg.h"
+
+#include <QCheckBox>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QVBoxLayout>
+
+ChannelTypeDlg::ChannelTypeDlg(ChannelTypes channelType, QWidget* parent)
+    : QDialog(parent)
+    , m_permanentBox(new QCheckBox(tr("Permanent channel (stored on server)"), this))
+    , m_soloTransmitBox(new QCheckBox(tr("No interruptions (no simultaneous voice transmission)"), this))
+    , m_classroomBox(new QCheckBox(tr("Classroom (operator-controlled transmissions)"), this))
+    , m_operatorReceiveOnlyBox(new QCheckBox(tr("Operator receive only (only operators see and hear users)"), this))
+    , m_noVoiceActivationBox(new QCheckBox(tr("No voice activation (only Push-to-Talk allowed)"), this))
+    , m_noRecordingBox(new QCheckBox(tr("No audio recording allowed"), this))
+    , m_hiddenBox(new QCheckBox(tr("Hidden channel (invisible and only known by name)"), this))
+{
+    setWindowTitle(tr("Channel Type"));
+    setAccessibleDescription(tr("Select the channel types used when creating a missing channel"));
+
+    auto layout = new QVBoxLayout(this);
+    layout->addWidget(new QLabel(tr("Select one or more channel types. Clear all options for a default channel."), this));
+
+    const QList<QPair<QCheckBox*, ChannelType>> options = {
+        {m_permanentBox, CHANNEL_PERMANENT},
+        {m_soloTransmitBox, CHANNEL_SOLO_TRANSMIT},
+        {m_classroomBox, CHANNEL_CLASSROOM},
+        {m_operatorReceiveOnlyBox, CHANNEL_OPERATOR_RECVONLY},
+        {m_noVoiceActivationBox, CHANNEL_NO_VOICEACTIVATION},
+        {m_noRecordingBox, CHANNEL_NO_RECORDING},
+        {m_hiddenBox, CHANNEL_HIDDEN},
+    };
+    for (const auto& option : options)
+    {
+        option.first->setObjectName(QString("channelType_%1").arg(option.second));
+        option.first->setChecked(channelType & option.second);
+        layout->addWidget(option.first);
+    }
+
+    auto buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    layout->addWidget(buttons);
+}
+
+ChannelTypes ChannelTypeDlg::channelType() const
+{
+    ChannelTypes channelType = CHANNEL_DEFAULT;
+    if (m_permanentBox->isChecked())
+        channelType |= CHANNEL_PERMANENT;
+    if (m_soloTransmitBox->isChecked())
+        channelType |= CHANNEL_SOLO_TRANSMIT;
+    if (m_classroomBox->isChecked())
+        channelType |= CHANNEL_CLASSROOM;
+    if (m_operatorReceiveOnlyBox->isChecked())
+        channelType |= CHANNEL_OPERATOR_RECVONLY;
+    if (m_noVoiceActivationBox->isChecked())
+        channelType |= CHANNEL_NO_VOICEACTIVATION;
+    if (m_noRecordingBox->isChecked())
+        channelType |= CHANNEL_NO_RECORDING;
+    if (m_hiddenBox->isChecked())
+        channelType |= CHANNEL_HIDDEN;
+    return channelType;
+}
+
+QString ChannelTypeDlg::channelTypeText(ChannelTypes channelType)
+{
+    QStringList channelTypes;
+    if (channelType & CHANNEL_PERMANENT)
+        channelTypes.append(tr("Permanent"));
+    if (channelType & CHANNEL_SOLO_TRANSMIT)
+        channelTypes.append(tr("No interruptions"));
+    if (channelType & CHANNEL_CLASSROOM)
+        channelTypes.append(tr("Classroom"));
+    if (channelType & CHANNEL_OPERATOR_RECVONLY)
+        channelTypes.append(tr("Operator receive only"));
+    if (channelType & CHANNEL_NO_VOICEACTIVATION)
+        channelTypes.append(tr("No voice activation"));
+    if (channelType & CHANNEL_NO_RECORDING)
+        channelTypes.append(tr("No recording"));
+    if (channelType & CHANNEL_HIDDEN)
+        channelTypes.append(tr("Hidden"));
+    return channelTypes.isEmpty() ? tr("Default") : channelTypes.join(", ");
+}

--- a/Client/qtTeamTalk/channeltypedlg.h
+++ b/Client/qtTeamTalk/channeltypedlg.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026, Bjørn D. Rasmussen, BearWare.dk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef CHANNELTYPEDLG_H
+#define CHANNELTYPEDLG_H
+
+#include "common.h"
+
+#include <QDialog>
+
+class QCheckBox;
+
+class ChannelTypeDlg : public QDialog
+{
+public:
+    explicit ChannelTypeDlg(ChannelTypes channelType, QWidget* parent = nullptr);
+
+    ChannelTypes channelType() const;
+    static QString channelTypeText(ChannelTypes channelType);
+
+private:
+    QCheckBox* m_permanentBox;
+    QCheckBox* m_soloTransmitBox;
+    QCheckBox* m_classroomBox;
+    QCheckBox* m_operatorReceiveOnlyBox;
+    QCheckBox* m_noVoiceActivationBox;
+    QCheckBox* m_noRecordingBox;
+    QCheckBox* m_hiddenBox;
+};
+
+#endif // CHANNELTYPEDLG_H

--- a/Client/qtTeamTalk/common.cpp
+++ b/Client/qtTeamTalk/common.cpp
@@ -178,6 +178,7 @@ void setServerEntry(int index, const HostEntry& host)
         ttSettings->setValue(QString(SETTINGS_SERVERENTRIES_LASTCHANNEL).arg(index), host.lastChan);
     ttSettings->setValue(QString((host.latesthost ? SETTINGS_LATESTHOST_CHANNEL : SETTINGS_SERVERENTRIES_CHANNEL)).arg(index), host.channel);
     ttSettings->setValue(QString((host.latesthost ? SETTINGS_LATESTHOST_CHANNELPASSWD : SETTINGS_SERVERENTRIES_CHANNELPASSWD)).arg(index), host.chanpasswd);
+    ttSettings->setValue(QString((host.latesthost ? SETTINGS_LATESTHOST_CHANNELTYPE : SETTINGS_SERVERENTRIES_CHANNELTYPE)).arg(index), host.chantype);
 }
 
 bool getServerEntry(int index, HostEntry& host, bool latesthost)
@@ -197,6 +198,7 @@ bool getServerEntry(int index, HostEntry& host, bool latesthost)
     host.statusmsg = ttSettings->value(QString((latesthost ? SETTINGS_LATESTHOST_STATUSMSG : SETTINGS_SERVERENTRIES_STATUSMSG)).arg(index)).toString();
     host.channel = ttSettings->value(QString((latesthost ? SETTINGS_LATESTHOST_CHANNEL : SETTINGS_SERVERENTRIES_CHANNEL)).arg(index)).toString();
     host.chanpasswd = ttSettings->value(QString((latesthost ? SETTINGS_LATESTHOST_CHANNELPASSWD : SETTINGS_SERVERENTRIES_CHANNELPASSWD)).arg(index)).toString();
+    host.chantype = static_cast<ChannelTypes>(ttSettings->value(QString((latesthost ? SETTINGS_LATESTHOST_CHANNELTYPE : SETTINGS_SERVERENTRIES_CHANNELTYPE)).arg(index), CHANNEL_DEFAULT).toUInt());
     if (!host.latesthost)
         host.lastChan = ttSettings->value(QString(SETTINGS_SERVERENTRIES_LASTCHANNEL).arg(index)).toBool();
     host.latesthost = latesthost;
@@ -229,6 +231,7 @@ void deleteServerEntry(const HostEntry& host)
             ttSettings->remove(QString(SETTINGS_SERVERENTRIES_LASTCHANNEL).arg(index));
         ttSettings->remove(QString((host.latesthost ? SETTINGS_LATESTHOST_CHANNEL : SETTINGS_SERVERENTRIES_CHANNEL)).arg(index));
         ttSettings->remove(QString((host.latesthost ? SETTINGS_LATESTHOST_CHANNELPASSWD : SETTINGS_SERVERENTRIES_CHANNELPASSWD)).arg(index));
+        ttSettings->remove(QString((host.latesthost ? SETTINGS_LATESTHOST_CHANNELTYPE : SETTINGS_SERVERENTRIES_CHANNELTYPE)).arg(index));
         index++;
         tmp = HostEntry();
     }

--- a/Client/qtTeamTalk/common.h
+++ b/Client/qtTeamTalk/common.h
@@ -98,6 +98,7 @@ struct HostEntry
     bool lastChan = false;
     QString channel;
     QString chanpasswd;
+    ChannelTypes chantype = CHANNEL_DEFAULT;
     //tt-file specific
     Gender gender = GENDER_NONE;
     hotkey_t hotkey;

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -1996,6 +1996,7 @@ void MainWindow::cmdCompleteLoggedIn(int myuserid)
         Channel chan = {};
         chan.nParentID = parentid;
         chan.nMaxUsers = m_srvprop.nMaxUsers;
+        chan.uChannelType = m_host.chantype;
         initDefaultAudioCodec(chan.audiocodec);
 
         chan.audiocfg.bEnableAGC = DEFAULT_CHANNEL_AUDIOCONFIG_ENABLE;

--- a/Client/qtTeamTalk/serverdlg.cpp
+++ b/Client/qtTeamTalk/serverdlg.cpp
@@ -18,6 +18,7 @@
 #include "serverdlg.h"
 #include "ui_serverdlg.h"
 #include "appinfo.h"
+#include "channeltypedlg.h"
 #include "encryptionsetupdlg.h"
 #include "settings.h"
 
@@ -31,8 +32,9 @@ extern NonDefaultSettings* ttSettings;
 ServerDlg::ServerDlg(ServerDlgType type, const HostEntry& host, QWidget *parent)
     : QDialog(parent)
     , ui(new Ui::ServerDlg)
-    , m_type(type)
     , m_hostentry(host)
+    , m_chantype(host.chantype)
+    , m_type(type)
 {
     ui->setupUi(this);
     setWindowIcon(QIcon(APPICON));
@@ -53,6 +55,15 @@ ServerDlg::ServerDlg(ServerDlgType type, const HostEntry& host, QWidget *parent)
             this, &ServerDlg::slotToggledWebLogin);
     connect(ui->lastChanChkBox, &QCheckBox::toggled,
             this, &ServerDlg::slotToggledLastChannel);
+    connect(ui->chantypeButton, &QAbstractButton::clicked, this, [&]()
+    {
+        ChannelTypeDlg dlg(m_chantype, this);
+        if (dlg.exec() == QDialog::Accepted)
+        {
+            m_chantype = dlg.channelType();
+            updateChannelTypeText();
+        }
+    });
     connect(ui->passwordChkBox, &QAbstractButton::clicked,
             this, [&](bool checked) { ui->passwordEdit->setEchoMode(checked ? QLineEdit::Normal : QLineEdit::Password); } );
     connect(ui->chanpasswordChkBox, &QAbstractButton::clicked,
@@ -87,6 +98,7 @@ ServerDlg::ServerDlg(ServerDlgType type, const HostEntry& host, QWidget *parent)
         ui->lastChanChkBox->setEnabled(false);
         ui->channelEdit->setReadOnly(true);
         ui->chanpasswdEdit->setReadOnly(true);
+        ui->chantypeButton->setEnabled(false);
         ui->connectSrvBox->setEnabled(false);
         ui->buttonBox->setStandardButtons(QDialogButtonBox::Close);
         ui->buttonBox->button(QDialogButtonBox::Close)->setText(tr("&Close"));
@@ -107,6 +119,7 @@ ServerDlg::ServerDlg(ServerDlgType type, const HostEntry& host, QWidget *parent)
     ui->lastChanChkBox->setChecked(m_hostentry.lastChan);
     ui->channelEdit->setText(m_hostentry.channel);
     ui->chanpasswdEdit->setText(m_hostentry.chanpasswd);
+    updateChannelTypeText();
     ui->joinCodeEdit->setText(host.joincode);
     if (host.joincode.isEmpty())
         ui->joincodeGroupBox->hide();
@@ -133,6 +146,7 @@ HostEntry ServerDlg::GetHostEntry() const
     newhostentry.lastChan = ui->lastChanChkBox->isChecked();
     newhostentry.channel = ui->channelEdit->text();
     newhostentry.chanpasswd = ui->chanpasswdEdit->text();
+    newhostentry.chantype = m_chantype;
 
     return newhostentry;
 }
@@ -145,6 +159,11 @@ bool ServerDlg::connectToServer() const
 void ServerDlg::generateEntryName()
 {
     ui->nameEdit->setText(GetHostEntry().generateEntryName());
+}
+
+void ServerDlg::updateChannelTypeText()
+{
+    ui->chantypeButton->setText(ChannelTypeDlg::channelTypeText(m_chantype));
 }
 
 void ServerDlg::accept()
@@ -195,6 +214,8 @@ void ServerDlg::slotToggledLastChannel()
     ui->chanpsw_label->setVisible(!ui->lastChanChkBox->isChecked());
     ui->chanpasswdEdit->setVisible(!ui->lastChanChkBox->isChecked());
     ui->chanpasswordChkBox->setVisible(!ui->lastChanChkBox->isChecked());
+    ui->chantypeLabel->setVisible(!ui->lastChanChkBox->isChecked());
+    ui->chantypeButton->setVisible(!ui->lastChanChkBox->isChecked());
 }
 
 bool ServerDlg::isServerNameUnique(const QString& serverName)

--- a/Client/qtTeamTalk/serverdlg.h
+++ b/Client/qtTeamTalk/serverdlg.h
@@ -49,8 +49,10 @@ protected:
 private:
     Ui::ServerDlg *ui;
     HostEntry m_hostentry;
+    ChannelTypes m_chantype;
     ServerDlgType m_type;
     void generateEntryName();
+    void updateChannelTypeText();
     void slotToggledWebLogin();
     void slotToggledLastChannel();
     bool isServerNameUnique(const QString& serverName);

--- a/Client/qtTeamTalk/serverdlg.ui
+++ b/Client/qtTeamTalk/serverdlg.ui
@@ -293,6 +293,26 @@
            </item>
           </layout>
          </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="chantypeLabel">
+           <property name="text">
+            <string>Channel type</string>
+           </property>
+           <property name="buddy">
+            <cstring>chantypeButton</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QPushButton" name="chantypeButton">
+           <property name="accessibleDescription">
+            <string>Select the channel types used when creating a missing channel</string>
+           </property>
+           <property name="text">
+            <string>Default</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>

--- a/Client/qtTeamTalk/settings.h
+++ b/Client/qtTeamTalk/settings.h
@@ -568,6 +568,7 @@
 #define SETTINGS_LATESTHOST_STATUSMSG                "latesthosts/%1_status-message"
 #define SETTINGS_LATESTHOST_CHANNEL                 "latesthosts/%1_channel"
 #define SETTINGS_LATESTHOST_CHANNELPASSWD           "latesthosts/%1_chanpassword"
+#define SETTINGS_LATESTHOST_CHANNELTYPE             "latesthosts/%1_channel-type"
 
 #define SETTINGS_SERVERENTRIES_NAME                 "serverentries/%1_name"
 #define SETTINGS_SERVERENTRIES_HOSTADDR             "serverentries/%1_hostaddr"
@@ -585,6 +586,7 @@
 #define SETTINGS_SERVERENTRIES_LASTCHANNEL              "serverentries/%1_join-last-channel"
 #define SETTINGS_SERVERENTRIES_CHANNEL              "serverentries/%1_channel"
 #define SETTINGS_SERVERENTRIES_CHANNELPASSWD        "serverentries/%1_chanpassword"
+#define SETTINGS_SERVERENTRIES_CHANNELTYPE          "serverentries/%1_channel-type"
 
 #define SETTINGS_DESKTOPACCESS_HOSTADDR             "desktopaccess/%1_hostaddr"
 #define SETTINGS_DESKTOPACCESS_TCPPORT              "desktopaccess/%1_tcpport"

--- a/Client/qtTeamTalk/utiltt.h
+++ b/Client/qtTeamTalk/utiltt.h
@@ -168,6 +168,14 @@ do {                                                            \
                              USERRIGHT_TEXTMESSAGE_USER |           \
                              USERRIGHT_TEXTMESSAGE_CHANNEL)
 
+constexpr ChannelTypes CHANNELTYPE_ALL  = CHANNEL_PERMANENT |
+                                          CHANNEL_SOLO_TRANSMIT |
+                                          CHANNEL_CLASSROOM |
+                                          CHANNEL_OPERATOR_RECVONLY |
+                                          CHANNEL_NO_VOICEACTIVATION |
+                                          CHANNEL_NO_RECORDING |
+                                          CHANNEL_HIDDEN;
+
 #define DEFAULT_MAX_STRING_LENGTH       50
 
 //whether to enable key-translation

--- a/Client/qtTeamTalk/utilxml.cpp
+++ b/Client/qtTeamTalk/utilxml.cpp
@@ -18,6 +18,17 @@
 #include "utilxml.h"
 #include "appinfo.h"
 
+namespace
+{
+constexpr UINT32 CHANNELTYPE_MASK = CHANNEL_PERMANENT |
+                                    CHANNEL_SOLO_TRANSMIT |
+                                    CHANNEL_CLASSROOM |
+                                    CHANNEL_OPERATOR_RECVONLY |
+                                    CHANNEL_NO_VOICEACTIVATION |
+                                    CHANNEL_NO_RECORDING |
+                                    CHANNEL_HIDDEN;
+}
+
 void processTrustedXML(const QDomElement& hostElement, HostEntry& entry)
 {
     QDomElement trusted = hostElement.firstChildElement("trusted-certificate");
@@ -75,6 +86,14 @@ void processJoinXML(const QDomElement& hostElement, HostEntry& entry)
         tmp = join.firstChildElement("join-last-channel");
         if (!tmp.isNull())
             entry.lastChan = tmp.text() == "true";
+        tmp = join.firstChildElement("channel-type");
+        if (!tmp.isNull())
+        {
+            bool ok = false;
+            UINT32 chantype = tmp.text().toUInt(&ok);
+            if (ok && !(chantype & ~CHANNELTYPE_MASK))
+                entry.chantype = static_cast<ChannelTypes>(chantype);
+        }
     }
 }
 
@@ -303,6 +322,13 @@ QByteArray generateTTFile(const HostEntry& entry)
         QDomElement joinlast = doc.createElement("join-last-channel");
         joinlast.appendChild(doc.createTextNode(entry.lastChan ? "true" : "false"));
         join.appendChild(joinlast);
+
+        if (entry.chantype != CHANNEL_DEFAULT)
+        {
+            QDomElement chantype = doc.createElement("channel-type");
+            chantype.appendChild(doc.createTextNode(QString::number(entry.chantype)));
+            join.appendChild(chantype);
+        }
 
         host.appendChild(join);
     }

--- a/Client/qtTeamTalk/utilxml.cpp
+++ b/Client/qtTeamTalk/utilxml.cpp
@@ -81,8 +81,8 @@ void processJoinXML(const QDomElement& hostElement, HostEntry& entry)
         {
             bool ok = false;
             UINT32 chantype = tmp.text().toUInt(&ok);
-            if (ok && !(chantype & ~CHANNELTYPE_ALL))
-                entry.chantype = static_cast<ChannelTypes>(chantype);
+            if (ok)
+                entry.chantype = static_cast<ChannelTypes>(chantype & CHANNELTYPE_ALL);
         }
     }
 }

--- a/Client/qtTeamTalk/utilxml.cpp
+++ b/Client/qtTeamTalk/utilxml.cpp
@@ -18,16 +18,6 @@
 #include "utilxml.h"
 #include "appinfo.h"
 
-namespace
-{
-constexpr UINT32 CHANNELTYPE_MASK = CHANNEL_PERMANENT |
-                                    CHANNEL_SOLO_TRANSMIT |
-                                    CHANNEL_CLASSROOM |
-                                    CHANNEL_OPERATOR_RECVONLY |
-                                    CHANNEL_NO_VOICEACTIVATION |
-                                    CHANNEL_NO_RECORDING |
-                                    CHANNEL_HIDDEN;
-}
 
 void processTrustedXML(const QDomElement& hostElement, HostEntry& entry)
 {
@@ -91,7 +81,7 @@ void processJoinXML(const QDomElement& hostElement, HostEntry& entry)
         {
             bool ok = false;
             UINT32 chantype = tmp.text().toUInt(&ok);
-            if (ok && !(chantype & ~CHANNELTYPE_MASK))
+            if (ok && !(chantype & ~CHANNELTYPE_ALL))
                 entry.chantype = static_cast<ChannelTypes>(chantype);
         }
     }


### PR DESCRIPTION
Hi,

This adds channel-type support to Qt TeamTalk `.tt` files and fixes #31.

The Qt client can now:
- select any supported channel-type combination from the Server dialog;
- store the selection for saved servers and recent hosts;
- read and write `<channel-type>` while keeping existing `.tt` files compatible;
- apply the selected type when creating a missing channel;
- mask unsupported channel-type bits while preserving supported values.

Tests:
- focused Qt harness covering the GUI bitmask, XML round trips, legacy/default behavior, invalid and unknown values, and real QSettings save/load/delete paths;
- full Qt TeamTalk client build with MSVC 19.44 and Qt 6.10.1;
- isolated TeamTalk Server 10332 canary creating and observing combined type 52, followed by automatic temporary-channel removal.

@bear101, could you please review this when you have time? Maintainer edits are enabled.

Thanks for reading!