### PR TITLE
Qt client. Handle user joins before channel tree rebuild

### DIFF
--- a/Client/qtTeamTalk/channelstree.cpp
+++ b/Client/qtTeamTalk/channelstree.cpp
@@ -275,6 +275,7 @@ void ChannelsTree::resetChannels()
     delete topLevelItem(0);
     m_channels.clear();
     m_users.clear();   
+    m_pendingusers.clear();
     m_videousers.clear();
     m_desktopaccess_users.clear();
     m_blinkhand_users.clear();
@@ -1007,7 +1008,9 @@ QTreeWidgetItem* ChannelsTree::getUserItem(int userid) const
 
 int ChannelsTree::getUserIndex(const QTreeWidgetItem* parent, const QString& name) const
 {
-    Q_ASSERT(parent);
+    if(!parent)
+        return -1;
+
     int count = parent->childCount();
     int i;
     for(i=0;i<count;i++)
@@ -1487,6 +1490,35 @@ void ChannelsTree::slotAddChannel(const Channel& chan)
         item->setExpanded(ttSettings->value(SETTINGS_DISPLAY_CHANEXP, SETTINGS_DISPLAY_CHANEXP_DEFAULT).toBool());
         updateChannelItem(chan.nChannelID);
     }
+
+    joinPendingUsers(chan.nChannelID);
+}
+
+void ChannelsTree::joinPendingUsers(int channelid)
+{
+    if(m_pendingusers.isEmpty())
+        return;
+
+    QVector<int> userids;
+    for(auto i=m_pendingusers.cbegin();i!=m_pendingusers.cend();++i)
+    {
+        if(i.value() == channelid)
+            userids.push_back(i.key());
+    }
+
+    for(int userid : userids)
+    {
+        m_pendingusers.remove(userid);
+        // don't insert the user twice if it already got an item
+        if(getUserItem(userid))
+            continue;
+        users_t::const_iterator ite = m_users.constFind(userid);
+        if(ite != m_users.constEnd())
+        {
+            User user = *ite;
+            slotUserJoin(channelid, user);
+        }
+    }
 }
 
 void ChannelsTree::slotUpdateChannel(const Channel& chan)
@@ -1523,6 +1555,7 @@ void ChannelsTree::slotUserLoggedOut(const User& user)
     m_blinkchalk_users.remove(user.nUserID);
     m_desktopaccess_users.remove(user.nUserID);
     m_videousers.remove(user.nUserID);
+    m_pendingusers.remove(user.nUserID);
 
     Q_ASSERT(m_users.find(user.nUserID) != m_users.end());
     m_users.remove(user.nUserID);
@@ -1552,11 +1585,14 @@ void ChannelsTree::slotUserUpdate(const User& user)
         if(item->data(COLUMN_ITEM, Qt::DisplayRole).toString() != name)
         {
             QTreeWidgetItem* parent = item->parent();
-            bool selected = this->currentItem() == item;
-            parent->removeChild(item);
-            parent->insertChild(getUserIndex(parent, getDisplayName(user)), item);
-            if (selected)
-               this->setCurrentItem(item);
+            if(parent)
+            {
+                bool selected = this->currentItem() == item;
+                parent->removeChild(item);
+                parent->insertChild(getUserIndex(parent, getDisplayName(user)), item);
+                if (selected)
+                    this->setCurrentItem(item);
+            }
         }
         //clear blinking request user (if enabled)
         if(user.uLocalSubscriptions & SUBSCRIBE_DESKTOPINPUT)
@@ -1571,7 +1607,16 @@ void ChannelsTree::slotUserJoin(int channelid, const User& user)
     m_users.insert(user.nUserID, user);
 
     QTreeWidgetItem* parent = getChannelItem(channelid), *item;
