### PR TITLE
Android client. Transmit button ignores accessibility clicks when TalkBack starts after launch

### DIFF
--- a/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
+++ b/Client/TeamTalkAndroid/src/main/java/dk/bearware/gui/MainActivity.java
@@ -1882,9 +1882,9 @@ private EditText newmsg;
         masterSeekBar.setOnSeekBarChangeListener(volListener);
         micSeekBar.setOnSeekBarChangeListener(volListener);
 
-        if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) && accessibilityAssistant.isServiceActive()) {
-            tx_btn.setOnClickListener(txButtonListener);
-        }
+        // The touch listener consumes the event, so performClick() only runs for an
+        // accessibility click. Attaching here covers a service started after onCreate().
+        tx_btn.setOnClickListener(txButtonListener);
 
         ImageButton speakerBtn = findViewById(R.id.speakerBtn);
         speakerBtn.setOnClickListener(v -> {


### PR DESCRIPTION
`setupButtons()` runs once from `onCreate()` and attaches the `OnClickListener` for the transmit button only if `accessibilityAssistant.isServiceActive()` is true at that moment. Turning TalkBack on does not recreate the activity, so a user who starts the app first and TalkBack second gets a transmit button that does nothing on double tap. The workaround today is to kill the app and reopen it.

The listener is now attached unconditionally. The touch listener returns `true`, so `performClick()` never runs for a finger and `onClick()` is reached only through an accessibility `ACTION_CLICK`. The push to talk and the latch behaviour for touch users are unchanged.

Tested on a Pixel 9a: transmit works after enabling TalkBack mid session, and press to talk plus tap to latch still behave the same with TalkBack off.