### PR TITLE
Qt client: Drain queued messages before clearing channels

### DIFF
--- a/Client/qtTeamTalk/channelstree.cpp
+++ b/Client/qtTeamTalk/channelstree.cpp
@@ -1524,14 +1524,19 @@ void ChannelsTree::slotUserLoggedOut(const User& user)
     m_desktopaccess_users.remove(user.nUserID);
     m_videousers.remove(user.nUserID);
 
-    Q_ASSERT(m_users.find(user.nUserID) != m_users.end());
+    if(m_users.find(user.nUserID) == m_users.end())
+        return;
+
     m_users.remove(user.nUserID);
 }
 
 void ChannelsTree::slotUserUpdate(const User& user)
 {
-    Q_ASSERT(m_users.find(user.nUserID) != m_users.end());
-    User oldUser = m_users[user.nUserID];
+    users_t::const_iterator known = m_users.constFind(user.nUserID);
+    if(known == m_users.constEnd())
+        return;
+
+    User oldUser = *known;
     m_users.insert(user.nUserID, user);
 
     //ignore user if not in channel
@@ -1552,11 +1557,14 @@ void ChannelsTree::slotUserUpdate(const User& user)
         if(item->data(COLUMN_ITEM, Qt::DisplayRole).toString() != name)
         {
             QTreeWidgetItem* parent = item->parent();
-            bool selected = this->currentItem() == item;
-            parent->removeChild(item);
-            parent->insertChild(getUserIndex(parent, getDisplayName(user)), item);
-            if (selected)
-               this->setCurrentItem(item);
+            if(parent)
+            {
+                bool selected = this->currentItem() == item;
+                parent->removeChild(item);
+                parent->insertChild(getUserIndex(parent, getDisplayName(user)), item);
+                if (selected)
+                    this->setCurrentItem(item);
+            }
         }
         //clear blinking request user (if enabled)
         if(user.uLocalSubscriptions & SUBSCRIBE_DESKTOPINPUT)
@@ -1568,10 +1576,11 @@ void ChannelsTree::slotUserUpdate(const User& user)
 
 void ChannelsTree::slotUserJoin(int channelid, const User& user)
 {
-    m_users.insert(user.nUserID, user);
-
     QTreeWidgetItem* parent = getChannelItem(channelid), *item;
-    Q_ASSERT(parent);
+    if(!parent)
+        return;
+
+    m_users.insert(user.nUserID, user);
 
     int i = getUserIndex(parent, getDisplayName(user));
     if(i == 0)
@@ -1602,7 +1611,9 @@ void ChannelsTree::slotUserJoin(int channelid, const User& user)
 
 void ChannelsTree::slotUserLeft(int channelid, const User& user)
 {
-    Q_ASSERT(m_users.find(user.nUserID) != m_users.end());
+    if(m_users.find(user.nUserID) == m_users.end())
+        return;
+
     m_stats.remove(user.nUserID);
     m_blinkhand_users.remove(user.nUserID);
     m_blinkchalk_users.remove(user.nUserID);

--- a/Client/qtTeamTalk/channelstree.cpp
+++ b/Client/qtTeamTalk/channelstree.cpp
@@ -1525,20 +1525,13 @@ void ChannelsTree::slotUserLoggedOut(const User& user)
     m_videousers.remove(user.nUserID);
 
     Q_ASSERT(m_users.find(user.nUserID) != m_users.end());
-    if(m_users.find(user.nUserID) == m_users.end())
-        return;
-
     m_users.remove(user.nUserID);
 }
 
 void ChannelsTree::slotUserUpdate(const User& user)
 {
-    users_t::const_iterator known = m_users.constFind(user.nUserID);
-    Q_ASSERT(known != m_users.constEnd());
-    if(known == m_users.constEnd())
-        return;
-
-    User oldUser = *known;
+    Q_ASSERT(m_users.find(user.nUserID) != m_users.end());
+    User oldUser = m_users[user.nUserID];
     m_users.insert(user.nUserID, user);
 
     //ignore user if not in channel
@@ -1559,15 +1552,11 @@ void ChannelsTree::slotUserUpdate(const User& user)
         if(item->data(COLUMN_ITEM, Qt::DisplayRole).toString() != name)
         {
             QTreeWidgetItem* parent = item->parent();
-            Q_ASSERT(parent);
-            if(parent)
-            {
-                bool selected = this->currentItem() == item;
-                parent->removeChild(item);
-                parent->insertChild(getUserIndex(parent, getDisplayName(user)), item);
-                if (selected)
-                    this->setCurrentItem(item);
-            }
+            bool selected = this->currentItem() == item;
+            parent->removeChild(item);
+            parent->insertChild(getUserIndex(parent, getDisplayName(user)), item);
+            if (selected)
+               this->setCurrentItem(item);
         }
         //clear blinking request user (if enabled)
         if(user.uLocalSubscriptions & SUBSCRIBE_DESKTOPINPUT)
@@ -1579,12 +1568,10 @@ void ChannelsTree::slotUserUpdate(const User& user)
 
 void ChannelsTree::slotUserJoin(int channelid, const User& user)
 {
+    m_users.insert(user.nUserID, user);
+
     QTreeWidgetItem* parent = getChannelItem(channelid), *item;
     Q_ASSERT(parent);
-    if(!parent)
-        return;
-
-    m_users.insert(user.nUserID, user);
 
     int i = getUserIndex(parent, getDisplayName(user));
     if(i == 0)
@@ -1616,9 +1603,6 @@ void ChannelsTree::slotUserJoin(int channelid, const User& user)
 void ChannelsTree::slotUserLeft(int channelid, const User& user)
 {
     Q_ASSERT(m_users.find(user.nUserID) != m_users.end());
-    if(m_users.find(user.nUserID) == m_users.end())
-        return;
-
     m_stats.remove(user.nUserID);
     m_blinkhand_users.remove(user.nUserID);
     m_blinkchalk_users.remove(user.nUserID);

--- a/Client/qtTeamTalk/channelstree.cpp
+++ b/Client/qtTeamTalk/channelstree.cpp
@@ -1524,6 +1524,7 @@ void ChannelsTree::slotUserLoggedOut(const User& user)
     m_desktopaccess_users.remove(user.nUserID);
     m_videousers.remove(user.nUserID);
 
+    Q_ASSERT(m_users.find(user.nUserID) != m_users.end());
     if(m_users.find(user.nUserID) == m_users.end())
         return;
 
@@ -1533,6 +1534,7 @@ void ChannelsTree::slotUserLoggedOut(const User& user)
 void ChannelsTree::slotUserUpdate(const User& user)
 {
     users_t::const_iterator known = m_users.constFind(user.nUserID);
+    Q_ASSERT(known != m_users.constEnd());
     if(known == m_users.constEnd())
         return;
 
@@ -1557,6 +1559,7 @@ void ChannelsTree::slotUserUpdate(const User& user)
         if(item->data(COLUMN_ITEM, Qt::DisplayRole).toString() != name)
         {
             QTreeWidgetItem* parent = item->parent();
+            Q_ASSERT(parent);
             if(parent)
             {
                 bool selected = this->currentItem() == item;
@@ -1577,6 +1580,7 @@ void ChannelsTree::slotUserUpdate(const User& user)
 void ChannelsTree::slotUserJoin(int channelid, const User& user)
 {
     QTreeWidgetItem* parent = getChannelItem(channelid), *item;
+    Q_ASSERT(parent);
     if(!parent)
         return;
 
@@ -1611,6 +1615,7 @@ void ChannelsTree::slotUserJoin(int channelid, const User& user)
 
 void ChannelsTree::slotUserLeft(int channelid, const User& user)
 {
+    Q_ASSERT(m_users.find(user.nUserID) != m_users.end());
     if(m_users.find(user.nUserID) == m_users.end())
         return;
 

--- a/Client/qtTeamTalk/mainwindow.cpp
+++ b/Client/qtTeamTalk/mainwindow.cpp
@@ -2151,8 +2151,6 @@ void MainWindow::disconnectFromServer()
         addServerEntry(m_host);
     }
 
-    TT_Disconnect(ttInst);
-
     // sync user settings to cache
     auto users = ui.channelsWidget->getUsers();
     for (int uid : users)
@@ -2161,6 +2159,12 @@ void MainWindow::disconnectFromServer()
         if (ui.channelsWidget->getUser(uid, u) && !userCacheID(u).isEmpty())
             m_usercache[userCacheID(u)] = UserCached(u);
     }
+
+    TT_Disconnect(ttInst);
+
+    TTMessage msg;
+    INT32 wait_ms = 0;
+    while(TT_GetMessage(ttInst, &msg, &wait_ms));
 
     ui.channelsWidget->resetChannels();
     ui.videogridWidget->resetGrid();


### PR DESCRIPTION
Hi,

The issue is a Qt client crash during connection loss. A connection-loss message can be handled while the Qt client is draining the SDK message queue, and messages already queued behind it must not be delivered after the channel tree has been cleared.

This now fixes the problem at the disconnect boundary, using the same lifecycle as TeamTalkClassic:

- Cache the current user settings.
- Call `TT_Disconnect()`.
- Drain the remaining `TTMessage`s without dispatching them.
- Clear the channel tree and the remaining connection UI.

The earlier defensive changes in `ChannelsTree` have been completely reverted. Its original assertions remain intact, so a genuine invalid widget state still breaks in a Debug build instead of being hidden by release-only guards.

The drain is inside `disconnectFromServer()`, so it covers connection loss, explicit logout, connection failure, manual disconnect, and shutdown paths. It also terminates the outer polling loop naturally because the SDK queue is empty when control returns.

Validation on the current commit confirms that `channelstree.cpp` is identical to upstream, that the order is cache, disconnect, drain, reset, and that the implementation matches the established TeamTalkClassic disconnect pattern. The repository's platform builds are also running on the current commit.

@bear101, could you please review the revised approach when you have time? Maintainer edits remain enabled.

Thanks for reading!
