### PR TITLE
Android client. Label parent channel shortcut in channel list

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -31,6 +31,7 @@ Android Client
 - Fixed bug where not all selected files could be uploaded
 - Fixed bug where sounds were not muted during outgoing calls
 - Fixed channel list items not being exposed as clickable for accessibility services
+- Fixed parent channel shortcut in the channel list not being announced by screen readers
 - Minimum supported Android version is now 6.0 (Marshmallow)
 iOS Client
 - User interface has been redesigned using a more modern UI toolkit

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -1317,6 +1317,28 @@ private EditText newmsg;
                         if (convertView == null ||
                                 convertView.findViewById(R.id.parentname) == null)
                             convertView = inflater.inflate(R.layout.item_channel_back, parent, false);
+
+                        TextView parentname = convertView.findViewById(R.id.parentname);
+                        TextView parenttopic = convertView.findViewById(R.id.chantopic);
+                        TextView parentpopulation = convertView.findViewById(R.id.population);
+
+                        String parentchanname;
+                        if (channel.nParentID == 0) {
+                            // show server name as channel name for root channel
+                            ServerProperties srvprop = new ServerProperties();
+                            getClient().getServerProperties(srvprop);
+                            parentchanname = srvprop.szServerName;
+                        }
+                        else {
+                            parentchanname = channel.szName;
+                        }
+                        parentname.setText(parentchanname);
+                        parentname.setContentDescription(getString(R.string.text_parent_channel, parentchanname));
+                        parenttopic.setText(channel.szTopic);
+
+                        int parentusers = Utils.getUsers(channel.nChannelID, getService().getUsers()).size();
+                        parentpopulation.setText((parentusers > 0) ? String.format(Locale.ROOT, "(%d)", parentusers) : "");
+
                         break;
 
                     case CHANNEL_VIEW_TYPE :

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -1318,22 +1318,9 @@ private EditText newmsg;
                                 convertView.findViewById(R.id.parentname) == null)
                             convertView = inflater.inflate(R.layout.item_channel_back, parent, false);
 
-                        TextView parentname = convertView.findViewById(R.id.parentname);
                         TextView parenttopic = convertView.findViewById(R.id.chantopic);
                         TextView parentpopulation = convertView.findViewById(R.id.population);
 
-                        String parentchanname;
-                        if (channel.nParentID == 0) {
-                            // show server name as channel name for root channel
-                            ServerProperties srvprop = new ServerProperties();
-                            getClient().getServerProperties(srvprop);
-                            parentchanname = srvprop.szServerName;
-                        }
-                        else {
-                            parentchanname = channel.szName;
-                        }
-                        parentname.setText(parentchanname);
-                        parentname.setContentDescription(getString(R.string.text_parent_channel, parentchanname));
                         parenttopic.setText(channel.szTopic);
 
                         int parentusers = Utils.getUsers(channel.nChannelID, getService().getUsers()).size();

--- a/Client/TeamTalkAndroid/src/main/res/layout/item_channel_back.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/item_channel_back.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="horizontal" >
@@ -29,7 +30,7 @@
                 android:id="@+id/parentname"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textSize="16sp"
+                android:textSize="16sp" 
                 android:singleLine="true"
                 android:text="@string/text_parent_channel" />
 

--- a/Client/TeamTalkAndroid/src/main/res/layout/item_channel_back.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/item_channel_back.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="horizontal" >
@@ -30,10 +29,9 @@
                 android:id="@+id/parentname"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textSize="16sp" 
+                android:textSize="16sp"
                 android:singleLine="true"
-                android:text=".."
-                tools:ignore="HardcodedText" />
+                android:text="" />
 
             <TextView
                 android:id="@+id/population"

--- a/Client/TeamTalkAndroid/src/main/res/layout/item_channel_back.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/item_channel_back.xml
@@ -31,7 +31,7 @@
                 android:layout_height="wrap_content"
                 android:textSize="16sp"
                 android:singleLine="true"