-    Q_ASSERT(parent);
+    if(!parent)
+    {
+        // The channel doesn't have an item yet. This happens when the join-event
+        // is processed before the channel has been added to the tree, e.g. while
+        // the tree is being rebuilt after a reconnect. Remember the user and
+        // insert it when the channel shows up in slotAddChannel().
+        m_pendingusers.insert(user.nUserID, channelid);
+        return;
+    }
+    m_pendingusers.remove(user.nUserID);
 
     int i = getUserIndex(parent, getDisplayName(user));
     if(i == 0)
@@ -1607,6 +1652,7 @@ void ChannelsTree::slotUserLeft(int channelid, const User& user)
     m_blinkhand_users.remove(user.nUserID);
     m_blinkchalk_users.remove(user.nUserID);
     m_desktopaccess_users.remove(user.nUserID);
+    m_pendingusers.remove(user.nUserID);
     delete getUserItem(user.nUserID);
     m_users.insert(user.nUserID, user);
 

--- a/Client/qtTeamTalk/channelstree.h
+++ b/Client/qtTeamTalk/channelstree.h
@@ -79,6 +79,9 @@ private:
     typedef QSet<int> uservideo_t;
     channels_t m_channels;
     users_t m_users; //contains all users (also those not in channels)
+    // users whose join-event was received before their channel item existed.
+    // Maps user ID to the channel ID which the user joined.
+    QMap<int, int> m_pendingusers;
     int m_last_talker_id;
     statistics_t m_stats;
     uservideo_t m_videousers;
@@ -97,8 +100,11 @@ private:
     QPixmap getUserIcon(const User& user, const Channel& chan, const QTreeWidgetItem* item) const;
     void setChannelTransmitUsers(const Channel& chan, QTreeWidgetItem* item);
     void setUserTransmitUser(const User& user, const Channel& chan, QTreeWidgetItem* item);
-    /* return the "should be" index. Not the current index */
+    /* return the "should be" index. Not the current index.
+     * Returns -1 if 'parent' is nullptr */
     int getUserIndex(const QTreeWidgetItem* parent, const QString& name) const;
+    /* insert users whose join-event arrived before 'channelid' had an item */
+    void joinPendingUsers(int channelid);
     /* return the "should be" index. Not the current index */
     int getChannelIndex(const QTreeWidgetItem* item) const;
     void updateChannelItem(int channelid);


### PR DESCRIPTION
Hi,

This fixes a Qt client crash that can occur when a user-join event arrives before the corresponding channel item has been added during a channel-tree rebuild.

`ChannelsTree::slotUserJoin()` assumed that `getChannelItem()` always returned a parent and relied on `Q_ASSERT(parent)`. In a Release build the assertion is disabled, so the null parent was passed to `getUserIndex()` and dereferenced by `QTreeWidgetItem::childCount()`.

The failure is deterministic with this event order:

1. Construct `ChannelsTree`.
2. Deliver `slotUserJoin()` for a user in channel 42.
3. Deliver `slotAddChannel()` for channel 42 afterward.

On unmodified master, Debug stops at `Q_ASSERT(parent)`. RelWithDebInfo and Release fail with a `0xC0000005` read at address `0x50` through:

```
QTreeWidgetItem::childCount()
ChannelsTree::getUserIndex()
ChannelsTree::slotUserJoin()
```

The fix defers a join when its channel item is not ready and replays it when that channel is added. Deferred entries retain later user updates and are removed after insertion, user leave, logout, or tree reset. The map is keyed by user ID, so repeated events remain bounded and cannot create duplicate rows.

Tests:

- Focused harness calling the real `ChannelsTree` methods.
- 19 checks covering replay, updates, leave/logout/reset cancellation, duplicate joins, multiple channels, alphabetical ordering, rename, removal, and repeated rebuilds.
- Debug, RelWithDebInfo, and Release configurations all passed.
- Long Release run: 300 rebuild cycles, 300 users per cycle, 157,800 event operations, and zero Qt warnings.
- Working set was 44,232 KB before, 55,384 KB after, and 57,784 KB peak; tripling the stress cycles did not produce proportional growth.

The standalone harness and complete logs are available if they would be useful for review.

@bear101, could you please review this when you have time? Maintainer edits are enabled.

Thanks for reading!