### PR TITLE
Android client. Label the nickname and status message fields

### DIFF
--- a/Client/TeamTalkAndroid/src/main/res/layout/dialog_change_nickname_status.xml
+++ b/Client/TeamTalkAndroid/src/main/res/layout/dialog_change_nickname_status.xml
@@ -8,7 +8,8 @@
         android:id="@+id/nickname_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/pref_title_nickname" />
+        android:text="@string/pref_title_nickname"
+        android:labelFor="@+id/nickname_input" />
 
     <EditText
         android:id="@+id/nickname_input"
@@ -21,7 +22,8 @@
         android:id="@+id/message_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/text_status_message" />
+        android:text="@string/text_status_message"
+        android:labelFor="@+id/status_message_input" />
 
     <EditText
         android:id="@+id/status_message_input"


### PR DESCRIPTION
The two text fields in the change nickname and status dialog have no hint and no `labelFor`, so a screen reader announces them as bare edit boxes. The labels sit above them as plain `TextView`s, which sighted users can read and TalkBack cannot associate.

Each label now points at its field with `android:labelFor`, the same way `activity_server_entry.xml` already does.

This is the only layout in the module where an `EditText` has neither a hint nor a label. Every other one carries `android:hint`.