### PR TITLE
Add Copy All action to Android private messages

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/TextMessageAdapter.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/data/TextMessageAdapter.java
@@ -305,6 +305,16 @@ public class TextMessageAdapter extends BaseAdapter {
         }
     }
 
+    public String getAllMessagesText() {
+        StringBuilder text = new StringBuilder();
+        for (MyTextMessage msg : getMessages()) {
+            if (text.length() > 0)
+                text.append(System.lineSeparator());
+            text.append(msg.time).append(" ").append(msg.szNickName).append(": ").append(msg.szMessage);
+        }
+        return text.toString();
+    }
+
     private void copyToClipboard(Context context, String text) {
         ClipboardManager cm = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
         ClipData clip = ClipData.newPlainText("message", text);

--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/TextMessageActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/TextMessageActivity.java
@@ -24,6 +24,8 @@
 package dk.bearware.gui;
 
 import android.app.Activity;
+import android.content.ClipData;
+import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -97,6 +99,10 @@ extends AppCompatActivity implements TeamTalkConnectionListener, ClientEventList
         // as you specify a parent activity in AndroidManifest.xml.
         int id = item.getItemId();
         if(id == R.id.action_settings) {
+            return true;
+        }
+        else if (id == R.id.action_copyall) {
+            copyAllMessagesToClipboard();
             return true;
         }
         else if (id == android.R.id.home) {
@@ -244,6 +250,15 @@ extends AppCompatActivity implements TeamTalkConnectionListener, ClientEventList
             adapter.notifyDataSetChanged();
             accessibilityAssistant.unlockEvents();
         }
+    }
+
+    private void copyAllMessagesToClipboard() {
+        if (adapter == null)
+            return;
+
+        ClipboardManager cm = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+        if (cm != null)
+            cm.setPrimaryClip(ClipData.newPlainText("messages", adapter.getAllMessagesText()));
     }
 
     private void sendTypingStatus(boolean typing) {

--- a/Client/TeamTalkAndroid/src/main/res/menu/text_message.xml
+++ b/Client/TeamTalkAndroid/src/main/res/menu/text_message.xml
@@ -2,4 +2,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="dk.bearware.gui.TextMessageActivity" >
 
+    <item
+        android:id="@+id/action_copyall"
+        android:title="@string/action_copyall"/>
+
 </menu>

--- a/Client/TeamTalkAndroid/src/main/res/values/strings.xml
+++ b/Client/TeamTalkAndroid/src/main/res/values/strings.xml
@@ -254,6 +254,7 @@
     <string name="action_resume">Resume stream</string>
     <string name="action_statusnick">Change Nickname and Status</string>
     <string name="action_copyname">Copy Name</string>
+    <string name="action_copyall">Copy All</string>
     <string name="action_copymessage">Copy Content Only</string>
     <string name="action_deletemessage">Delete</string>
     <string name="action_clear">Clear</string>


### PR DESCRIPTION
Closes #3413.\n\nAdds a Copy All action to the Android private message screen so users can copy the visible conversation history to the clipboard in one step. This is useful for TalkBack/screen-reader users who need to back up or reuse a full private message history without copying each message individually.\n\nChanges:\n- adds a Copy All action to the private message menu;\n- copies the adapter's current visible message history to the clipboard;\n- formats each copied line with timestamp, nickname, and message content.\n\nValidation:\n- git diff --check passed;\n- attempted ./gradlew.bat assembleDebug with Android Studio JBR and local SDK configured; build reached dependency resolution but failed because Library/TeamTalkJNI/libs/TeamTalk5.jar is not present in this checkout, which the Android README documents as an SDK-provided dependency.