### PR TITLE
Android client. Let screen readers reach the action bar first

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -31,6 +31,7 @@ Android Client
 - Fixed bug where not all selected files could be uploaded
 - Fixed bug where sounds were not muted during outgoing calls
 - Fixed channel list items not being exposed as clickable for accessibility services
+- Fixed screen readers reaching the action bar only after every other control on the screen
 - Minimum supported Android version is now 6.0 (Marshmallow)
 iOS Client
 - User interface has been redesigned using a more modern UI toolkit

--- a/Client/TeamTalkAndroid/src/main/AndroidManifest.xml
+++ b/Client/TeamTalkAndroid/src/main/AndroidManifest.xml
@@ -50,6 +50,7 @@
 
         <activity
             android:name=".ServerListActivity"
+            android:theme="@style/AppTheme.NoActionBar"
             android:icon="@drawable/teamtalk_blue"
             android:launchMode="singleTop"
             android:exported="true">
@@ -70,12 +71,14 @@
 
         <activity
             android:name=".ServerEntryActivity"
+            android:theme="@style/AppTheme.NoActionBar"
             android:label="@string/title_activity_server_entry"
             android:exported="false">
         </activity>
 
         <activity
             android:name=".MainActivity"
+            android:theme="@style/AppTheme.NoActionBar"
             android:configChanges="orientation|screenSize"
             android:label="@string/title_activity_main"
             android:launchMode="singleTop"
@@ -85,12 +88,14 @@
 
         <activity
             android:name=".ChannelPropActivity"
+            android:theme="@style/AppTheme.NoActionBar"
             android:label="@string/title_activity_channel_prop"
             android:exported="false">
         </activity>
 
         <activity
             android:name=".StreamMediaActivity"
+            android:theme="@style/AppTheme.NoActionBar"
             android:label="@string/title_activity_stream_media"
             android:exported="false">
         </activity>
@@ -104,12 +109,14 @@
 
         <activity
             android:name=".UserPropActivity"
+            android:theme="@style/AppTheme.NoActionBar"
             android:label="@string/title_activity_user_prop"
             android:exported="false">
         </activity>
 
         <activity
             android:name=".TextMessageActivity"
+            android:theme="@style/AppTheme.NoActionBar"
             android:label="@string/title_activity_text_message"
             android:parentActivityName=".MainActivity"
             android:exported="false">
@@ -120,6 +127,7 @@
 
         <activity
             android:name=".PreferencesActivity"
+            android:theme="@style/AppTheme.NoActionBar"
             android:label="@string/title_activity_preferences"
             android:exported="false">
         </activity>
@@ -132,6 +140,7 @@
 
         <activity
             android:name=".OnlineUsersActivity"
