### PR TITLE
Android client. Submit nickname and status dialog from the keyboard

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -30,6 +30,7 @@ import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.graphics.Color;
@@ -483,7 +484,15 @@ extends AppCompatActivity
         });
 
         alert.setNegativeButton(android.R.string.cancel, null);
-        alert.show();
+        final AlertDialog dialog = alert.create();
+        dialog.show();
+        statusMessageInput.setOnEditorActionListener((v, actionId, event) -> {
+            if (actionId == EditorInfo.IME_ACTION_DONE || actionId == EditorInfo.IME_NULL) {
+                dialog.getButton(DialogInterface.BUTTON_POSITIVE).performClick();
+                return true;
+            }
+            return false;
+        });
     }
 
     private void applyNicknameStatusChange(String nickname, int mode, String statusMessage) {

--- a/Client/TeamTalkAndroid/src/main/res/layout/dialog_change_nickname_status.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/dialog_change_nickname_status.xml
@@ -15,6 +15,7 @@
         android:id="@+id/nickname_input"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:imeOptions="actionNext"
         android:inputType="textCapSentences"
         android:singleLine="true" />
 
@@ -29,6 +30,7 @@
         android:id="@+id/status_message_input"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:imeOptions="actionDone"
         android:inputType="textCapSentences"
         android:singleLine="true" />
 


### PR DESCRIPTION
The two text fields in the change nickname and status dialog set no IME action, so the keyboard has nothing to submit with. With TalkBack's braille keyboard the two finger swipe up gesture only closes the keyboard, and a hardware Enter key does the same, leaving the dialog open.

The nickname field now uses `actionNext` so it moves to the status message, and the status message field uses `actionDone`. An editor action listener clicks the OK button on Done or on a plain Enter key (`IME_NULL`), which matches the channel chat input and the channel password dialog in #3427.

Same problem as #3427, different dialog.