-                android:text="" />
+                android:text="@string/text_parent_channel" />
 
             <TextView
                 android:id="@+id/population"

--- a/Client/TeamTalkAndroid/src/main/res/values/strings.xml
+++ b/Client/TeamTalkAndroid/src/main/res/values/strings.xml
@@ -424,6 +424,7 @@
     <string name="text_officialserver">Official server</string>
     <string name="text_unofficialserver">Unofficial server</string>
     <string name="text_passwdprot">Password protected</string>
+    <string name="text_parent_channel">Go to parent channel: %1$s</string>
     <string name="text_translator">Translated by Bjørn Damstedt Rasmussen</string>
     <string name="desktop_image">Desktop image</string>
     <string name="channel_change_alert">All active transfers will be stopped when switching a channel</string>

--- a/Client/TeamTalkAndroid/src/main/res/values/strings.xml
+++ b/Client/TeamTalkAndroid/src/main/res/values/strings.xml
@@ -424,7 +424,7 @@
     <string name="text_officialserver">Official server</string>
     <string name="text_unofficialserver">Unofficial server</string>
     <string name="text_passwdprot">Password protected</string>
-    <string name="text_parent_channel">Go to parent channel: %1$s</string>
+    <string name="text_parent_channel">Parent channel</string>
     <string name="text_translator">Translated by Bjørn Damstedt Rasmussen</string>
     <string name="desktop_image">Desktop image</string>
     <string name="channel_change_alert">All active transfers will be stopped when switching a channel</string>


### PR DESCRIPTION
## Problem

In the Android client's channel list, the row that navigates up to the parent channel is unlabelled for screen readers.

`ChannelListAdapter.getView()` inflates `item_channel_back.xml` for `PARENT_CHANNEL_VIEW_TYPE` but never populates it:

```java
case PARENT_CHANNEL_VIEW_TYPE :
    // show parent channel shortcut
    if (convertView == null ||
            convertView.findViewById(R.id.parentname) == null)
        convertView = inflater.inflate(R.layout.item_channel_back, parent, false);
    break;
```

The layout supplies a hardcoded `".."` in `parentname` and leaves `population` and `chantopic` empty, and the back arrow is `importantForAccessibility="no"`. So the row's entire accessible label is `".."`, which TalkBack does not announce as anything useful.

This matters more than it might look. Rows are ordered sticky channels → users → parent shortcut → subchannels, so on a server with a flat channel structure, this row is the *only* way back to the channel list once you have joined a channel. A TalkBack user swipes past every user in the channel, reaches an item that announces nothing, and has no way to know it is the way back.

## Change

- `parentname` now carries a static `@string/text_parent_channel` ("Parent channel") set from the layout, replacing the hardcoded `".."`.
- `chantopic` and `population` are filled in from the parent channel, so the row also says something about where it leads.

The label is deliberately *not* the parent's name — that would make the row read like just another subchannel, which is exactly what it needs to be distinguishable from (thanks for catching that).

Note that the user count is set unconditionally rather than behind the `nMaxUsers > 0` guard used in `CHANNEL_VIEW_TYPE`, so a recycled view cannot keep a stale count.

## Testing

Tested on device: a debug build installed on a Pixel 9a announces the row as "Parent channel" under TalkBack, where previously it was silent.

The build was made against the v5.22a Android SDK's prebuilt `TeamTalk5.jar` and JNI libraries (`Library/TeamTalkJNI/src` is identical between v5.22a and this tree, so the wrapper API matches):

- `./gradlew assembleDebug` — BUILD SUCCESSFUL, all four ABIs plus universal.
- Verified in the packaged APK with `aapt2` that `item_channel_back.xml`'s `parentname` binds `android:text` to `0x7f10024a` = `string/text_parent_channel` = "Parent channel".
- `./gradlew lintDebug` — no new findings in the changed files; `item_channel_back.xml` is clean and the `MainActivity.java` and `strings.xml` findings are all pre-existing and at unrelated lines.