+            android:theme="@style/AppTheme.NoActionBar"
             android:label="@string/online_users"
             android:parentActivityName=".MainActivity">
             <meta-data

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/AccessibilityHelper.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/AccessibilityHelper.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2005-2018, BearWare.dk
+ * 
+ * Contact Information:
+ *
+ * Bjoern D. Rasmussen
+ * Kirketoften 5
+ * DK-8260 Viby J
+ * Denmark
+ * Email: contact@bearware.dk
+ * Phone: +45 20 20 54 59
+ * Web: http://www.bearware.dk
+ *
+ * This source code is part of the TeamTalk SDK owned by
+ * BearWare.dk. Use of this file, or its compiled unit, requires a
+ * TeamTalk SDK License Key issued by BearWare.dk.
+ *
+ * The TeamTalk SDK License Agreement along with its Terms and
+ * Conditions are outlined in the file License.txt included with the
+ * TeamTalk SDK distribution.
+ *
+ */
+
+package dk.bearware.gui;
+
+import android.app.Activity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+
+import androidx.appcompat.widget.Toolbar;
+
+public class AccessibilityHelper {
+
+    /**
+     * Replaces the window decor action bar with a toolbar placed above the
+     * activity's content.
+     *
+     * AppCompat lays the decor action bar and the window content on top of each
+     * other, both starting at the top left corner of the screen. Accessibility
+     * services order the two by size rather than by position, so the content,
+     * being the taller of the two, always comes first. That leaves "Navigate
+     * up", the screen title and the menu at the very end of the screen, after
+     * every control the screen contains.
+     *
+     * A toolbar occupies a band of its own above the content, so the two no
+     * longer overlap and are ordered by position instead.
+     *
+     * The activity must use a theme without a decor action bar, and must have
+     * set its content view. The returned toolbar still has to be handed to
+     * setSupportActionBar().
+     */
+    public static Toolbar installToolbar(Activity activity) {
+        ViewGroup content = activity.findViewById(android.R.id.content);
+        if (content == null || content.getChildCount() != 1)
+            return null;
+
+        View view = content.getChildAt(0);
+        ViewGroup.LayoutParams viewparams = view.getLayoutParams();
+        content.removeView(view);
+
+        LinearLayout wrapper = new LinearLayout(activity);
+        wrapper.setOrientation(LinearLayout.VERTICAL);
+
+        Toolbar toolbar = (Toolbar) activity.getLayoutInflater().inflate(R.layout.toolbar, wrapper, false);
+        wrapper.addView(toolbar);
+
+        // Content filling the activity must not keep doing so now that the
+        // toolbar has taken a part of it, or it pushes itself off the screen.
+        boolean fills = viewparams == null ||
+            viewparams.height == ViewGroup.LayoutParams.MATCH_PARENT;
+        wrapper.addView(view, new LinearLayout.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            fills ? 0 : viewparams.height,
+                            fills ? 1 : 0));
+
+        content.addView(wrapper, new ViewGroup.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.MATCH_PARENT));
+        return toolbar;
+    }
+}

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ChannelPropActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ChannelPropActivity.java
@@ -91,6 +91,7 @@ implements TeamTalkConnectionListener, ClientEventListener.OnCmdErrorListener, C
         mConnection = new TeamTalkConnection(this);
         setContentView(R.layout.activity_channel_prop);
         EdgeToEdgeHelper.enableEdgeToEdge(this);
+        setSupportActionBar(AccessibilityHelper.installToolbar(this));
 
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);        
     }

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -267,6 +267,7 @@ extends AppCompatActivity
         mConnection = new TeamTalkConnection(this);
         setContentView(R.layout.activity_main);
         EdgeToEdgeHelper.enableEdgeToEdge(this);
+        setSupportActionBar(AccessibilityHelper.installToolbar(this));
 
         String serverName = getIntent().getStringExtra(ServerEntry.KEY_SERVERNAME);
         if ((serverName != null) && !serverName.isEmpty())

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/OnlineUsersActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/OnlineUsersActivity.java
@@ -95,6 +95,7 @@ public class OnlineUsersActivity extends AppCompatActivity implements
         mConnection = new TeamTalkConnection(this);
         setContentView(R.layout.activity_online_users);
         EdgeToEdgeHelper.enableEdgeToEdge(this);
+        setSupportActionBar(AccessibilityHelper.installToolbar(this));
 
         onlineUsersList = findViewById(R.id.online_users_list);
         adapter = new OnlineUserAdapter(this, onlineUsers);

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/PreferencesActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/PreferencesActivity.java
@@ -99,6 +99,7 @@ public class PreferencesActivity extends PreferenceActivity implements TeamTalkC
         super.onCreate(savedInstanceState);
         mConnection = new TeamTalkConnection(this);
         EdgeToEdgeHelper.enableEdgeToEdge(this);
+        getDelegate().setSupportActionBar(AccessibilityHelper.installToolbar(this));
     }
 
     @Override

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerEntryActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerEntryActivity.java
@@ -80,6 +80,7 @@ public class ServerEntryActivity extends AppCompatActivity
         binding = ActivityServerEntryBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
         EdgeToEdgeHelper.enableEdgeToEdge(this);
+        setSupportActionBar(AccessibilityHelper.installToolbar(this));
 
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerListActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/ServerListActivity.java
@@ -122,6 +122,7 @@ public class ServerListActivity extends AppCompatActivity
 
         setContentView(R.layout.activity_server_list);
         EdgeToEdgeHelper.enableEdgeToEdge(this);
+        setSupportActionBar(AccessibilityHelper.installToolbar(this));
 
         initializeViews();
         setupRecyclerView();

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/StreamMediaActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/StreamMediaActivity.java
@@ -71,6 +71,7 @@ extends AppCompatActivity implements TeamTalkConnectionListener {
         mConnection = new TeamTalkConnection(this);
         setContentView(R.layout.activity_stream_media);
         EdgeToEdgeHelper.enableEdgeToEdge(this);
+        setSupportActionBar(AccessibilityHelper.installToolbar(this));
 
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         file_path = this.findViewById(R.id.file_path_txt);

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/TextMessageActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/TextMessageActivity.java
@@ -77,6 +77,7 @@ extends AppCompatActivity implements TeamTalkConnectionListener, ClientEventList
         mConnection = new TeamTalkConnection(this);
         setContentView(R.layout.activity_text_message);
         EdgeToEdgeHelper.enableEdgeToEdge(this);
+        setSupportActionBar(AccessibilityHelper.installToolbar(this));
 
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/UserPropActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/UserPropActivity.java
@@ -73,6 +73,7 @@ public class UserPropActivity extends AppCompatActivity implements TeamTalkConne
         mConnection = new TeamTalkConnection(this);
         setContentView(R.layout.activity_user_prop);
         EdgeToEdgeHelper.enableEdgeToEdge(this);
+        setSupportActionBar(AccessibilityHelper.installToolbar(this));
 
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 

--- a/Client/TeamTalkAndroid/src/main/res/layout/toolbar.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/toolbar.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.appcompat.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/toolbar"
+    android:layout_width="match_parent"
+    android:layout_height="?attr/actionBarSize"
+    android:background="?attr/colorPrimary"
+    android:theme="?attr/actionBarTheme"
+    app:popupTheme="?attr/actionBarPopupTheme" />


### PR DESCRIPTION
## Problem

On every screen, TalkBack reaches "Navigate up", the screen title and the menu only *after* swiping through every control the screen contains, and then wraps around to the start. On Preferences that means all seven headers come before the title; on the server list, the whole server list and three version labels.

## Root cause

AppCompat draws the decor action bar and the window content on top of each other. Dumped from a device on the server list screen:

```
content              [0,0][1080,2424]   <- spans the whole screen
action_bar_container [0,0][1080,277]
```

Accessibility services order siblings by their bounds, not by child order. Both start at `top=0, left=0`, so the comparison falls through to size and the larger view goes first. The full-screen content wins every time.

Two things that look like fixes are not:

- `setAccessibilityTraversalBefore` pointing the action bar at `android.R.id.content` — the target is a non-focusable full-screen container, and nothing changes.
- Reordering the children so the action bar comes first — I confirmed the reorder applies and survives layout, and the traversal order is still unchanged, because it is derived from the bounds.

For the action bar to come first its bottom has to be above the content's top, which the decor action bar never is.

## Change

Give the affected activities `AppTheme.NoActionBar` and put a `Toolbar` above the content instead. A toolbar occupies a band of its own, so the two no longer overlap and are ordered by position.

`AccessibilityHelper.installToolbar()` wraps whatever content view the activity has already set, so this stays in one place instead of an edit in all ten layouts. The activities already had a common call site for it, next to where they set up edge-to-edge insets. `PreferencesActivity` goes through `getDelegate()`, being a `PreferenceActivity`.

`AudioCodecActivity` deliberately keeps the decor action bar: it uses `ActionBar.NAVIGATION_MODE_TABS`, and a toolbar-backed action bar throws on `setNavigationMode()`. Converting it means replacing the tabs with a `TabLayout`, which felt like a separate change. Its swipe order is still wrong. `WebLoginActivity` has no action bar at all and is untouched.

## Testing

Verified on a Pixel 9a, by dumping the accessibility tree before and after and by swiping with TalkBack.

Preferences, which was the worst case, now reads:

```
 3  toolbar          [0,53][2424,160]
 4  ImageButton      d=Navigate up
 5  TextView         t=Preferences
 6  prefs_container  [107,213][2272,1080]
 7    ... General, Sound Events, Text-To-Speech, ...
```

Same on the General sub-screen (Navigate up, then "General", then Nickname/Status message/Gender) and on the server list (title, the two action buttons, More options, then the search box and the list). The toolbar band and the content no longer overlap, which is what makes the ordering work.

Every converted screen has since been walked with TalkBack on the device: the server list, server entry, main window, channel properties, user properties, text messages, online users, stream media, and Preferences including its sub-screens. Navigate up and the title come first on each of them, and nothing looked out of place.

